### PR TITLE
[3.9] Add configuration property access

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Configuration/PropertyAccess.php
+++ b/lib/Alchemy/Phrasea/Core/Configuration/PropertyAccess.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of Phraseanet
+ *
+ * (c) 2005-2013 Alchemy
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Alchemy\Phrasea\Core\Configuration;
+
+use Alchemy\Phrasea\Exception\InvalidArgumentException;
+
+/**
+ * Give recursive access to a ConfigurationInterface
+ *
+ * @example PropertyAccess::get(['level1', 'level2']) return the value of $conf['level1']['level2']
+ */
+class PropertyAccess
+{
+    /** @var ConfigurationInterface */
+    private $conf;
+
+    public function __construct(ConfigurationInterface $conf)
+    {
+        $this->conf = $conf;
+    }
+
+    /**
+     * Gets the value given one or more properties
+     *
+     * @param array|string $props   The property to get
+     * @param mixed        $default The default value to return in case the property is not accessible
+     *
+     * @return mixed
+     */
+    public function get($props, $default = null)
+    {
+        $conf = $this->conf->getConfig();
+
+        return $this->doGet($conf, $this->arrayize($props), $default);
+    }
+
+    /**
+     * Checks if a property exists.
+     *
+     * @param array|string $props The property to check
+     *
+     * @return Boolean
+     */
+    public function has($props)
+    {
+        $conf = $this->conf->getConfig();
+
+        return $this->doHas($conf, $this->arrayize($props));
+    }
+
+    /**
+     * Set a value to a property
+     *
+     * @param array|string $props The property to set
+     * @param mixed        $value
+     *
+     * @return mixed The set value
+     */
+    public function set($props, $value)
+    {
+        $conf = $this->conf->getConfig();
+        $this->doSet($conf, $this->arrayize($props), $value);
+        $this->conf->setConfig($conf);
+
+        return $value;
+    }
+
+    /**
+     * Merges a value to the current property value
+     *
+     * @param array|string $props The property to set
+     * @param array        $value
+     *
+     * @throws InvalidArgumentException If the target property contains a scalar.
+     *
+     * @return mixed The merged value
+     */
+    public function merge($props, array $value)
+    {
+        $conf = $this->conf->getConfig();
+        $ret = $this->doMerge($conf, $this->arrayize($props), $value);
+        $this->conf->setConfig($conf);
+
+        return $ret;
+    }
+
+    /**
+     * Removes a property
+     *
+     * @param array|string $props The property to remove
+     *
+     * @return mixed The value of the removed property
+     */
+    public function remove($props)
+    {
+        $conf = $this->conf->getConfig();
+        $value = $this->doRemove($conf, $this->arrayize($props));
+        $this->conf->setConfig($conf);
+
+        return $value;
+    }
+
+    private function doGet(array $conf, array $props, $default)
+    {
+        $prop = array_shift($props);
+        if (!array_key_exists($prop, $conf)) {
+            return $default;
+        }
+        if (count($props) === 0) {
+            return $conf[$prop];
+        }
+        if (!is_array($conf[$prop])) {
+            return $default;
+        }
+
+        return $this->doGet($conf[$prop], $props, $default);
+    }
+
+    private function doHas(array $conf, array $props)
+    {
+        $prop = array_shift($props);
+        if (! array_key_exists($prop, $conf)) {
+            return false;
+        }
+        if (count($props) === 0) {
+            return true;
+        }
+
+        return $this->doHas($conf[$prop], $props);
+    }
+
+    private function doSet(array &$conf, array $props, $value)
+    {
+        $prop = array_shift($props);
+        if (count($props) === 0) {
+            $conf[$prop] = $value;
+        } else {
+            if (! array_key_exists($prop, $conf)) {
+                $conf[$prop] = array();
+            }
+            $this->doSet($conf[$prop], $props, $value);
+        }
+    }
+
+    private function doMerge(array &$conf, array $props, array $value)
+    {
+        $prop = array_shift($props);
+        if (count($props) === 0) {
+            if (array_key_exists($prop, $conf)) {
+                if (!is_array($conf[$prop])) {
+                    throw new InvalidArgumentException('Unable to merge an array in a scalar.');
+                }
+                return $conf[$prop] = array_replace($conf[$prop], $value);
+            }
+
+            return $conf[$prop] = $value;
+        }
+        if (!array_key_exists($prop, $conf)) {
+            $conf[$prop] = array();
+        }
+
+        return $this->doMerge($conf[$prop], $props, $value);
+    }
+
+    private function doRemove(array &$conf, array $props)
+    {
+        $prop = array_shift($props);
+        if (count($props) === 0) {
+            if (array_key_exists($prop, $conf)) {
+                $value = $conf[$prop];
+            } else {
+                $value = null;
+            }
+            unset($conf[$prop]);
+
+            return $value;
+        }
+
+        if (array_key_exists($prop, $conf)) {
+            return $this->doRemove($conf[$prop], $props);
+        }
+    }
+
+    private function arrayize($value)
+    {
+        if (!is_array($value)) {
+            return array($value);
+        }
+
+        return $value;
+    }
+}

--- a/tests/Alchemy/Tests/Phrasea/Core/Configuration/PropertyAccessTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Configuration/PropertyAccessTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Alchemy\Tests\Phrasea\Core\Configuration;
+
+use Alchemy\Phrasea\Core\Configuration\ConfigurationInterface;
+use Alchemy\Phrasea\Core\Configuration\PropertyAccess;
+
+class PropertyAccessTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideGetData
+     */
+    public function testGet($conf, $props, $expected, $default)
+    {
+        $propAccess = new PropertyAccess(new ArrayConf($conf));
+        $this->assertSame($expected, $propAccess->get($props, $default));
+    }
+
+    /**
+     * @dataProvider provideHasData
+     */
+    public function testHas($conf, $props, $expected)
+    {
+        $propAccess = new PropertyAccess(new ArrayConf($conf));
+        $this->assertSame($expected, $propAccess->has($props));
+    }
+
+    /**
+     * @dataProvider provideSetData
+     */
+    public function testSet($conf, $props, $value, $expectedConf)
+    {
+        $conf = new ArrayConf($conf);
+        $propAccess = new PropertyAccess($conf);
+        $this->assertSame($value, $propAccess->set($props, $value));
+        $this->assertSame($expectedConf, $conf->getConfig());
+    }
+
+    /**
+     * @dataProvider provideRemoveData
+     */
+    public function testRemove($conf, $props, $expectedReturnValue, $expectedConf)
+    {
+        $conf = new ArrayConf($conf);
+        $propAccess = new PropertyAccess($conf);
+        $this->assertSame($expectedReturnValue, $propAccess->remove($props));
+        $this->assertSame($expectedConf, $conf->getConfig());
+    }
+
+    /**
+     * @dataProvider provideMergeData
+     */
+    public function testMerge($conf, $props, $value, $expectedReturnValue, $expectedConf)
+    {
+        $conf = new ArrayConf($conf);
+        $propAccess = new PropertyAccess($conf);
+        $this->assertSame($expectedReturnValue, $propAccess->merge($props, $value));
+        $this->assertSame($expectedConf, $conf->getConfig());
+    }
+
+    public function provideMergeData()
+    {
+        $conf = array(
+            'key1' => array('subkey1' => 'value1'),
+        );
+
+        return array(
+            array($conf, 'key1', array('subkey2' => 'valuetest'), array('subkey1' => 'value1', 'subkey2' => 'valuetest'), array('key1' => array('subkey1' => 'value1', 'subkey2' => 'valuetest'))),
+            array($conf, 'key1', array('subkey1' => 'valuetest'), array('subkey1' => 'valuetest'), array('key1' => array('subkey1' => 'valuetest'))),
+            array($conf, 'key2', array('subkey1' => 'valuetest'), array('subkey1' => 'valuetest'), array('key1' => array('subkey1' => 'value1'), 'key2' => array('subkey1' => 'valuetest'))),
+            array($conf, array('key1', 'subkey2'), array('subkey3' => 'valuetest'), array('subkey3' => 'valuetest'), array('key1' => array('subkey1' => 'value1', 'subkey2' => array('subkey3' => 'valuetest')))),
+        );
+    }
+
+    public function provideGetData()
+    {
+        $conf = array(
+            'key1' => array('subkey1' => 'value1'),
+            'key2' => array('subkey1' => 'value1', 'subkey2' => array('subkey3' => 'value3')),
+        );
+
+        return array(
+            array($conf, 'key1', array('subkey1' => 'value1'), null),
+            array($conf, 'key1', array('subkey1' => 'value1'), 'ladada'),
+            array($conf, 'key2', array('subkey1' => 'value1', 'subkey2' => array('subkey3' => 'value3')), null),
+            array($conf, 'key2', array('subkey1' => 'value1', 'subkey2' => array('subkey3' => 'value3')), 'ladada'),
+            array($conf, array('key2', 'subkey1'), 'value1', null),
+            array($conf, array('key2', 'subkey1'), 'value1', 'ladada'),
+            array($conf, array('key2', 'subkey2', 'subkey3'), 'value3', null),
+            array($conf, array('key2', 'subkey2', 'subkey3'), 'value3', 'ladada'),
+            array($conf, array('key2', 'subkey2', 'subkey4'), null, null),
+            array($conf, array('key2', 'subkey2', 'subkey4'), 'ladada', 'ladada'),
+            array($conf, array('key', 'subkey', 'subkey'), null, null),
+            array($conf, array('key', 'subkey', 'subkey'), 'ladada', 'ladada'),
+            array($conf, 'key3', null, null),
+            array($conf, 'key3', 'ladada', 'ladada'),
+        );
+    }
+
+    public function provideHasData()
+    {
+        $conf = array(
+            'key1' => array('subkey1' => 'value1'),
+            'key2' => array('subkey1' => 'value1', 'subkey2' => array('subkey3' => 'value3')),
+        );
+
+        return array(
+            array($conf, 'key1', true),
+            array($conf, 'key2', true),
+            array($conf, array('key2', 'subkey1'), true),
+            array($conf, array('key2', 'subkey2', 'subkey3'), true),
+            array($conf, array('key2', 'subkey2', 'subkey4'), false),
+            array($conf, array('key', 'subkey', 'subkey'), false),
+            array($conf, 'key3', false),
+        );
+    }
+
+    public function provideSetData()
+    {
+        $conf = array(
+            'key1' => array('subkey1' => 'value1'),
+        );
+
+        return array(
+            array($conf, 'key1', 'valuetest', array('key1' => 'valuetest')),
+            array($conf, 'key2', 'valuetest', array('key1' => array('subkey1' => 'value1'), 'key2' => 'valuetest')),
+            array($conf, array('key2', 'subkey1'), 'valuetest', array('key1' => array('subkey1' => 'value1'), 'key2' => array('subkey1' => 'valuetest'))),
+            array($conf, array('key1', 'subkey2'), 'valuetest', array('key1' => array('subkey1' => 'value1', 'subkey2' => 'valuetest'))),
+        );
+    }
+
+    public function provideRemoveData()
+    {
+        $conf = array(
+            'key1' => array('subkey1' => 'value1'),
+        );
+
+        return array(
+            array($conf, 'key1', array('subkey1' => 'value1'), array()),
+            array($conf, array('key1', 'subkey1'), 'value1', array('key1' => array())),
+            array($conf, array('key1', 'subkey2'), null, $conf),
+            array($conf, 'key2', null, $conf),
+        );
+    }
+}
+
+class ArrayConf implements ConfigurationInterface
+{
+    private $conf;
+
+    public function __construct(array $conf)
+    {
+        $this->conf = $conf;
+    }
+
+    public function getConfig()
+    {
+        return $this->conf;
+    }
+
+    public function setConfig(array $config)
+    {
+        $this->conf = $config;
+    }
+
+    public function offsetGet($offset)
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function offsetExists($offset)
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function setDefault($name)
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function initialize()
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function delete()
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function isSetup()
+    {
+        throw new \Exception('not implemented');
+    }
+
+    public function compileAndWrite()
+    {
+        throw new \Exception('not implemented');
+    }
+}


### PR DESCRIPTION
This adds a service to allow easy configuration property access : 

Imagine we provide this service as $app['conf'] : 

``` php
// instead of 
if (isset($app['configuration']['main']) && isset($app['configuration']['main']['key']) && isset($app['configuration']['main']['key']['subkey'])) {
    // ...
}
// lets use :
if ($app['conf']->has(['main', 'key', 'subkey'])) {
    // ...
}
```

Various methods are provided : 

``` php
$app['conf']->get(['main', 'key', 'subkey']);
$app['conf']->set(['main', 'key', 'subkey'], 'value');
$app['conf']->remove(['main', 'key', 'subkey']);
$app['conf']->merge(['main', 'key'], ['subkey2' => 'othervalue']);
```
