### PR TITLE
[3.9] Rename "phraseanet.configuration" service to "configuration"

### DIFF
--- a/bin/developer
+++ b/bin/developer
@@ -56,7 +56,7 @@ $cli = new CLI("
  under certain conditions; type `about:license' for details.\n\n"
             . ' Phraseanet Developer Tools ', Version::getName() . ' ' . Version::getNumber());
 
-if ($cli['phraseanet.configuration']->isSetup()) {
+if ($cli['configuration']->isSetup()) {
     $helpers = array(
         'db' => new ConnectionHelper($cli['EM']->getConnection()),
         'em' => new EntityManagerHelper($cli['EM'])

--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -240,8 +240,8 @@ class Application extends SilexApplication
                     'swftools.timeout'             => 'swftools_timeout',
                     'unoconv.timeout'              => 'unoconv_timeout',
             ) as $parameter => $key) {
-                if (isset($this['phraseanet.configuration']['binaries'][$key])) {
-                    $configuration[$parameter] = $this['phraseanet.configuration']['binaries'][$key];
+                if (isset($this['configuration']['binaries'][$key])) {
+                    $configuration[$parameter] = $this['configuration']['binaries'][$key];
                 }
             }
 
@@ -550,8 +550,8 @@ class Application extends SilexApplication
     private function setupUrlGenerator()
     {
         $this['url_generator'] = $this->share($this->extend('url_generator', function ($urlGenerator, $app) {
-            if ($app['phraseanet.configuration']->isSetup()) {
-                $data = parse_url($app['phraseanet.configuration']['main']['servername']);
+            if ($app['configuration']->isSetup()) {
+                $data = parse_url($app['configuration']['main']['servername']);
 
                 if (isset($data['scheme'])) {
                     $urlGenerator->getContext()->setScheme($data['scheme']);

--- a/lib/Alchemy/Phrasea/Command/Compile/Configuration.php
+++ b/lib/Alchemy/Phrasea/Command/Compile/Configuration.php
@@ -25,7 +25,7 @@ class Configuration extends Command
 
     protected function doExecute(InputInterface $input, OutputInterface $output)
     {
-        $this->container['phraseanet.configuration']->compileAndWrite();
+        $this->container['configuration']->compileAndWrite();
         $output->writeln("Confguration compiled.");
 
         return 0;

--- a/lib/Alchemy/Phrasea/Command/Developer/RegenerateSqliteDb.php
+++ b/lib/Alchemy/Phrasea/Command/Developer/RegenerateSqliteDb.php
@@ -32,7 +32,7 @@ class RegenerateSqliteDb extends Command
         }
 
         try {
-            $dbParams = $this->container['phraseanet.configuration']->getTestConnectionParameters();
+            $dbParams = $this->container['configuration']->getTestConnectionParameters();
             $dbParams['path'] = $source;
 
             $this->container->register(new ORMServiceProvider());

--- a/lib/Alchemy/Phrasea/Command/Setup/XSendFileMappingGenerator.php
+++ b/lib/Alchemy/Phrasea/Command/Setup/XSendFileMappingGenerator.php
@@ -53,7 +53,7 @@ class XSendFileMappingGenerator extends Command
 
         if ($input->getOption('write')) {
             $output->write("Writing configuration ...");
-            $this->container['phraseanet.configuration']['xsendfile'] = $conf;
+            $this->container['configuration']['xsendfile'] = $conf;
             $output->writeln(" <info>OK</info>");
             $output->writeln("");
             $output->write("It is now strongly recommended to use <info>xsendfile:dump-configuration</info> command to upgrade your virtual-host");

--- a/lib/Alchemy/Phrasea/Controller/AbstractDelivery.php
+++ b/lib/Alchemy/Phrasea/Controller/AbstractDelivery.php
@@ -46,7 +46,7 @@ abstract class AbstractDelivery implements ControllerProviderInterface
                 $referrer = $_SERVER['HTTP_REFERER'];
             }
 
-            $record->log_view($log_id, $referrer, $app['phraseanet.configuration']['main']['key']);
+            $record->log_view($log_id, $referrer, $app['configuration']['main']['key']);
         } catch (\Exception $e) {
 
         }

--- a/lib/Alchemy/Phrasea/Controller/Admin/Databoxes.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/Databoxes.php
@@ -158,7 +158,7 @@ class Databoxes implements ControllerProviderInterface
 
         if ((null === $request->request->get('new_settings')) && (null !== $dataTemplate = $request->request->get('new_data_template'))) {
 
-            $configuration = $app['phraseanet.configuration'];
+            $configuration = $app['configuration'];
             $connexion = $configuration['main']['database'];
 
             $hostname = $connexion['host'];
@@ -229,7 +229,7 @@ class Databoxes implements ControllerProviderInterface
 
         if ((null === $request->request->get('new_settings'))) {
             try {
-                $configuration = $app['phraseanet.configuration'];
+                $configuration = $app['configuration'];
                 $connexion = $configuration['main']['database'];
 
                 $hostname = $connexion['host'];

--- a/lib/Alchemy/Phrasea/Controller/Admin/TaskManager.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/TaskManager.php
@@ -139,7 +139,7 @@ class TaskManager implements ControllerProviderInterface
         $task = $app['manipulator.task']->create(
             $job->getName(),
             $job->getJobId(),
-            $job->getEditor()->getDefaultSettings($app['phraseanet.configuration']),
+            $job->getEditor()->getDefaultSettings($app['configuration']),
             $job->getEditor()->getDefaultPeriod()
         );
 

--- a/lib/Alchemy/Phrasea/Controller/Root/Session.php
+++ b/lib/Alchemy/Phrasea/Controller/Root/Session.php
@@ -110,7 +110,7 @@ class Session implements ControllerProviderInterface
         }
 
         if (in_array($app['session']->get('phraseanet.message'), array('1', null))) {
-            if ($app['phraseanet.configuration']['main']['maintenance']) {
+            if ($app['configuration']['main']['maintenance']) {
                 $ret['message'] .= _('The application is going down for maintenance, please logout.');
             }
 

--- a/lib/Alchemy/Phrasea/Core/CLIProvider/CLIDriversServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/CLIProvider/CLIDriversServiceProvider.php
@@ -36,12 +36,12 @@ class CLIDriversServiceProvider implements ServiceProviderInterface
                 $extraDirs[] = $app['root.path'] . '/node_modules/.bin';
             }
 
-            if (!$app['phraseanet.configuration']->isSetup()) {
+            if (!$app['configuration']->isSetup()) {
                 return $app['executable-finder']->find($name, null, $extraDirs);
             }
 
-            if (isset($app['phraseanet.configuration']['binaries'][$configName])) {
-                return $app['phraseanet.configuration']['binaries'][$configName];
+            if (isset($app['configuration']['binaries'][$configName])) {
+                return $app['configuration']['binaries'][$configName];
             }
 
             return $app['executable-finder']->find($name, null, $extraDirs);

--- a/lib/Alchemy/Phrasea/Core/CLIProvider/PluginServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/CLIProvider/PluginServiceProvider.php
@@ -56,7 +56,7 @@ class PluginServiceProvider implements ServiceProviderInterface
         });
 
         $app['plugins.composer-installer'] = $app->share(function (Application $app) {
-            $binaries = $app['phraseanet.configuration']['binaries'];
+            $binaries = $app['configuration']['binaries'];
             $phpBinary = isset($binaries['php_binary']) ? $binaries['php_binary'] : null;
 
             if (!is_executable($phpBinary)) {

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/DebuggerSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/DebuggerSubscriber.php
@@ -41,11 +41,11 @@ class DebuggerSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($this->app['phraseanet.configuration']->isSetup()
-            && isset($this->app['phraseanet.configuration']['debugger'])
-            && isset($this->app['phraseanet.configuration']['debugger']['allowed-ips'])) {
+        if ($this->app['configuration']->isSetup()
+            && isset($this->app['configuration']['debugger'])
+            && isset($this->app['configuration']['debugger']['allowed-ips'])) {
 
-            $allowedIps = $this->app['phraseanet.configuration']['debugger']['allowed-ips'];
+            $allowedIps = $this->app['configuration']['debugger']['allowed-ips'];
             $allowedIps = is_array($allowedIps) ? $allowedIps : array($allowedIps);
         } else {
             $allowedIps = array();

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/MaintenanceSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/MaintenanceSubscriber.php
@@ -34,7 +34,7 @@ class MaintenanceSubscriber implements EventSubscriberInterface
 
     public function checkForMaintenance(GetResponseEvent $event)
     {
-        if ($this->app['phraseanet.configuration']->isSetup() && $this->app['phraseanet.configuration']['main']['maintenance']) {
+        if ($this->app['configuration']->isSetup() && $this->app['configuration']['main']['maintenance']) {
             $this->app->abort(503, 'Service Temporarily Unavailable', array('Retry-After' => 3600));
         }
     }

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/PersistentCookieSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/PersistentCookieSubscriber.php
@@ -36,7 +36,7 @@ class PersistentCookieSubscriber implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if ($this->app['phraseanet.configuration']->isSetup() && $request->cookies->has('persistent') && !$this->app['authentication']->isAuthenticated()) {
+        if ($this->app['configuration']->isSetup() && $request->cookies->has('persistent') && !$this->app['authentication']->isAuthenticated()) {
             if (false !== $session = $this->app['authentication.persistent-manager']->getSession($request->cookies->get('persistent'))) {
                 $this->app['authentication']->refreshAccount($session);
             }

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/XSendFileSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/XSendFileSubscriber.php
@@ -35,7 +35,7 @@ class XSendFileSubscriber implements EventSubscriberInterface
 
     public function applyHeaders(GetResponseEvent $event)
     {
-        if (!$this->app['phraseanet.configuration']->isSetup()) {
+        if (!$this->app['configuration']->isSetup()) {
             return;
         }
 

--- a/lib/Alchemy/Phrasea/Core/Provider/AuthenticationManagerServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/AuthenticationManagerServiceProvider.php
@@ -53,7 +53,7 @@ class AuthenticationManagerServiceProvider implements ServiceProviderInterface
         });
 
         $app['authentication.providers.account-creator'] = $app->share(function (Application $app) {
-            $authConf = $app['phraseanet.configuration']['authentication'];
+            $authConf = $app['configuration']['authentication'];
             $templates = array_filter(array_map(function ($templateId) use ($app) {
                 try {
                     if (is_int($templateId) || ctype_digit($templateId)) {
@@ -78,7 +78,7 @@ class AuthenticationManagerServiceProvider implements ServiceProviderInterface
 
             $providers = new ProvidersCollection();
 
-            $authConf = $app['phraseanet.configuration']['authentication'];
+            $authConf = $app['configuration']['authentication'];
             foreach ($authConf['providers'] as $providerId => $data) {
                 if (isset($data['enabled']) && false === $data['enabled']) {
                     continue;
@@ -94,7 +94,7 @@ class AuthenticationManagerServiceProvider implements ServiceProviderInterface
         });
 
         $app['auth.password-encoder'] = $app->share(function (Application $app) {
-            return new PasswordEncoder($app['phraseanet.configuration']['main']['key']);
+            return new PasswordEncoder($app['configuration']['main']['key']);
         });
 
         $app['auth.old-password-encoder'] = $app->share(function (Application $app) {
@@ -102,7 +102,7 @@ class AuthenticationManagerServiceProvider implements ServiceProviderInterface
         });
 
         $app['auth.native.failure-manager'] = $app->share(function (Application $app) {
-            $authConf = $app['phraseanet.configuration']['authentication']['captcha'];
+            $authConf = $app['configuration']['authentication']['captcha'];
 
             return new FailureManager($app['EM'], $app['recaptcha'], isset($authConf['trials-before-display']) ? $authConf['trials-before-display'] : 9);
         });
@@ -112,7 +112,7 @@ class AuthenticationManagerServiceProvider implements ServiceProviderInterface
         });
 
         $app['auth.native'] = $app->share(function (Application $app) {
-            $authConf = $app['phraseanet.configuration']['authentication'];
+            $authConf = $app['configuration']['authentication'];
 
             if ($authConf['captcha']['enabled']) {
                 return new FailureHandledNativeAuthentication(

--- a/lib/Alchemy/Phrasea/Core/Provider/BorderManagerServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/BorderManagerServiceProvider.php
@@ -30,7 +30,7 @@ class BorderManagerServiceProvider implements ServiceProviderInterface
 
             }
 
-            $options = $app['phraseanet.configuration']['border-manager'];
+            $options = $app['configuration']['border-manager'];
 
             $registeredCheckers = array();
 

--- a/lib/Alchemy/Phrasea/Core/Provider/CacheServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/CacheServiceProvider.php
@@ -42,13 +42,13 @@ class CacheServiceProvider implements ServiceProviderInterface
         });
 
         $app['cache'] = $app->share(function (Application $app) {
-            $conf = $app['phraseanet.configuration']['main']['cache'];
+            $conf = $app['configuration']['main']['cache'];
 
             return $app['phraseanet.cache-service']->factory('cache', $conf['type'], $conf['options']);
         });
 
         $app['opcode-cache'] = $app->share(function (Application $app) {
-            $conf = $app['phraseanet.configuration']['main']['opcodecache'];
+            $conf = $app['configuration']['main']['opcodecache'];
 
             return $app['phraseanet.cache-service']->factory('cache', $conf['type'], $conf['options']);
         });

--- a/lib/Alchemy/Phrasea/Core/Provider/ConfigurationServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/ConfigurationServiceProvider.php
@@ -31,7 +31,7 @@ class ConfigurationServiceProvider implements ServiceProviderInterface
         $app['phraseanet.configuration.config-path'] = $app['root.path'] . '/config/configuration.yml';
         $app['phraseanet.configuration.config-compiled-path'] = $app['root.path'] . '/tmp/configuration-compiled.php';
 
-        $app['phraseanet.configuration'] = $app->share(function (SilexApplication $app) {
+        $app['configuration'] = $app->share(function (SilexApplication $app) {
             return new Configuration(
                 $app['phraseanet.configuration.yaml-parser'],
                 $app['phraseanet.configuration.compiler'],
@@ -39,6 +39,11 @@ class ConfigurationServiceProvider implements ServiceProviderInterface
                 $app['phraseanet.configuration.config-compiled-path'],
                 $app['debug']
             );
+        });
+
+        // Maintaining BC until 3.10
+        $app['phraseanet.configuration'] = $app->share(function (SilexApplication $app) {
+            return $app['configuration'];
         });
     }
 
@@ -49,7 +54,7 @@ class ConfigurationServiceProvider implements ServiceProviderInterface
     {
         $app['dispatcher'] = $app->share(
             $app->extend('dispatcher', function ($dispatcher, SilexApplication $app) {
-                $dispatcher->addSubscriber(new TrustedProxySubscriber($app['phraseanet.configuration']));
+                $dispatcher->addSubscriber(new TrustedProxySubscriber($app['configuration']));
 
                 return $dispatcher;
             })

--- a/lib/Alchemy/Phrasea/Core/Provider/LocaleServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/LocaleServiceProvider.php
@@ -38,10 +38,10 @@ class LocaleServiceProvider implements ServiceProviderInterface
         $app['locales.available'] = $app->share(function (Application $app) {
             $availableLanguages = PhraseaApplication::getAvailableLanguages();
 
-            if ($app['phraseanet.configuration']->isSetup()
-                && isset($app['phraseanet.configuration']['main']['languages'])
-                && !empty($app['phraseanet.configuration']['main']['languages'])) {
-                $languages = $app['phraseanet.configuration']['main']['languages'];
+            if ($app['configuration']->isSetup()
+                && isset($app['configuration']['main']['languages'])
+                && !empty($app['configuration']['main']['languages'])) {
+                $languages = $app['configuration']['main']['languages'];
                 $enabledLanguages = $availableLanguages;
 
                 foreach ($enabledLanguages as $code => $language) {

--- a/lib/Alchemy/Phrasea/Core/Provider/ORMServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/ORMServiceProvider.php
@@ -100,17 +100,17 @@ class ORMServiceProvider implements ServiceProviderInterface
         });
 
         $app['EM.opcode-cache-type'] = $app->share(function (Application $app) {
-            return $app['phraseanet.configuration']['main']['opcodecache']['type'];
+            return $app['configuration']['main']['opcodecache']['type'];
         });
         $app['EM.opcode-cache-options'] = $app->share(function (Application $app) {
-            return $app['phraseanet.configuration']['main']['opcodecache']['options'];
+            return $app['configuration']['main']['opcodecache']['options'];
         });
 
         $app['EM.cache-type'] = $app->share(function (Application $app) {
-            return $app['phraseanet.configuration']['main']['cache']['type'];
+            return $app['configuration']['main']['cache']['type'];
         });
         $app['EM.cache-options'] = $app->share(function (Application $app) {
-            return $app['phraseanet.configuration']['main']['cache']['options'];
+            return $app['configuration']['main']['cache']['options'];
         });
         $app['EM.events-manager'] = $app->share(function (Application $app) {
             $evm = new EventManager();
@@ -121,10 +121,10 @@ class ORMServiceProvider implements ServiceProviderInterface
 
         $app['EM.dbal-conf'] = $app->share(function (Application $app) {
             if ('test' === $app->getEnvironment()) {
-                return $app['phraseanet.configuration']['main']['database-test'];
+                return $app['configuration']['main']['database-test'];
             }
 
-            return $app['phraseanet.configuration']['main']['database'];
+            return $app['configuration']['main']['database'];
         });
 
         $app['EM'] = $app->share(function (Application $app) {

--- a/lib/Alchemy/Phrasea/Core/Provider/RegistrationServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/RegistrationServiceProvider.php
@@ -21,7 +21,7 @@ class RegistrationServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['registration.fields'] = $app->share(function (Application $app) {
-            return isset($app['phraseanet.configuration']['registration-fields']) ? $app['phraseanet.configuration']['registration-fields'] : array();
+            return isset($app['configuration']['registration-fields']) ? $app['configuration']['registration-fields'] : array();
         });
 
         $app['registration.enabled'] = $app->share(function (Application $app) {

--- a/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
@@ -24,8 +24,8 @@ class SearchEngineServiceProvider implements ServiceProviderInterface
     {
         $app['phraseanet.SE'] = $app->share(function ($app) {
 
-            $engineClass = $app['phraseanet.configuration']['main']['search-engine']['type'];
-            $engineOptions = $app['phraseanet.configuration']['main']['search-engine']['options'];
+            $engineClass = $app['configuration']['main']['search-engine']['type'];
+            $engineOptions = $app['configuration']['main']['search-engine']['options'];
 
             if (!class_exists($engineClass) || $engineClass instanceof SearchEngineInterface) {
                 throw new InvalidArgumentException(sprintf('%s is not valid SearchEngineInterface', $engineClass));

--- a/lib/Alchemy/Phrasea/Core/Provider/TasksServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/TasksServiceProvider.php
@@ -36,8 +36,8 @@ class TasksServiceProvider implements ServiceProviderInterface
         });
 
         $app['task-manager.listener.options'] = $app->share(function (Application $app) {
-            if (isset($app['phraseanet.configuration']['task-manager']) && isset($app['phraseanet.configuration']['task-manager']['listener'])) {
-                $listenerConf = $app['phraseanet.configuration']['task-manager']['listener'];
+            if (isset($app['configuration']['task-manager']) && isset($app['configuration']['task-manager']['listener'])) {
+                $listenerConf = $app['configuration']['task-manager']['listener'];
             } else {
                 $listenerConf = array();
             }
@@ -55,7 +55,7 @@ class TasksServiceProvider implements ServiceProviderInterface
         });
 
         $app['task-manager.status'] = $app->share(function (Application $app) {
-            return new TaskManagerStatus($app['phraseanet.configuration']);
+            return new TaskManagerStatus($app['configuration']);
         });
 
         $app['task-manager.live-information'] = $app->share(function (Application $app) {

--- a/lib/Alchemy/Phrasea/Http/XSendFile/XSendFileFactory.php
+++ b/lib/Alchemy/Phrasea/Http/XSendFile/XSendFileFactory.php
@@ -48,7 +48,7 @@ class XSendFileFactory
      */
     public static function create(Application $app)
     {
-        $conf = $app['phraseanet.configuration']['xsendfile'];
+        $conf = $app['configuration']['xsendfile'];
 
         $mapping = array();
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Phrasea/PhraseaEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Phrasea/PhraseaEngine.php
@@ -161,7 +161,7 @@ class PhraseaEngine implements SearchEngineInterface
             return $this;
         }
 
-        $connexion = $this->app['phraseanet.configuration']['main']['database'];
+        $connexion = $this->app['configuration']['main']['database'];
 
         $hostname = $connexion['host'];
         $port = (int) $connexion['port'];
@@ -228,7 +228,7 @@ class PhraseaEngine implements SearchEngineInterface
     public function getConfigurationPanel()
     {
         if (!$this->configurationPanel) {
-            $this->configurationPanel = new ConfigurationPanel($this, $this->app['phraseanet.configuration']);
+            $this->configurationPanel = new ConfigurationPanel($this, $this->app['configuration']);
         }
 
         return $this->configurationPanel;
@@ -556,7 +556,7 @@ class PhraseaEngine implements SearchEngineInterface
                     , $sbas_id
                     , $this->colls[$sbas_id]
                     , $this->arrayq[$sbas_id]
-                    , $this->app['phraseanet.configuration']['main']['key']
+                    , $this->app['configuration']['main']['key']
                     , $this->app['session']->get('usr_id')
                     , false
                     , $this->options->getSearchType() == SearchEngineOptions::RECORD_GROUPING ? PHRASEA_MULTIDOC_REGONLY : PHRASEA_MULTIDOC_DOCONLY

--- a/lib/Alchemy/Phrasea/SearchEngine/SphinxSearch/SphinxSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/SphinxSearch/SphinxSearchEngine.php
@@ -175,7 +175,7 @@ class SphinxSearchEngine implements SearchEngineInterface
     public function getConfigurationPanel()
     {
         if (!$this->configurationPanel) {
-            $this->configurationPanel = new ConfigurationPanel($this, $this->app['phraseanet.configuration']);
+            $this->configurationPanel = new ConfigurationPanel($this, $this->app['configuration']);
         }
 
         return $this->configurationPanel;

--- a/lib/Alchemy/Phrasea/Setup/ConfigurationTester.php
+++ b/lib/Alchemy/Phrasea/Setup/ConfigurationTester.php
@@ -81,7 +81,7 @@ class ConfigurationTester
      */
     public function isInstalled()
     {
-        return $this->app['phraseanet.configuration']->isSetup();
+        return $this->app['configuration']->isSetup();
     }
 
     /**

--- a/lib/Alchemy/Phrasea/Setup/Installer.php
+++ b/lib/Alchemy/Phrasea/Setup/Installer.php
@@ -104,7 +104,7 @@ class Installer
             $this->app['manipulator.task']->create(
                 $job->getName(),
                 $job->getJobId(),
-                $job->getEditor()->getDefaultSettings($this->app['phraseanet.configuration']),
+                $job->getEditor()->getDefaultSettings($this->app['configuration']),
                 $job->getEditor()->getDefaultPeriod()
             );
         }
@@ -152,7 +152,7 @@ class Installer
             }
         }
 
-        $this->app['phraseanet.configuration']->delete();
+        $this->app['configuration']->delete();
 
         return;
     }
@@ -176,7 +176,7 @@ class Installer
 
     private function createConfigFile($abConn, $serverName, $binaryData)
     {
-        $config = $this->app['phraseanet.configuration']->initialize();
+        $config = $this->app['configuration']->initialize();
 
         foreach ($abConn->get_credentials() as $key => $value) {
             $key = $key == 'hostname' ? 'host' : $key;
@@ -192,6 +192,6 @@ class Installer
         $config['main']['key'] = md5(mt_rand(100000000, 999999999));
 
         $this->app['phraseanet.registry']->setKey($config['main']['key']);
-        $this->app['phraseanet.configuration']->setConfig($config);
+        $this->app['configuration']->setConfig($config);
     }
 }

--- a/lib/Alchemy/Phrasea/Setup/Probe/BinariesProbe.php
+++ b/lib/Alchemy/Phrasea/Setup/Probe/BinariesProbe.php
@@ -39,6 +39,6 @@ class BinariesProbe extends BinariesRequirements implements ProbeInterface
      */
     public static function create(Application $app)
     {
-        return new static($app['phraseanet.configuration']['binaries']);
+        return new static($app['configuration']['binaries']);
     }
 }

--- a/lib/Alchemy/Phrasea/Setup/Version/Migration/Migration35.php
+++ b/lib/Alchemy/Phrasea/Setup/Version/Migration/Migration35.php
@@ -29,7 +29,7 @@ class Migration35 implements MigrationInterface
             throw new \LogicException('Required config files not found');
         }
 
-        $config = $this->app['phraseanet.configuration']->initialize();
+        $config = $this->app['configuration']->initialize();
 
         foreach ($config['registration-fields'] as $key => $field) {
             $config['registration-fields'][$key]['required'] = (boolean) $field['required'];
@@ -67,6 +67,6 @@ class Migration35 implements MigrationInterface
         rename(__DIR__ . '/../../../../../../config/connexion.inc', __DIR__ . '/../../../../../../config/connexion.inc.old');
         rename(__DIR__ . '/../../../../../../config/config.inc', __DIR__ . '/../../../../../../config/config.inc.old');
 
-        $this->app['phraseanet.configuration']->setConfig($config);
+        $this->app['configuration']->setConfig($config);
     }
 }

--- a/lib/Alchemy/Phrasea/Setup/Version/Migration/Migration38.php
+++ b/lib/Alchemy/Phrasea/Setup/Version/Migration/Migration38.php
@@ -49,14 +49,14 @@ class Migration38 implements MigrationInterface
 
     private function doMigrate($app)
     {
-        $app['phraseanet.configuration']->initialize();
-        $conf = $app['phraseanet.configuration']->getConfig();
+        $app['configuration']->initialize();
+        $conf = $app['configuration']->getConfig();
 
         $this->migrateConnexions($conf);
         $this->migrateConfigAndServices($conf);
         $this->migrateBinaries($conf);
 
-        $app['phraseanet.configuration']->setConfig($conf);
+        $app['configuration']->setConfig($conf);
 
         foreach (array(
             $this->configYaml,

--- a/lib/Alchemy/Phrasea/TaskManager/Job/PhraseanetIndexerJob.php
+++ b/lib/Alchemy/Phrasea/TaskManager/Job/PhraseanetIndexerJob.php
@@ -79,7 +79,7 @@ class PhraseanetIndexerJob extends AbstractJob
 
     private function getPhraseanetIndexerPath(Application $app)
     {
-        $binaries = $app['phraseanet.configuration']['binaries'];
+        $binaries = $app['configuration']['binaries'];
 
         if (isset($binaries['phraseanet_indexer'])) {
             $path = $binaries['phraseanet_indexer'];

--- a/lib/classes/ACL.php
+++ b/lib/classes/ACL.php
@@ -1478,7 +1478,7 @@ class ACL implements cache_cacheableInterface
 
         foreach ($this->get_granted_base(array(), array($databox->get_sbas_id())) as $collection) {
             $stmt->execute(array(
-                ':site_id'  => $this->app['phraseanet.configuration']['main']['key'],
+                ':site_id'  => $this->app['configuration']['main']['key'],
                 ':usr_id'   => $this->user->get_id(),
                 ':coll_id'  => $collection->get_coll_id(),
                 ':mask_and' => $this->get_mask_and($collection->get_base_id()),
@@ -1506,7 +1506,7 @@ class ACL implements cache_cacheableInterface
         $sql = 'DELETE FROM collusr WHERE usr_id = :usr_id AND site = :site';
         $params = array(
             ':usr_id' => $this->user->get_id()
-            , ':site'   => $this->app['phraseanet.configuration']['main']['key']
+            , ':site'   => $this->app['configuration']['main']['key']
         );
         $stmt = $databox->get_connection()->prepare($sql);
         $stmt->execute($params);

--- a/lib/classes/API/V1/adapter.php
+++ b/lib/classes/API/V1/adapter.php
@@ -310,9 +310,9 @@ class API_V1_adapter extends API_V1_Abstract
 
         $ret['phraseanet']['environment'] = $app->getEnvironment();
         $ret['phraseanet']['debug'] = $app['debug'];
-        $ret['phraseanet']['maintenance'] = $app['phraseanet.configuration']['main']['maintenance'];
+        $ret['phraseanet']['maintenance'] = $app['configuration']['main']['maintenance'];
         $ret['phraseanet']['errorsLog'] = $app['debug'];
-        $ret['phraseanet']['serverName'] = $app['phraseanet.configuration']['main']['servername'];
+        $ret['phraseanet']['serverName'] = $app['configuration']['main']['servername'];
 
         return $ret;
     }
@@ -330,7 +330,7 @@ class API_V1_adapter extends API_V1_Abstract
             $SEStatus = array('error' => $e->getMessage());
         }
 
-        $binaries = $app['phraseanet.configuration']['binaries'];
+        $binaries = $app['configuration']['binaries'];
 
         return array(
             'global_values' => array(
@@ -341,13 +341,13 @@ class API_V1_adapter extends API_V1_Abstract
                 'httpServer'  => array(
                     'logErrors'       => $app['phraseanet.registry']->get('GV_log_errors'),
                     'phpTimezone'     => ini_get('date.timezone'),
-                    'siteId'          => $app['phraseanet.configuration']['main']['key'],
+                    'siteId'          => $app['configuration']['main']['key'],
                     'staticUrl'       => $app['phraseanet.registry']->get('GV_STATIC_URL'),
                     'defaultLanguage' => $app['phraseanet.registry']->get('id_GV_default_lng'),
                     'allowIndexing'   => $app['phraseanet.registry']->get('GV_allow_search_engine'),
                     'modes'           => array(
-                        'XsendFile'                     => $app['phraseanet.configuration']['xsendfile']['enabled'],
-                        'XsendFileMapping'              => $app['phraseanet.configuration']['xsendfile']['mapping'],
+                        'XsendFile'                     => $app['configuration']['xsendfile']['enabled'],
+                        'XsendFileMapping'              => $app['configuration']['xsendfile']['mapping'],
                         'h264Streaming'                 => $app['phraseanet.registry']->get('GV_h264_streaming'),
                         'authTokenDirectory'            => $app['phraseanet.registry']->get('GV_mod_auth_token_directory'),
                         'authTokenDirectoryPath'        => $app['phraseanet.registry']->get('GV_mod_auth_token_directory_path'),

--- a/lib/classes/API/V1/result.php
+++ b/lib/classes/API/V1/result.php
@@ -199,7 +199,7 @@ class API_V1_result
 
         $this->app['dispatcher']->dispatch(PhraseaEvents::API_RESULT, new ApiResultEvent());
 
-        $conf = $this->app['phraseanet.configuration'];
+        $conf = $this->app['configuration'];
 
         if (isset($conf['main']['api-timers']) && true === $conf['main']['api-timers']) {
             $ret['timers'] = $this->app['api.timers']->toArray();

--- a/lib/classes/Session/Logger.php
+++ b/lib/classes/Session/Logger.php
@@ -121,7 +121,7 @@ class Session_Logger
         $params = array(
             ':ses_id'          => $app['session']->get('session_id'),
             ':usr_login'       => $app['authentication']->getUser() ? $app['authentication']->getUser()->get_login() : null,
-            ':site_id'         => $app['phraseanet.configuration']['main']['key'],
+            ':site_id'         => $app['configuration']['main']['key'],
             ':usr_id'          => $app['authentication']->isAuthenticated() ? $app['authentication']->getUser()->get_id() : null,
             ':browser'         => $browser->getBrowser(),
             ':browser_version' => $browser->getExtendedVersion(),
@@ -167,7 +167,7 @@ class Session_Logger
             WHERE site = :site AND sit_session = :ses_id';
 
         $params = array(
-            ':site'   => $app['phraseanet.configuration']['main']['key']
+            ':site'   => $app['configuration']['main']['key']
             , ':ses_id' => $app['session']->get('session_id')
         );
 

--- a/lib/classes/User/Adapter.php
+++ b/lib/classes/User/Adapter.php
@@ -1057,12 +1057,12 @@ class User_Adapter implements User_Interface, cache_cacheableInterface
             }
         }
 
-        if (isset($this->app['phraseanet.configuration']['user-settings'])) {
+        if (isset($this->app['configuration']['user-settings'])) {
             $this->_prefs = array_replace(
                 $this->_prefs,
                 // remove keys that are not defined in default values
                 array_intersect_key(
-                    $this->app['phraseanet.configuration']['user-settings'],
+                    $this->app['configuration']['user-settings'],
                     self::$def_values
                 )
             );

--- a/lib/classes/appbox.php
+++ b/lib/classes/appbox.php
@@ -65,7 +65,7 @@ class appbox extends base
     {
         $this->app = $app;
         $this->connection = connection::getPDOConnection($app);
-        $connexion = $app['phraseanet.configuration']['main']['database'];
+        $connexion = $app['configuration']['main']['database'];
 
         $this->host = $connexion['host'];
         $this->port = $connexion['port'];

--- a/lib/classes/connection.php
+++ b/lib/classes/connection.php
@@ -129,7 +129,7 @@ class connection
             if (trim($name) !== 'appbox') {
                 $connection_params = phrasea::sbas_params($app);
             } else {
-                $connexion = $app['phraseanet.configuration']['main']['database'];
+                $connexion = $app['configuration']['main']['database'];
 
                 $hostname = $connexion['host'];
                 $port = $connexion['port'];

--- a/lib/classes/databox.php
+++ b/lib/classes/databox.php
@@ -462,7 +462,7 @@ class databox extends base
 
         $this->app['EM']->flush();
 
-        $params = array(':site_id' => $this->app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id' => $this->app['configuration']['main']['key']);
 
         $sql = 'DELETE FROM clients WHERE site_id = :site_id';
         $stmt = $this->get_connection()->prepare($sql);

--- a/lib/classes/module/console/checkExtension.php
+++ b/lib/classes/module/console/checkExtension.php
@@ -70,7 +70,7 @@ class module_console_checkExtension extends Command
             $output->writeln("<info>$function</info>");
         }
 
-        $configuration = $this->getService('phraseanet.configuration');
+        $configuration = $this->getService('configuration');
         $connexion = $configuration['main']['database'];
         $hostname = $connexion['host'];
         $port = $connexion['port'];
@@ -167,7 +167,7 @@ class module_console_checkExtension extends Command
                 , $base["sbas_id"]
                 , $base["searchcoll"]
                 , $base["arrayq"]
-                , $this->container['phraseanet.configuration']['main']['key']
+                , $this->container['configuration']['main']['key']
                 , $usrId
                 , false
                 , PHRASEA_MULTIDOC_DOCONLY

--- a/lib/classes/module/report/activity.php
+++ b/lib/classes/module/report/activity.php
@@ -624,7 +624,7 @@ class module_report_activity extends module_report
         $result['top_ten_poiddoc'] = array();
         $result['top_ten_poidprev'] = array();
 
-        $params = array(':site_id' => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id' => $app['configuration']['main']['key']);
 
         $datefilter = module_report_sqlfilter::constructDateFilter($dmin, $dmax);
         $params = array_merge($params, $datefilter['params']);
@@ -704,7 +704,7 @@ class module_report_activity extends module_report
         $collfilter =
             module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
 
-        $params = array(':site_id' => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id' => $app['configuration']['main']['key']);
         $params = array_merge($params, $datefilter['params'], $collfilter['params']);
 
         $sql = "
@@ -751,7 +751,7 @@ class module_report_activity extends module_report
         $collfilter =
             module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
 
-        $params = array(':site_id' => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id' => $app['configuration']['main']['key']);
         $params = array_merge($params, $datefilter['params'], $collfilter['params']);
 
         $sql = "
@@ -792,7 +792,7 @@ class module_report_activity extends module_report
         $collfilter =
             module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
 
-        $params = array(':site_id' => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id' => $app['configuration']['main']['key']);
         $params = array_merge($params, $datefilter['params'], $collfilter['params']);
 
         $sql = "
@@ -832,7 +832,7 @@ class module_report_activity extends module_report
         $collfilter =
             module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
 
-        $params = array(':site_id' => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id' => $app['configuration']['main']['key']);
         $params = array_merge($params, $datefilter['params'], $collfilter['params']);
 
         $sql = "

--- a/lib/classes/module/report/connexion.php
+++ b/lib/classes/module/report/connexion.php
@@ -141,7 +141,7 @@ class module_report_connexion extends module_report
         $collfilter = module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
 
         $params = array_merge(array(
-                ':site_id' => $app['phraseanet.configuration']['main']['key']
+                ':site_id' => $app['configuration']['main']['key']
             ),
             $datefilter['params'],
             $collfilter['params']

--- a/lib/classes/module/report/download.php
+++ b/lib/classes/module/report/download.php
@@ -174,7 +174,7 @@ class module_report_download extends module_report
     {
         $conn = connection::getPDOConnection($app, $sbas_id);
 
-        $params = array(':site_id'  => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id'  => $app['configuration']['main']['key']);
         $datefilter = module_report_sqlfilter::constructDateFilter($dmin, $dmax);
         $collfilter = module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
         $params = array_merge($params, $datefilter['params'], $collfilter['params']);
@@ -210,7 +210,7 @@ class module_report_download extends module_report
         $databox = $app['phraseanet.appbox']->get_databox((int) $sbas_id);
         $conn = $databox->get_connection();
 
-        $params = array(':site_id'  => $app['phraseanet.configuration']['main']['key']);
+        $params = array(':site_id'  => $app['configuration']['main']['key']);
         $datefilter = module_report_sqlfilter::constructDateFilter($dmin, $dmax);
         $collfilter = module_report_sqlfilter::constructCollectionFilter($app, $list_coll_id);
         $params = array_merge($params, $datefilter['params'], $collfilter['params']);

--- a/lib/classes/module/report/sqlfilter.php
+++ b/lib/classes/module/report/sqlfilter.php
@@ -64,7 +64,7 @@ class module_report_sqlfilter
     {
         $finalfilter = '';
 
-        $params = array(':log_site' => $this->app['phraseanet.configuration']['main']['key']);
+        $params = array(':log_site' => $this->app['configuration']['main']['key']);
 
         if ($this->filter['date']) {
             $finalfilter .= $this->filter['date']['sql'] . ' AND ';
@@ -88,7 +88,7 @@ class module_report_sqlfilter
         $params = array();
 
         $sql = 'log.site = :log_site_gv_filter';
-        $params[':log_site_gv_filter'] = $this->app['phraseanet.configuration']['main']['key'];
+        $params[':log_site_gv_filter'] = $this->app['configuration']['main']['key'];
 
         return array('sql' => $sql, 'params' => $params);
     }

--- a/lib/classes/patch/370alpha9a.php
+++ b/lib/classes/patch/370alpha9a.php
@@ -59,7 +59,7 @@ class patch_370alpha9a implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $app['phraseanet.configuration']->setDefault('border-manager');
+        $app['configuration']->setDefault('border-manager');
 
         return true;
     }

--- a/lib/classes/patch/373alpha1a.php
+++ b/lib/classes/patch/373alpha1a.php
@@ -98,7 +98,7 @@ class patch_373alpha1a implements patchInterface
 
         $stmt->closeCursor();
 
-        $config = $app['phraseanet.configuration']->getConfig();
+        $config = $app['configuration']->getConfig();
         $config['binaries'] = $binaries;
 
         $sql = 'DELETE FROM registry WHERE `key` = :key';
@@ -118,7 +118,7 @@ class patch_373alpha1a implements patchInterface
 
         $config['main']['key'] = $row['value'];
 
-        $app['phraseanet.configuration']->setConfig($config);
+        $app['configuration']->setConfig($config);
 
         $sql = 'DELETE FROM registry WHERE `key` = :key';
         $stmt = $app['phraseanet.appbox']->get_connection()->prepare($sql);

--- a/lib/classes/patch/380alpha13a.php
+++ b/lib/classes/patch/380alpha13a.php
@@ -51,7 +51,7 @@ class patch_380alpha13a implements patchInterface
         $xsendfilePath = $app['phraseanet.registry']->get('GV_X_Accel_Redirect');
         $xsendfileMountPoint = $app['phraseanet.registry']->get('GV_X_Accel_Redirect_mount_point');
 
-        $config = $app['phraseanet.configuration']
+        $config = $app['configuration']
             ->setDefault('xsendfile')
             ->getConfig();
 
@@ -65,7 +65,7 @@ class patch_380alpha13a implements patchInterface
             ));
         }
 
-        $app['phraseanet.configuration']->setConfig($config);
+        $app['configuration']->setConfig($config);
 
         $toRemove = array('GV_X_Accel_Redirect', 'GV_X_Accel_Redirect_mount_point', 'GV_modxsendfile');
 

--- a/lib/classes/patch/380alpha14a.php
+++ b/lib/classes/patch/380alpha14a.php
@@ -48,7 +48,7 @@ class patch_380alpha14a implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $app['phraseanet.configuration']->setDefault('plugins');
+        $app['configuration']->setDefault('plugins');
 
         return true;
     }

--- a/lib/classes/patch/380alpha15a.php
+++ b/lib/classes/patch/380alpha15a.php
@@ -48,9 +48,9 @@ class patch_380alpha15a implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $binaries = $app['phraseanet.configuration']['binaries'];
+        $binaries = $app['configuration']['binaries'];
         unset($binaries['composite_binary'], $binaries['convert_binary']);
-        $app['phraseanet.configuration']['binaries'] = $binaries;
+        $app['configuration']['binaries'] = $binaries;
 
         return true;
     }

--- a/lib/classes/patch/380alpha16a.php
+++ b/lib/classes/patch/380alpha16a.php
@@ -48,7 +48,7 @@ class patch_380alpha16a implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $xsendfile = $app['phraseanet.configuration']['xsendfile'];
+        $xsendfile = $app['configuration']['xsendfile'];
 
         if (!isset($xsendfile['mapping'])) {
             $xsendfile['mapping'] = array();
@@ -63,7 +63,7 @@ class patch_380alpha16a implements patchInterface
             'mount-point' => '/download/',
         );
 
-        $app['phraseanet.configuration']['xsendfile'] = $xsendfile;
+        $app['configuration']['xsendfile'] = $xsendfile;
 
         return true;
     }

--- a/lib/classes/patch/380alpha17a.php
+++ b/lib/classes/patch/380alpha17a.php
@@ -48,7 +48,7 @@ class patch_380alpha17a implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $auth = $app['phraseanet.configuration']['authentication'];
+        $auth = $app['configuration']['authentication'];
 
         if (isset($auth['captcha']) && isset($auth['captcha']['trials-before-failure'])) {
             $auth['captcha']['trials-before-display'] = $auth['captcha']['trials-before-failure'];
@@ -59,7 +59,7 @@ class patch_380alpha17a implements patchInterface
             unset($auth['auto-create']['enabled']);
         }
 
-        $app['phraseanet.configuration']['authentication'] = $auth;
+        $app['configuration']['authentication'] = $auth;
 
         return true;
     }

--- a/lib/classes/patch/380alpha18a.php
+++ b/lib/classes/patch/380alpha18a.php
@@ -51,9 +51,9 @@ class patch_380alpha18a implements patchInterface
     {
         $finder = new ExecutableFinder();
 
-        $binaries = $app['phraseanet.configuration']['binaries'];
+        $binaries = $app['configuration']['binaries'];
         $binaries['recess_binary'] = $finder->find('recess');
-        $app['phraseanet.configuration']['binaries'] = $binaries;
+        $app['configuration']['binaries'] = $binaries;
 
         return true;
     }

--- a/lib/classes/patch/380alpha2a.php
+++ b/lib/classes/patch/380alpha2a.php
@@ -59,12 +59,12 @@ class patch_380alpha2a implements patchInterface
      */
     public function apply(base $databox, Application $app)
     {
-        $config = $app['phraseanet.configuration']->getConfig();
+        $config = $app['configuration']->getConfig();
 
         if (isset($config['main']['database-test'])) {
             $config['main']['database-test']['path'] = '/tmp/db.sqlite';
         }
 
-        $app['phraseanet.configuration']->setConfig($config);
+        $app['configuration']->setConfig($config);
     }
 }

--- a/lib/classes/patch/380alpha3b.php
+++ b/lib/classes/patch/380alpha3b.php
@@ -60,7 +60,7 @@ class patch_380alpha3b implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $app['phraseanet.configuration']->setDefault('main', 'search-engine');
+        $app['configuration']->setDefault('main', 'search-engine');
 
         return true;
     }

--- a/lib/classes/patch/380alpha6a.php
+++ b/lib/classes/patch/380alpha6a.php
@@ -48,7 +48,7 @@ class patch_380alpha6a implements patchInterface
      */
     public function apply(base $appbox, Application $app)
     {
-        $app['phraseanet.configuration']->setDefault('registration-fields');
-        $app['phraseanet.configuration']->setDefault('authentication');
+        $app['configuration']->setDefault('registration-fields');
+        $app['configuration']->setDefault('authentication');
     }
 }

--- a/lib/classes/patch/380alpha8a.php
+++ b/lib/classes/patch/380alpha8a.php
@@ -63,9 +63,9 @@ class patch_380alpha8a implements patchInterface
         $sxe = simplexml_load_string($row['settings']);
         $indexer = $sxe->binpath . '/phraseanet_indexer';
 
-        $binaries = $app['phraseanet.configuration']['binaries'];
+        $binaries = $app['configuration']['binaries'];
         $binaries['phraseanet_indexer'] = $indexer;
-        $app['phraseanet.configuration']['binaries'] = $binaries;
+        $app['configuration']['binaries'] = $binaries;
 
         return true;
     }

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -1921,7 +1921,7 @@ class record_adapter implements record_Interface, cache_cacheableInterface
               ORDER BY g.ord ASC, dateadd ASC, record_id ASC';
 
             $params = array(
-                ':GV_site'   => $this->app['phraseanet.configuration']['main']['key'],
+                ':GV_site'   => $this->app['configuration']['main']['key'],
                 ':usr_id'    => $this->app['authentication']->getUser()->get_id(),
                 ':record_id' => $this->get_record_id(),
             );
@@ -1972,7 +1972,7 @@ class record_adapter implements record_Interface, cache_cacheableInterface
             WHERE rid_child = :record_id';
 
         $params = array(
-            ':GV_site'   => $this->app['phraseanet.configuration']['main']['key']
+            ':GV_site'   => $this->app['configuration']['main']['key']
             , ':usr_id'    => $this->app['authentication']->getUser()->get_id()
             , ':record_id' => $this->get_record_id()
         );

--- a/lib/classes/record/preview.php
+++ b/lib/classes/record/preview.php
@@ -348,7 +348,7 @@ class record_preview extends record_adapter
         if (! $report) {
             $sql .= ' AND ((l.usrid = :usr_id AND l.site= :site) OR action="add")';
             $params[':usr_id'] = $this->app['authentication']->getUser()->get_id();
-            $params[':site'] = $this->app['phraseanet.configuration']['main']['key'];
+            $params[':site'] = $this->app['configuration']['main']['key'];
         }
 
         $sql .= 'ORDER BY d.date, usrid DESC';
@@ -453,7 +453,7 @@ class record_preview extends record_adapter
         $stmt->execute(
             array(
                 ':record_id' => $this->get_record_id(),
-                ':site'      => $this->app['phraseanet.configuration']['main']['key']
+                ':site'      => $this->app['configuration']['main']['key']
             )
         );
         $rs = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -614,7 +614,7 @@ class record_preview extends record_adapter
         $stmt->execute(
             array(
                 ':record_id' => $this->get_record_id(),
-                ':site'      => $this->app['phraseanet.configuration']['main']['key']
+                ':site'      => $this->app['configuration']['main']['key']
             )
         );
         $rs = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/lib/classes/registry.php
+++ b/lib/classes/registry.php
@@ -47,10 +47,10 @@ class registry implements registryInterface
         $this->cache = new ArrayCache();
 
         if ($app['phraseanet.configuration-tester']->isInstalled()) {
-            $this->cache->save('GV_ServerName', $app['phraseanet.configuration']['main']['servername']);
+            $this->cache->save('GV_ServerName', $app['configuration']['main']['servername']);
             $this->cache->save('GV_debug', $app['debug']);
 
-            $config = $app['phraseanet.configuration']->getConfig();
+            $config = $app['configuration']->getConfig();
 
             if (isset($config['main']['key'])) {
                 $this->cache->save('GV_sit', $config['main']['key']);

--- a/tests/Alchemy/Tests/Phrasea/Application/OverviewTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Application/OverviewTest.php
@@ -196,7 +196,7 @@ class OverviewTest extends \PhraseanetWebTestCaseAuthenticatedAbstract
             $this->assertEquals($value, $response->headers->get($name));
         }
 
-        $this->assertEquals(rtrim(self::$DI['app']['phraseanet.configuration']['main']['servername'], '/') . "/permalink/v1/1/". self::$DI['record_1']->get_record_id()."/caption/?token=".$token, $response->headers->get("Link"));
+        $this->assertEquals(rtrim(self::$DI['app']['configuration']['main']['servername'], '/') . "/permalink/v1/1/". self::$DI['record_1']->get_record_id()."/caption/?token=".$token, $response->headers->get("Link"));
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -238,7 +238,7 @@ class OverviewTest extends \PhraseanetWebTestCaseAuthenticatedAbstract
             $this->assertEquals($value, $response->headers->get($name));
         }
 
-        $this->assertEquals(rtrim(self::$DI['app']['phraseanet.configuration']['main']['servername'], '/') . "/permalink/v1/1/". self::$DI['record_1']->get_record_id()."/caption/?token=".$token, $response->headers->get("Link"));
+        $this->assertEquals(rtrim(self::$DI['app']['configuration']['main']['servername'], '/') . "/permalink/v1/1/". self::$DI['record_1']->get_record_id()."/caption/?token=".$token, $response->headers->get("Link"));
         $this->assertEquals(200, $response->getStatusCode());
     }
 

--- a/tests/Alchemy/Tests/Phrasea/ApplicationTest.php
+++ b/tests/Alchemy/Tests/Phrasea/ApplicationTest.php
@@ -291,11 +291,11 @@ class ApplicationTest extends \PhraseanetPHPUnitAbstract
     public function testUrlGeneratorContext()
     {
         $app = new Application('test');
-        $app['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
-        $app['phraseanet.configuration']->expects($this->once())
+        $app['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        $app['configuration']->expects($this->once())
             ->method('isSetup')
             ->will($this->returnValue(true));
-        $app['phraseanet.configuration']->expects($this->once())
+        $app['configuration']->expects($this->once())
             ->method('offsetGet')
             ->with('main')
             ->will($this->returnValue(array('servername' => 'https://cat.turbocat.com/')));

--- a/tests/Alchemy/Tests/Phrasea/Command/Compile/ConfigurationTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Command/Compile/ConfigurationTest.php
@@ -11,8 +11,8 @@ class ConfigurationTest extends \PhraseanetPHPUnitAbstract
         $command = new Configuration();
         $command->setContainer(self::$DI['cli']);
 
-        self::$DI['cli']['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
-        self::$DI['cli']['phraseanet.configuration']->expects($this->once())
+        self::$DI['cli']['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        self::$DI['cli']['configuration']->expects($this->once())
             ->method('compileAndWrite');
 
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');

--- a/tests/Alchemy/Tests/Phrasea/Command/Setup/XSendFileMappingGeneratorTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Command/Setup/XSendFileMappingGeneratorTest.php
@@ -30,13 +30,13 @@ class XSendFileMappingGeneratorTest extends \PhraseanetPHPUnitAbstract
         self::$DI['cli']['monolog'] = self::$DI['cli']->share(function () use ($phpunit) {
             return $phpunit->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock();
         });
-        self::$DI['cli']['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        self::$DI['cli']['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
         if ($option) {
-            self::$DI['cli']['phraseanet.configuration']->expects($this->once())
+            self::$DI['cli']['configuration']->expects($this->once())
                 ->method('offsetSet')
                 ->with('xsendfile');
         } else {
-            self::$DI['cli']['phraseanet.configuration']->expects($this->never())
+            self::$DI['cli']['configuration']->expects($this->never())
                 ->method('offsetSet');
         }
         $command->setContainer(self::$DI['cli']);

--- a/tests/Alchemy/Tests/Phrasea/Controller/Utils/ConnectionTestTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Utils/ConnectionTestTest.php
@@ -9,7 +9,7 @@ class ControllerConnectionTestTest extends \PhraseanetWebTestCaseAbstract
      */
     public function testRouteMysql()
     {
-        $connexion = self::$DI['app']['phraseanet.configuration']['main']['database'];
+        $connexion = self::$DI['app']['configuration']['main']['database'];
 
         $params = array(
             "hostname" => $connexion['host'],
@@ -26,7 +26,7 @@ class ControllerConnectionTestTest extends \PhraseanetWebTestCaseAbstract
 
     public function testRouteMysqlFailed()
     {
-        $connexion = self::$DI['app']['phraseanet.configuration']['main']['database'];
+        $connexion = self::$DI['app']['configuration']['main']['database'];
 
         $params = array(
             "hostname" => $connexion['host'],
@@ -52,7 +52,7 @@ class ControllerConnectionTestTest extends \PhraseanetWebTestCaseAbstract
 
     public function testRouteMysqlDbFailed()
     {
-        $connexion = self::$DI['app']['phraseanet.configuration']['main']['database'];
+        $connexion = self::$DI['app']['configuration']['main']['database'];
 
         $params = array(
             "hostname" => $connexion['host'],

--- a/tests/Alchemy/Tests/Phrasea/Core/CLIProvider/PluginServiceProviderTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/CLIProvider/PluginServiceProviderTest.php
@@ -94,7 +94,7 @@ class PluginServiceProvidertest extends ServiceProviderTestCase
         }
 
         $app = self::$DI['cli'];
-        $app['phraseanet.configuration'] = array('binaries' => array('php_binary' => null));
+        $app['configuration'] = array('binaries' => array('php_binary' => null));
         $app->register(new PluginServiceProvider());
         $this->assertInstanceOf('Alchemy\Phrasea\Plugin\Management\ComposerInstaller', $app['plugins.composer-installer']);
     }
@@ -102,7 +102,7 @@ class PluginServiceProvidertest extends ServiceProviderTestCase
     public function testInstallerCanDetectPhpConf()
     {
         $app = self::$DI['cli'];
-        $app['phraseanet.configuration'] = array('binaries' => array('php_binary' => null));
+        $app['configuration'] = array('binaries' => array('php_binary' => null));
         $app->register(new PluginServiceProvider());
         $this->assertInstanceOf('Alchemy\Phrasea\Plugin\Management\ComposerInstaller', $app['plugins.composer-installer']);
     }

--- a/tests/Alchemy/Tests/Phrasea/Core/Event/Subscriber/DebuggerSubscriberTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Event/Subscriber/DebuggerSubscriberTest.php
@@ -30,7 +30,7 @@ class DebuggerSubscriberTest extends \PHPUnit_Framework_TestCase
             unlink($app['phraseanet.configuration.config-compiled-path']);
         }
 
-        $app['phraseanet.configuration']['debugger'] = array('allowed-ips' => $authorized);
+        $app['configuration']['debugger'] = array('allowed-ips' => $authorized);
         $app['dispatcher']->addSubscriber(new DebuggerSubscriber($app));
         $app->get('/', function () {
             return 'success';

--- a/tests/Alchemy/Tests/Phrasea/Core/Event/Subscriber/PhraseaLocaleSubscriberTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Event/Subscriber/PhraseaLocaleSubscriberTest.php
@@ -110,7 +110,7 @@ class PhraseaLocaleSubscriberTest extends \PhraseanetPHPUnitAbstract
         $app['phraseanet.registry'] = $this->getMockBuilder('\registry')
             ->disableOriginalConstructor()
             ->getmock();
-        $app['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        $app['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
 
         $app['dispatcher']->addSubscriber(new PhraseaLocaleSubscriber($app));
 

--- a/tests/Alchemy/Tests/Phrasea/Core/Provider/AuthenticationManagerServiceProviderTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Provider/AuthenticationManagerServiceProviderTest.php
@@ -87,9 +87,9 @@ class AuthenticationManagerServiceProvidertest extends ServiceProviderTestCase
         $app->register(new AuthenticationManagerServiceProvider());
         $app->register(new ConfigurationServiceProvider());
 
-        $app['phraseanet.configuration'] = $conf = $app['phraseanet.configuration']->getConfig();
+        $app['configuration'] = $conf = $app['configuration']->getConfig();
         $conf['authentication']['captcha']['trials-before-display'] = 42;
-        $app['phraseanet.configuration'] = $conf;
+        $app['configuration'] = $conf;
 
         $app['EM'] = $this->getMockBuilder('Doctrine\Orm\EntityManager')
             ->disableOriginalConstructor()
@@ -107,11 +107,11 @@ class AuthenticationManagerServiceProvidertest extends ServiceProviderTestCase
         $app = new PhraseaApplication();
         $app->register(new ConfigurationServiceProvider());
 
-        $conf = $app['phraseanet.configuration']->getConfig();
+        $conf = $app['configuration']->getConfig();
         $conf['authentication']['auto-create'] = array(
             'templates' => array(),
         );
-        $app['phraseanet.configuration']->setConfig($conf);
+        $app['configuration']->setConfig($conf);
 
         $app['authentication.providers.account-creator'];
     }
@@ -138,11 +138,11 @@ class AuthenticationManagerServiceProvidertest extends ServiceProviderTestCase
             }));
         $app['phraseanet.appbox'] = self::$DI['app']['phraseanet.appbox'];
 
-        $conf = $app['phraseanet.configuration']->getConfig();
+        $conf = $app['configuration']->getConfig();
         $conf['authentication']['captcha'] = array(
             'enabled' => true,
         );
-        $app['phraseanet.configuration']->setConfig($conf);
+        $app['configuration']->setConfig($conf);
 
         $app['EM'] = $this->getMockBuilder('Doctrine\Orm\EntityManager')
             ->disableOriginalConstructor()
@@ -176,11 +176,11 @@ class AuthenticationManagerServiceProvidertest extends ServiceProviderTestCase
             }));
         $app['phraseanet.appbox'] = self::$DI['app']['phraseanet.appbox'];
 
-        $conf = $app['phraseanet.configuration']->getConfig();
+        $conf = $app['configuration']->getConfig();
         $conf['authentication']['captcha'] = array(
             'enabled' => false,
         );
-        $app['phraseanet.configuration']->setConfig($conf);
+        $app['configuration']->setConfig($conf);
 
         $app['EM'] = $this->getMockBuilder('Doctrine\Orm\EntityManager')
             ->disableOriginalConstructor()
@@ -202,14 +202,14 @@ class AuthenticationManagerServiceProvidertest extends ServiceProviderTestCase
         $template2 = \User_Adapter::create(self::$DI['app'], 'template' . $random->generatePassword(), $random->generatePassword(), null, false);
         $template2->set_template(self::$DI['user']);
 
-        $conf = $app['phraseanet.configuration']->getConfig();
+        $conf = $app['configuration']->getConfig();
         $conf['authentication']['auto-create'] = array(
             'templates' => array(
                 $template1->get_id(),
                 $template2->get_login()
             )
         );
-        $app['phraseanet.configuration']->setConfig($conf);
+        $app['configuration']->setConfig($conf);
 
         $this->assertEquals(array($template1, $template2), $app['authentication.providers.account-creator']->getTemplates());
 

--- a/tests/Alchemy/Tests/Phrasea/Core/Provider/BorderManagerServiceProviderTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Provider/BorderManagerServiceProviderTest.php
@@ -32,7 +32,7 @@ class BorderManagerServiceProvidertest extends ServiceProviderTestCase
             )
         ));
         $app->register(new BorderManagerServiceProvider());
-        $app['phraseanet.configuration'] = array('border-manager' => array('enabled' => false));
+        $app['configuration'] = array('border-manager' => array('enabled' => false));
 
         $this->assertInstanceOf('Alchemy\Phrasea\Border\Manager', $app['border-manager']);
         $this->assertNull($app['border-manager']->getPdfToText());
@@ -54,7 +54,7 @@ class BorderManagerServiceProvidertest extends ServiceProviderTestCase
             )
         ));
         $app->register(new BorderManagerServiceProvider());
-        $app['phraseanet.configuration'] = array('border-manager' => array('enabled' => false));
+        $app['configuration'] = array('border-manager' => array('enabled' => false));
 
         $this->assertInstanceOf('Alchemy\Phrasea\Border\Manager', $app['border-manager']);
         $this->assertInstanceOf('XPDF\PdfToText', $app['border-manager']->getPdfToText());

--- a/tests/Alchemy/Tests/Phrasea/Core/Provider/ConfigurationServiceProviderTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Provider/ConfigurationServiceProviderTest.php
@@ -17,6 +17,11 @@ class ConfigurationServiceProvidertest extends ServiceProviderTestCase
         return array(
             array(
                 'Alchemy\Phrasea\Core\Provider\ConfigurationServiceProvider',
+                'configuration',
+                'Alchemy\\Phrasea\\Core\\Configuration\\Configuration'
+            ),
+            array(
+                'Alchemy\Phrasea\Core\Provider\ConfigurationServiceProvider',
                 'phraseanet.configuration',
                 'Alchemy\\Phrasea\\Core\\Configuration\\Configuration'
             ),

--- a/tests/Alchemy/Tests/Phrasea/Core/Provider/LocaleServiceProviderTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Provider/LocaleServiceProviderTest.php
@@ -22,15 +22,15 @@ class LocaleServiceProvidertest extends \PhraseanetPHPUnitAbstract
     {
         $app = new Application();
         $app->register(new LocaleServiceProvider());
-        $app['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
-        $app['phraseanet.configuration']->expects($this->any())
+        $app['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        $app['configuration']->expects($this->any())
             ->method('offsetExist')
             ->with('main')
             ->will($this->returnValue(true));
-        $app['phraseanet.configuration']->expects($this->any())
+        $app['configuration']->expects($this->any())
             ->method('isSetup')
             ->will($this->returnValue(true));
-        $app['phraseanet.configuration']->expects($this->any())
+        $app['configuration']->expects($this->any())
             ->method('offsetGet')
             ->with('main')
             ->will($this->returnValue(array('languages' => array('fr_FR', 'en_US', 'de'))));
@@ -46,15 +46,15 @@ class LocaleServiceProvidertest extends \PhraseanetPHPUnitAbstract
     {
         $app = new Application();
         $app->register(new LocaleServiceProvider());
-        $app['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
-        $app['phraseanet.configuration']->expects($this->any())
+        $app['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        $app['configuration']->expects($this->any())
             ->method('offsetExist')
             ->with('main')
             ->will($this->returnValue(true));
-        $app['phraseanet.configuration']->expects($this->any())
+        $app['configuration']->expects($this->any())
             ->method('isSetup')
             ->will($this->returnValue(true));
-        $app['phraseanet.configuration']->expects($this->any())
+        $app['configuration']->expects($this->any())
             ->method('offsetGet')
             ->with('main')
             ->will($this->returnValue(array('languages' => array('en_US'))));

--- a/tests/Alchemy/Tests/Phrasea/Core/Provider/RegistrationServiceProviderTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Provider/RegistrationServiceProviderTest.php
@@ -13,9 +13,9 @@ class RegistrationServiceProvidertest extends \PhraseanetPHPUnitAbstract
     {
         self::$DI['app']->register(new RegistrationServiceProvider());
 
-        $conf = self::$DI['app']['phraseanet.configuration']->getConfig();
+        $conf = self::$DI['app']['configuration']->getConfig();
         $conf['registration-fields'] = array('plop');
-        self::$DI['app']['phraseanet.configuration'] = $conf;
+        self::$DI['app']['configuration'] = $conf;
 
         $this->assertEquals(array('plop'), self::$DI['app']['registration.fields']);
         $this->assertEquals(array('plop'), self::$DI['app']['registration.fields']);

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/PhraseaConfigurationPanelTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/PhraseaConfigurationPanelTest.php
@@ -18,6 +18,6 @@ class PhraseaConfigurationPanelTest extends ConfigurationPanelAbstractTest
 
     public function getPanel()
     {
-        return new ConfigurationPanel(new PhraseaEngine(self::$DI['app']), self::$DI['app']['phraseanet.configuration']);
+        return new ConfigurationPanel(new PhraseaEngine(self::$DI['app']), self::$DI['app']['configuration']);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/SphinxSearchConfigurationPanelTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/SphinxSearchConfigurationPanelTest.php
@@ -18,7 +18,7 @@ class SphinxSearchConfigurationPanelTest extends ConfigurationPanelAbstractTest
 
     public function getPanel()
     {
-        return new ConfigurationPanel(new SphinxSearchEngine(self::$DI['app'], 'localhost', 9306, 'localhost', 9308), self::$DI['app']['phraseanet.configuration']);
+        return new ConfigurationPanel(new SphinxSearchEngine(self::$DI['app'], 'localhost', 9306, 'localhost', 9308), self::$DI['app']['configuration']);
     }
 
     public function testGetAVailableCharsets()

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/SphinxSearchEngineTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/SphinxSearchEngineTest.php
@@ -35,16 +35,16 @@ class SphinxSearchEngineTest extends SearchEngineAbstractTest
         $app = new Application('test');
         $appbox = $app['phraseanet.appbox'];
 
-        $configuration = $app['phraseanet.configuration']->getConfig();
+        $configuration = $app['configuration']->getConfig();
         $configuration['main']['search-engine']['options'] = array(
             'host'    => '127.0.0.1',
             'port'    => 9312,
             'rt_host' => '127.0.0.1',
             'rt_port' => 9306,
         );
-        $app['phraseanet.configuration']->setConfig($configuration);
+        $app['configuration']->setConfig($configuration);
 
-        self::$searchEngine = SphinxSearchEngine::create($app, $app['phraseanet.configuration']['main']['search-engine']['options']);
+        self::$searchEngine = SphinxSearchEngine::create($app, $app['configuration']['main']['search-engine']['options']);
 
         self::$config = tempnam(sys_get_temp_dir(), 'tmp_sphinx.conf');
         $configuration = self::$searchEngine->getConfigurationPanel()->getConfiguration();
@@ -73,7 +73,7 @@ class SphinxSearchEngineTest extends SearchEngineAbstractTest
         self::$searchd = new Process($searchd . ' -c ' . self::$config);
         self::$searchd->run();
 
-        self::$searchEngine = SphinxSearchEngine::create($app, $app['phraseanet.configuration']['main']['search-engine']['options']);
+        self::$searchEngine = SphinxSearchEngine::create($app, $app['configuration']['main']['search-engine']['options']);
     }
 
     public function setUp()

--- a/tests/Alchemy/Tests/Phrasea/Setup/InstallerTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Setup/InstallerTest.php
@@ -51,7 +51,7 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
         @unlink($config);
         @unlink($compiled);
 
-        $app['phraseanet.configuration'] = new Configuration(new Yaml(), new Compiler(), $config, $compiled, true);
+        $app['configuration'] = new Configuration(new Yaml(), new Compiler(), $config, $compiled, true);
 
         $abConn = new \connection_pdo('abConn', 'localhost', 3306, $credentials['user'], $credentials['password'], 'ab_unitTests');
         $dbConn = new \connection_pdo('dbConn', 'localhost', 3306, $credentials['user'], $credentials['password'], 'db_unitTests');
@@ -64,14 +64,14 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
 
         \User_Adapter::unsetInstances();
 
-        $this->assertTrue($app['phraseanet.configuration']->isSetup());
+        $this->assertTrue($app['configuration']->isSetup());
         $this->assertTrue($app['phraseanet.configuration-tester']->isUpToDate());
 
         $databoxes = $app['phraseanet.appbox']->get_databoxes();
         $databox = array_pop($databoxes);
         $this->assertContains('<path>'.realpath($dataPath).'/db_unitTests/subdefs</path>', $databox->get_structure());
 
-        $conf = $app['phraseanet.configuration']->getConfig();
+        $conf = $app['configuration']->getConfig();
         $this->assertArrayHasKey('main', $conf);
         $this->assertArrayHasKey('key', $conf['main']);
         $this->assertGreaterThan(10, strlen($conf['main']['key']));

--- a/tests/Alchemy/Tests/Phrasea/Setup/Version/Migration/Migration35Test.php
+++ b/tests/Alchemy/Tests/Phrasea/Setup/Version/Migration/Migration35Test.php
@@ -62,7 +62,7 @@ class Migration35Test extends AbstractSetupTester
         $app = $app ? : new Application('test');
 
         if ($this->specifications) {
-            $app['phraseanet.configuration'] = $this->specifications;
+            $app['configuration'] = $this->specifications;
         }
 
         return new Migration35($app);

--- a/tests/Alchemy/Tests/Phrasea/Setup/Version/Migration/Migration38Test.php
+++ b/tests/Alchemy/Tests/Phrasea/Setup/Version/Migration/Migration38Test.php
@@ -30,17 +30,17 @@ class Migration38Test extends AbstractSetupTester
     public function testMigrate()
     {
         $app = new Application();
-        $app['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        $app['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
         $app['root.path'] = __DIR__ . '/../Probe/fixtures-3807';
 
-        $app['phraseanet.configuration']->expects($this->once())
+        $app['configuration']->expects($this->once())
             ->method('initialize');
 
-        $app['phraseanet.configuration']->expects($this->once())
+        $app['configuration']->expects($this->once())
             ->method('getConfig')
             ->will($this->returnValue($this->getCurrent()));
 
-        $app['phraseanet.configuration']->expects($this->once())
+        $app['configuration']->expects($this->once())
             ->method('setConfig')
             ->with($this->getModified());
 

--- a/tests/Alchemy/Tests/Phrasea/TaskManager/Editor/EditorTestCase.php
+++ b/tests/Alchemy/Tests/Phrasea/TaskManager/Editor/EditorTestCase.php
@@ -43,7 +43,7 @@ abstract class EditorTestCase extends \PhraseanetPHPUnitAbstract
         $editor = $this->getEditor();
         $dom = new \DOMDocument();
         $dom->strictErrorChecking = true;
-        $this->assertTrue(false !== $dom->loadXML($editor->getDefaultSettings(self::$DI['app']['phraseanet.configuration'])));
+        $this->assertTrue(false !== $dom->loadXML($editor->getDefaultSettings(self::$DI['app']['configuration'])));
     }
 
     public function testGetDefaultSettingsWithoutConfiguration()

--- a/tests/classes/PhraseanetPHPUnitAbstract.php
+++ b/tests/classes/PhraseanetPHPUnitAbstract.php
@@ -142,7 +142,7 @@ abstract class PhraseanetPHPUnitAbstract extends WebTestCase
             });
 
             $app['url_generator'] = $app->share($app->extend('url_generator', function ($generator, $app) {
-                $host = parse_url($app['phraseanet.configuration']['main']['servername'], PHP_URL_HOST);
+                $host = parse_url($app['configuration']['main']['servername'], PHP_URL_HOST);
                 $generator->setContext(new RequestContext('', 'GET', $host));
 
                 return $generator;
@@ -183,7 +183,7 @@ abstract class PhraseanetPHPUnitAbstract extends WebTestCase
             });
 
             $app['url_generator'] = $app->share($app->extend('url_generator', function ($generator, $app) {
-                $host = parse_url($app['phraseanet.configuration']['main']['servername'], PHP_URL_HOST);
+                $host = parse_url($app['configuration']['main']['servername'], PHP_URL_HOST);
                 $generator->setContext(new RequestContext('', 'GET', $host));
 
                 return $generator;

--- a/tests/classes/PhraseanetWebTestCaseAuthenticatedAbstract.php
+++ b/tests/classes/PhraseanetWebTestCaseAuthenticatedAbstract.php
@@ -98,7 +98,7 @@ abstract class PhraseanetWebTestCaseAuthenticatedAbstract extends PhraseanetPHPU
     {
         $this->createDatabase();
 
-        $connexion = self::$DI['app']['phraseanet.configuration']['main']['database'];
+        $connexion = self::$DI['app']['configuration']['main']['database'];
 
         try {
             $conn = new \connection_pdo(

--- a/tests/classes/Session/Session_LoggerTest.php
+++ b/tests/classes/Session/Session_LoggerTest.php
@@ -40,7 +40,7 @@ class Session_LoggerTest extends PhraseanetPHPUnitAbstract
         $params = array(
             ':ses_id' => self::$DI['app']['session']->get('session_id')
             , ':usr_id' => self::$DI['app']['authentication']->getUser()->get_id()
-            , ':site'   => self::$DI['app']['phraseanet.configuration']['main']['key']
+            , ':site'   => self::$DI['app']['configuration']['main']['key']
         );
 
         $stmt = $this->databox->get_connection()->prepare($sql);
@@ -59,7 +59,7 @@ class Session_LoggerTest extends PhraseanetPHPUnitAbstract
         $params = array(
             ':ses_id' => $ses_id
             , ':usr_id' => $usr_id
-            , ':site'   => self::$DI['app']['phraseanet.configuration']['main']['key']
+            , ':site'   => self::$DI['app']['configuration']['main']['key']
         );
 
         $stmt = $this->databox->get_connection()->prepare($sql);

--- a/tests/classes/api/v1/api_v1_resultTest.php
+++ b/tests/classes/api/v1/api_v1_resultTest.php
@@ -17,9 +17,9 @@ class API_V1_resultTest extends PhraseanetPHPUnitAuthenticatedAbstract
 
         self::$DI['app']->register(new \API_V1_Timer());
 
-        $conf = self::$DI['app']['phraseanet.configuration']->getConfig();
+        $conf = self::$DI['app']['configuration']->getConfig();
         $conf['main']['api-timers'] = true;
-        self::$DI['app']['phraseanet.configuration']->setConfig($conf);
+        self::$DI['app']['configuration']->setConfig($conf);
 
         $this->api = $this->getMock("API_V1_adapter", array("get_version"), array(), "", false);
         $this->api->expects($this->any())->method("get_version")->will($this->returnValue("my_super_version1.0"));

--- a/tests/classes/patch/380alpha3bTest.php
+++ b/tests/classes/patch/380alpha3bTest.php
@@ -15,8 +15,8 @@ class patch_380alpha3bTest extends PhraseanetPHPUnitAbstract
 
         $app = self::$DI['app'];
 
-        $app['phraseanet.configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
-        $app['phraseanet.configuration']->expects($this->once())
+        $app['configuration'] = $this->getMock('Alchemy\Phrasea\Core\Configuration\ConfigurationInterface');
+        $app['configuration']->expects($this->once())
             ->method('setDefault')
             ->with('main', 'search-engine');
 

--- a/tests/classes/userTest.php
+++ b/tests/classes/userTest.php
@@ -60,9 +60,9 @@ class userTest extends PhraseanetPHPUnitAbstract
 
     public function testGetPrefWithACustomizedConf()
     {
-        $data = isset(self::$DI['app']['phraseanet.configuration']['user-settings']) ? self::$DI['app']['phraseanet.configuration']['user-settings'] : null;
+        $data = isset(self::$DI['app']['configuration']['user-settings']) ? self::$DI['app']['configuration']['user-settings'] : null;
 
-        self::$DI['app']['phraseanet.configuration']['user-settings'] = array(
+        self::$DI['app']['configuration']['user-settings'] = array(
             'images_per_page' => 42,
             'images_size'     => 666,
             'lalala'          => 'didou',
@@ -76,9 +76,9 @@ class userTest extends PhraseanetPHPUnitAbstract
         $this->assertSame(\User_Adapter::$def_values['editing_top_box'], $user->getPrefs('editing_top_box'));
 
         if (null === $data) {
-            unset(self::$DI['app']['phraseanet.configuration']['user-settings']);
+            unset(self::$DI['app']['configuration']['user-settings']);
         } else {
-            self::$DI['app']['phraseanet.configuration']['user-settings'] = $data;
+            self::$DI['app']['configuration']['user-settings'] = $data;
         }
     }
 


### PR DESCRIPTION
In this PR, I propose to rename `phraseanet.configuration` service to `configuration`. I also propose we keep BC for the previous name until 3.10
