### PR TITLE
[3.8] [PHRAS-69] Remove highlight on record title

### DIFF
--- a/templates/web/prod/results/record.html.twig
+++ b/templates/web/prod/results/record.html.twig
@@ -23,7 +23,7 @@
         <div style="padding: 4px;">
             <div style="height:40px; position: relative; z-index: 95;">
                 <div class="title">
-                {{record.get_title(highlight, searchEngine)|thesaurus}}
+                {{record.get_title}}
                 </div>
                 <div class="status">
                 {{record.get_status_icons|raw}}


### PR DESCRIPTION
This feature is removed for performance purpose
# Bench of processing time to render the view
## Context
- 500 records in database
- 100 records displayed

**full twig**
- 3.3 sec

**empty twig**
- 0.2 sec

**empty twig only title + highlight**
- 3.0 sec

**full twig + no highlight**
- 1.2 sec
