### PR TITLE
Empty indexer queues after flushing to index

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer.php
@@ -191,6 +191,9 @@ class Indexer
             $this->recordIndexer->delete($bulk, $this->deleteQueue);
             $bulk->flush();
         });
+
+        $this->indexQueue = new SplObjectStorage();
+        $this->deleteQueue = new SplObjectStorage();
     }
 
     private function apply(Closure $work)


### PR DESCRIPTION
I use here SplObjectStorage::removeAllExcept() with an empty one since I didn't
found a simpler one step solution.