### PR TITLE
[3.9] Fix token value sql length

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Entities/Token.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/Token.php
@@ -22,7 +22,7 @@ class Token
 {
     /**
      * @ORM\Id
-     * @ORM\Column(type="string", length=16)
+     * @ORM\Column(type="string", length=128)
      */
     private $value;
 


### PR DESCRIPTION
Some tokens are made of 64 chars, it is truncated un mysql db.