### PR TITLE
[3.8] Wrap technical data into blocks

### DIFF
--- a/templates/web/common/technical_datas.html.twig
+++ b/templates/web/common/technical_datas.html.twig
@@ -8,17 +8,24 @@
 
     {% set document = record.get_subdef('document') %}
 
+{% block td_original_name %}
     {% trans 'Nom Original' %} :
     {{ record.get_original_name() }}
+{% endblock %}
     <br/>
 
+{%  block td_mime %}
     {{ record.get_mime() }}
+{% endblock %}
 
+{% block td_weight %}
     {% if document and document.get_size() %}
         - {{document.get_size()| formatOctets}}
     {% endif %}
+{% endblock %}
     <br/>
 
+{% block td_size %}
     {% if document and document.get_width() and document.get_height() %}
         {% trans 'Size' %} :
         {{document.get_width()}} x {{document.get_height()}} px
@@ -32,33 +39,44 @@
             {{ size_w|round(1) }} x {{ size_h|round(1) }} cm (72dpi)
         {% endif %}
     {% endif %}
+{%  endblock %}
     <hr/>
-
+{% block td_camera_model %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_CAMERAMODEL')) is not empty %}
       {% trans 'Camera Model' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_CAMERAMODEL')) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_color_space %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_COLORSPACE')) is not empty %}
       {% trans 'Color space' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_COLORSPACE')) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_channels %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_CHANNELS')) is not empty %}
       {% trans 'Channels' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_CHANNELS')) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_color_depth %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_COLORDEPTH')) is not empty %}
       {% trans 'Color Depth' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_COLORDEPTH')) }} bits
       <br />
     {% endif %}
+{% endblock %}
+{% block td_iso_sensibility %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_ISO')) is not empty %}
       {% trans 'ISO sensibility' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_ISO')) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_flash %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_FLASHFIRED')) is not empty %}
       {% trans 'Flash' %} :
       {% if record.get_technical_infos(constant('media_subdef::TC_DATA_FLASHFIRED')) %}
@@ -68,57 +86,75 @@
       {% endif %}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_shutter_speed %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_SHUTTERSPEED')) is not empty %}
         {% trans 'Shutter speed' %} :
         {{ record.get_technical_infos(constant('media_subdef::TC_DATA_SHUTTERSPEED')) }} s.
         <br />
     {% endif %}
+{% endblock %}
+{% block td_apeture %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_APERTURE')) is not empty %}
       {% trans 'Aperture' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_APERTURE')) | round(2) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_focal_length %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_FOCALLENGTH')) is not empty %}
         {% trans 'Focal length' %} :
         {{ record.get_technical_infos(constant('media_subdef::TC_DATA_FOCALLENGTH')) }} mm
         <br />
     {% endif %}
+{% endblock %}
+{% block td_hyperfocal_distance %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_HYPERFOCALDISTANCE')) is not empty %}
       {% trans 'Hyperfocal distance' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_HYPERFOCALDISTANCE')) | round(2) }} mm
       <br />
     {% endif %}
+{% endblock %}
+{% block td_light_value %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_LIGHTVALUE')) is not empty %}
       {% trans 'Light Value' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_LIGHTVALUE')) | round(2) }}
       <br />
     {% endif %}
-
+{% endblock %}
+{% block td_duration %}
     {% if record.get_formated_duration() %}
       {% trans 'Duree' %} :
       {{ record.get_formated_duration() }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_framerate %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_FRAMERATE')) is not empty %}
       {% trans 'Images par secondes' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_FRAMERATE')) | round(2) }} ips
       <br />
     {% endif %}
+{% endblock %}
+{% block td_codec_audio %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_AUDIOCODEC'))  %}
       {% trans 'Codec Audio' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_AUDIOCODEC')) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_codec_video %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_VIDEOCODEC'))  %}
       {% trans 'Codec Video' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_VIDEOCODEC')) }}
       <br />
     {% endif %}
+{% endblock %}
+{% block td_audio_rate %}
     {% if record.get_technical_infos(constant('media_subdef::TC_DATA_AUDIOSAMPLERATE'))  %}
       {% trans 'Frequence d\'echantillonage' %} :
       {{ record.get_technical_infos(constant('media_subdef::TC_DATA_AUDIOSAMPLERATE')) | round(2) }} kHz
       <br />
     {% endif %}
-
+{% endblock %}
 {% endif %}
-


### PR DESCRIPTION
Useful to override this template in plugins for examples.
