### PR TITLE
Strict facet matching (the return)

### DIFF
--- a/grammar/query.pp
+++ b/grammar/query.pp
@@ -12,7 +12,7 @@
 %token  string:quoted   [^"]+
 %token  string:_quote   "        -> default
 %token  raw_quote_      r"       -> raw
-%token  raw:raw_quoted  [^"\\]*(?:\\.[^"\\]*)+
+%token  raw:raw_quoted  (?:(?>[^"\\]+)|\\.)+
 %token  raw:_raw_quote  "        -> default
 
 // Operators


### PR DESCRIPTION
Followup of #1347 

Fix mandatory escaping sequence in raw expressions (used in facets queries)