### PR TITLE
set lastname mandatory for registration

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -131,6 +131,9 @@ registration-fields:
         name: firstname
         required: true
     -
+        name: lastname
+        required: true
+    -
         name: geonameid
         required: true
 xsendfile:


### PR DESCRIPTION
For new installation, the last name is now mandatory in registration
from.
