### PR TITLE
List collection rights in /me

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -753,13 +753,12 @@ class V1Controller extends Controller
     {
         $acl = $this->getAclForUser($user);
         $rights = $acl->get_bas_rights();
-        /** @var \collection[] $bases */
         $bases = $acl->get_granted_base();
 
-        $grants = array();
+        $grants = [];
 
         foreach ($bases as $base) {
-            $baseGrants = array();
+            $baseGrants = [];
 
             foreach ($rights as $right) {
                 if (! $acl->has_right_on_base($base->get_coll_id(), $right)) {
@@ -769,12 +768,12 @@ class V1Controller extends Controller
                 $baseGrants[] = $right;
             }
 
-            $grants[] = array(
+            $grants[] = [
                 'databox_id' => $base->get_sbas_id(),
                 'base_id' => $base->get_base_id(),
                 'collection_id' => $base->get_coll_id(),
                 'rights' => $baseGrants
-            );
+            ];
         }
 
         return $grants;

--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -749,6 +749,37 @@ class V1Controller extends Controller
         ];
     }
 
+    private function listUserCollections(User $user)
+    {
+        $acl = $this->getAclForUser($user);
+        $rights = $acl->get_bas_rights();
+        /** @var \collection[] $bases */
+        $bases = $acl->get_granted_base();
+
+        $grants = array();
+
+        foreach ($bases as $base) {
+            $baseGrants = array();
+
+            foreach ($rights as $right) {
+                if (! $acl->has_right_on_base($base->get_coll_id(), $right)) {
+                    continue;
+                }
+
+                $baseGrants[] = $right;
+            }
+
+            $grants[] = array(
+                'databox_id' => $base->get_sbas_id(),
+                'base_id' => $base->get_base_id(),
+                'collection_id' => $base->get_coll_id(),
+                'rights' => $baseGrants
+            );
+        }
+
+        return $grants;
+    }
+
     public function addRecordAction(Request $request)
     {
         if (count($request->files->get('file')) == 0) {
@@ -2226,7 +2257,10 @@ class V1Controller extends Controller
 
     public function getCurrentUserAction(Request $request)
     {
-        $ret = ["user" => $this->listUser($this->getAuthenticatedUser())];
+        $ret = [
+            "user" => $this->listUser($this->getAuthenticatedUser()),
+            "collections" => $this->listUserCollections($this->getAuthenticatedUser())
+        ];
 
         return Result::create($request, $ret)->createResponse();
     }

--- a/lib/classes/ACL.php
+++ b/lib/classes/ACL.php
@@ -16,6 +16,17 @@ use Alchemy\Phrasea\Model\RecordInterface;
 
 class ACL implements cache_cacheableInterface
 {
+
+    protected static $bas_rights = [
+        'canputinalbum', 'candwnldhd',
+        'candwnldpreview', 'cancmd',
+        'canadmin', 'actif', 'canreport', 'canpush',
+        'canaddrecord', 'canmodifrecord', 'candeleterecord',
+        'chgstatus', 'imgtools',
+        'manage', 'modify_struct',
+        'nowatermark', 'order_master',
+    ];
+
     /**
      *
      * @var user
@@ -114,6 +125,16 @@ class ACL implements cache_cacheableInterface
         $this->app = $app;
 
         return $this;
+    }
+
+    /**
+     * Returns the list of available rights for collections
+     *
+     * @return string[]
+     */
+    public function get_bas_rights()
+    {
+        return self::$bas_rights;
     }
 
     /**
@@ -302,14 +323,7 @@ class ACL implements cache_cacheableInterface
             $this->update_rights_to_sbas($sbas_id, $rights);
         }
 
-        $bas_rights = ['canputinalbum', 'candwnldhd'
-            , 'candwnldpreview', 'cancmd'
-            , 'canadmin', 'actif', 'canreport', 'canpush'
-            , 'canaddrecord', 'canmodifrecord', 'candeleterecord'
-            , 'chgstatus', 'imgtools'
-            , 'manage', 'modify_struct'
-            , 'nowatermark', 'order_master'
-        ];
+        $bas_rights = self::$bas_rights;
 
         $bas_to_acces = $masks_to_give = $rights_to_give = [];
 

--- a/lib/classes/ACL.php
+++ b/lib/classes/ACL.php
@@ -18,13 +18,23 @@ class ACL implements cache_cacheableInterface
 {
 
     protected static $bas_rights = [
-        'canputinalbum', 'candwnldhd',
-        'candwnldpreview', 'cancmd',
-        'canadmin', 'actif', 'canreport', 'canpush',
-        'canaddrecord', 'canmodifrecord', 'candeleterecord',
-        'chgstatus', 'imgtools',
-        'manage', 'modify_struct',
-        'nowatermark', 'order_master',
+        'actif',
+        'canaddrecord',
+        'canadmin',
+        'cancmd',
+        'candeleterecord',
+        'candwnldhd',
+        'candwnldpreview',
+        'canmodifrecord',
+        'canpush',
+        'canputinalbum',
+        'canreport',
+        'chgstatus',
+        'imgtools',
+        'manage',
+        'modify_struct',
+        'nowatermark',
+        'order_master',
     ];
 
     /**
@@ -74,26 +84,26 @@ class ACL implements cache_cacheableInterface
      * @var Array
      */
     protected $_global_rights = [
-        'taskmanager'        => false,
-        'manageusers'        => false,
-        'order'              => false,
-        'report'             => false,
-        'push'               => false,
         'addrecord'          => false,
-        'modifyrecord'       => false,
-        'changestatus'       => false,
-        'doctools'           => false,
-        'deleterecord'       => false,
         'addtoalbum'         => false,
-        'coll_modify_struct' => false,
-        'coll_manage'        => false,
-        'order_master'       => false,
+        'bas_chupub'         => false,
+        'bas_manage'         => false,
         'bas_modif_th'       => false,
         'bas_modify_struct'  => false,
-        'bas_manage'         => false,
-        'bas_chupub'         => false,
+        'candwnldhd'         => true,
         'candwnldpreview'    => true,
-        'candwnldhd'         => true
+        'changestatus'       => false,
+        'coll_manage'        => false,
+        'coll_modify_struct' => false,
+        'deleterecord'       => false,
+        'doctools'           => false,
+        'manageusers'        => false,
+        'modifyrecord'       => false,
+        'order'              => false,
+        'order_master'       => false,
+        'push'               => false,
+        'report'             => false,
+        'taskmanager'        => false,
     ];
 
     /**
@@ -323,7 +333,7 @@ class ACL implements cache_cacheableInterface
             $this->update_rights_to_sbas($sbas_id, $rights);
         }
 
-        $bas_rights = self::$bas_rights;
+        $bas_rights = $this->get_bas_rights();
 
         $bas_to_acces = $masks_to_give = $rights_to_give = [];
 


### PR DESCRIPTION
Adds accessible collection info to /me route in API.

The available collections are listed as follows:

```
collections: [{
    databox_id: 1,
    base_id: 1,
    collection_id: 1,
    rights: [
        "actif"
    ]
}, {
    databox_id: 1,
    base_id: 2,
    collection_id: 2,
    rights: [
        "actif"
    ]
}]
```

