### PR TITLE
phras-79 fix last name mandatory in registration

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -173,6 +173,9 @@ registration-fields:
         name: firstname
         required: true
     -
+        name: lastname
+        required: true
+    -
         name: geonameid
         required: true
 xsendfile:


### PR DESCRIPTION
For new installation last name  is now mandatory in registration from.
