### PR TITLE
Strict facet matching

### DIFF
--- a/grammar/query.pp
+++ b/grammar/query.pp
@@ -11,6 +11,9 @@
 %token  quote_          "        -> string
 %token  string:quoted   [^"]+
 %token  string:_quote   "        -> default
+%token  raw_quote_      r"       -> raw
+%token  raw:raw_quoted  [^"\\]*(?:\\.[^"\\]*)+
+%token  raw:_raw_quote  "        -> default
 
 // Operators
 %token  in              IN
@@ -74,12 +77,16 @@ string_keyword_symbol:
 string:
     word_or_keyword() ( <space>? word_or_keyword() )*
   | quoted_string()
+  | raw_quoted_string()
 
 word_or_keyword:
     <word> | keyword()
 
 quoted_string:
     ::quote_:: <quoted> ::_quote::
+
+raw_quoted_string:
+    ::raw_quote_:: <raw_quoted> ::_raw_quote::
 
 keyword:
     <in>

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/ContextAbleInterface.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/ContextAbleInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Term;
+
+interface ContextAbleInterface
+{
+    /**
+     * Return a new object with the same content and the provided context.
+     *
+     * @param Context $context Context to add on the new object
+     */
+    public function withContext(Context $context);
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
+
+class RawNode extends Node
+{
+    private $text;
+
+    public static function createFromEscaped($escaped)
+    {
+        $unescaped = str_replace(
+            array('\\\\', '\\"'),
+            array('\\', '"'),
+            $escaped
+        );
+
+        return new self($unescaped);
+    }
+
+    public function __construct($text)
+    {
+        $this->text = $text;
+    }
+
+    public function buildQuery(QueryContext $context)
+    {
+        $fields = $context->getRawFields();
+        $query = array();
+        if (count($fields) > 1) {
+            $query['multi_match']['query'] = $this->text;
+            $query['multi_match']['fields'] = $fields;
+            $query['multi_match']['analyzer'] = 'keyword';
+        } else {
+            $field = reset($fields);
+            $query['term'][$field] = $this->text;
+        }
+
+        return $query;
+    }
+
+    public function getTermNodes()
+    {
+        return array();
+    }
+
+    public function __toString()
+    {
+        return sprintf('<raw:"%s">', $this->text);
+    }
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -5,7 +5,7 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Term;
 
-class TextNode extends AbstractTermNode
+class TextNode extends AbstractTermNode implements ContextAbleInterface
 {
     /**
      * Merge two text nodes by concatenating their content.

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/RecordIndexer.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/RecordIndexer.php
@@ -209,12 +209,14 @@ class RecordIndexer
         $mapping
             ->add('caption_all', 'string')
             ->addLocalizedSubfields($this->locales)
+            ->addRawVersion()
         ;
         $privateCaptionMapping = new Mapping();
         $mapping->add('private_caption', $privateCaptionMapping);
         $mapping
             ->add('private_caption_all', 'string')
             ->addLocalizedSubfields($this->locales)
+            ->addRawVersion()
         ;
         // Inferred thesaurus concepts
         $conceptPathMapping = new Mapping();

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Escaper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Escaper.php
@@ -16,4 +16,9 @@ class Escaper
 
         return $value;
     }
+
+    public function escapeRaw($value)
+    {
+        return preg_replace('/"|\\\\/u', '\\\\$0', $value);
+    }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
@@ -50,10 +50,9 @@ class FacetsResponse implements JsonSerializable
 
     private function buildQuery($name, $value)
     {
-        $value = $this->escaper->escapeWord($value);
         return ($name === 'Collection') ?
-            sprintf('collection:%s', $value) :
-            sprintf('%s IN %s', $value, $name);
+            sprintf('collection:%s', $this->escaper->escapeWord($value)) :
+            sprintf('r"%s" IN %s', $this->escaper->escapeRaw($value), $name);
     }
 
     private function throwAggregationResponseError()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/NodeTypes.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/NodeTypes.php
@@ -19,4 +19,5 @@ class NodeTypes
     // Token types for leaf nodes
     const TOKEN_WORD          = 'word';
     const TOKEN_QUOTED_STRING = 'quoted';
+    const TOKEN_RAW_STRING    = 'raw_quoted';
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
@@ -25,11 +25,24 @@ class QueryContext
             if (!$fields) {
                 throw new QueryException('Query narrowed to non available fields');
             }
-        } else {
-            $fields = null;
         }
 
         return new static($this->locales, $this->queryLocale, $fields);
+    }
+
+    public function getRawFields()
+    {
+        // TODO Private fields handling
+        if ($this->fields === null) {
+            return array('caption_all.raw');
+        }
+
+        $fields = array();
+        foreach ($this->fields as $field) {
+            $fields[] = sprintf('caption.%s.raw', $field);
+        }
+
+        return $fields;
     }
 
     public function getLocalizedFields()

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/EscaperTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/EscaperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Alchemy\Tests\Phrasea\SearchEngine;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\Search\Escaper;
+
+class EscaperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider escapeRawProvider
+     */
+    public function testEscapeRaw($unescaped, $escaped)
+    {
+        $escaper = new Escaper();
+        $this->assertEquals($escaped, $escaper->escapeRaw($unescaped));
+    }
+
+    public function escapeRawProvider()
+    {
+        return [
+            ['foo', 'foo'],
+            ['"', '\\"'],
+            ['\\', '\\\\'],
+            ['foo"bar\\baz', 'foo\"bar\\\\baz'],
+        ];
+    }
+}


### PR DESCRIPTION
Clicking on a facet value on the left pane now return the expected result count.

This commit implement a new "raw" matcher. It can be used like `r"some raw value"`. It operate on the the `.raw` multi-field and skips all analysis. Escaping `"` is supported by prepending a backslash `\"`. You can also escape the escaping character `\` by doubling it (`\\`).

Adds a new `ContextAbleInterface` to differenciate matcher supporting an optional context from those who can't.

Fixes an issue with `QueryContext::narrowToFields()` ignoring passed fields.