### PR TITLE
[3.8] Add UrlGenerator helpers in Application

### DIFF
--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -108,6 +108,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 
 class Application extends SilexApplication
 {
@@ -335,6 +336,32 @@ class Application extends SilexApplication
 
             return $data[1];
         };
+    }
+
+    /**
+     * Generates a path from the given parameters.
+     *
+     * @param string $route      The name of the route
+     * @param mixed  $parameters An array of parameters
+     *
+     * @return string The generated path
+     */
+    public function path($route, $parameters = array())
+    {
+        return $this['url_generator']->generate($route, $parameters, UrlGenerator::ABSOLUTE_PATH);
+    }
+
+    /**
+     * Generates an absolute URL from the given parameters.
+     *
+     * @param string $route      The name of the route
+     * @param mixed  $parameters An array of parameters
+     *
+     * @return string The generated URL
+     */
+    public function url($route, $parameters = array())
+    {
+        return $this['url_generator']->generate($route, $parameters, UrlGenerator::ABSOLUTE_URL);
     }
 
     public function initSession(GetResponseEvent $event)

--- a/tests/Alchemy/Tests/Phrasea/ApplicationTest.php
+++ b/tests/Alchemy/Tests/Phrasea/ApplicationTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\Cookie as BrowserCookie;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 
 class ApplicationTest extends \PhraseanetPHPUnitAbstract
 {
@@ -185,6 +186,46 @@ class ApplicationTest extends \PhraseanetPHPUnitAbstract
     {
         $app = new Application('dev');
         $this->assertTrue(isset($app['profiler']));
+    }
+
+    public function testGeneratePath()
+    {
+        $generator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGenerator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $app = new Application();
+        $app['url_generator'] = $generator;
+
+        $ret = 'retval-' . mt_rand();
+        $route = 'route';
+
+        $generator->expects($this->once())
+            ->method('generate')
+            ->with($this->equalTo($route), $this->equalTo(array()), $this->equalTo(UrlGenerator::ABSOLUTE_PATH))
+            ->will($this->returnValue($ret));
+
+        $this->assertEquals($ret, $app->path($route));
+    }
+
+    public function testGenerateUrl()
+    {
+        $generator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGenerator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $app = new Application();
+        $app['url_generator'] = $generator;
+
+        $ret = 'retval-' . mt_rand();
+        $route = 'route';
+
+        $generator->expects($this->once())
+            ->method('generate')
+            ->with($this->equalTo($route), $this->equalTo(array()), $this->equalTo(UrlGenerator::ABSOLUTE_URL))
+            ->will($this->returnValue($ret));
+
+        $this->assertEquals($ret, $app->url($route));
     }
 
     private function getAppThatReturnLocale()


### PR DESCRIPTION
two new methods are available :

`Application::path` that returns an absolute path
`Application::url` that returns an absolute url
