### PR TITLE
Fix #1378 : sphinx host is replaced by sphinx port in admin panel

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/SphinxSearch/ConfigurationPanel.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/SphinxSearch/ConfigurationPanel.php
@@ -72,7 +72,7 @@ class ConfigurationPanel extends AbstractConfigurationPanel
         }
 
         $configuration['host'] = $request->request->get('host');
-        $configuration['host'] = $request->request->get('port');
+        $configuration['port'] = $request->request->get('port');
         $configuration['rt_host'] = $request->request->get('rt_host');
         $configuration['rt_port'] = $request->request->get('rt_port');
 


### PR DESCRIPTION
The configuration generated by the search engine tools in the admin panel has the port instead of the host written.
