### PR TITLE
Fix builder.php

### DIFF
--- a/builder.php
+++ b/builder.php
@@ -66,7 +66,6 @@ $finder = new Finder();
 $finder
     ->directories()
     ->name('test')
-    ->name('Test')
     ->name('tests')
     ->name('Tests')
     ->name('test-suite')


### PR DESCRIPTION
Suite aux modifications du commit 19c4fd7c7e4db7726d00212787c80fed5946bbd1, le script builder.php supprime des fichiers requis.

Le script supprime le répertoire lib/Twig/Test du package "Twig" et provoque donc l'erreur PHP suivante: 

Fatal error: Class 'Twig_Test_Function' not found in lib/Alchemy/Phrasea/Core/Service/TemplateEngine/Twig.php on line 113 

La classe Twig_Test_Function est présente dans le dossier vendor/twig/twig/lib/Twig/Test
