### PR TITLE
Fix number field search

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
@@ -34,12 +34,12 @@ class RawNode extends Node
             foreach ($fields as $field) {
                 $index_fields[] = $field->getIndexField(true);
             }
-            $query = [];
+            $query = null;
             if (count($index_fields) > 1) {
                 $query['multi_match']['query'] = $this->text;
                 $query['multi_match']['fields'] = $index_fields;
                 $query['multi_match']['analyzer'] = 'keyword';
-            } else {
+            } elseif (count($index_fields) === 1) {
                 $index_field = reset($index_fields);
                 $query['term'][$index_field] = $this->text;
             }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
@@ -30,38 +30,30 @@ class RawNode extends Node
     public function buildQuery(QueryContext $context)
     {
         $query_builder = function (array $fields) {
+            $index_fields = [];
+            foreach ($fields as $field) {
+                $index_fields[] = $field->getIndexField(true);
+            }
             $query = [];
-            if (count($fields) > 1) {
+            if (count($index_fields) > 1) {
                 $query['multi_match']['query'] = $this->text;
-                $query['multi_match']['fields'] = $fields;
+                $query['multi_match']['fields'] = $index_fields;
                 $query['multi_match']['analyzer'] = 'keyword';
             } else {
-                $field = reset($fields);
-                $query['term'][$field] = $this->text;
+                $index_field = reset($index_fields);
+                $query['term'][$index_field] = $this->text;
             }
 
             return $query;
         };
 
-        $fields = $context->getRawFields();
-        $query = count($fields) ? $query_builder($fields) : null;
-
-        foreach (QueryHelper::buildPrivateFieldQueries($context, $query_builder, $this->getIndexFieldsCallback()) as $private_field_query) {
+        $query = $query_builder($context->getUnrestrictedFields());
+        $private_fields = $context->getPrivateFields();
+        foreach (QueryHelper::wrapPrivateFieldQueries($private_fields, $query_builder) as $private_field_query) {
             $query = QueryHelper::applyBooleanClause($query, 'should', $private_field_query);
         }
 
         return $query;
-    }
-
-    private function getIndexFieldsCallback()
-    {
-        if ($this->index_fields_callback === null) {
-            $this->index_fields_callback = function (StructureField $field) {
-                return $field->getIndexField(true);
-            };
-        }
-
-        return $this->index_fields_callback;
     }
 
     public function getTermNodes()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
@@ -9,8 +9,12 @@ class TermNode extends AbstractTermNode
 {
     public function buildQuery(QueryContext $context)
     {
-        $query = [];
-        $query['bool']['should'] = $this->buildConceptQueries($context);
+        $query = $this->buildConceptQuery($context);
+
+        // Should not match anything if no concept is defined
+        if ($query === null) {
+            $query['bool']['should'] = [];
+        }
 
         return $query;
     }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
@@ -3,6 +3,7 @@
 namespace Alchemy\Phrasea\SearchEngine\Elastic\Search;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Exception\QueryException;
+use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Field as ASTField;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Structure;
@@ -56,20 +57,6 @@ class QueryContext
         return $fields;
     }
 
-    public function getLocalizedFields()
-    {
-        if ($this->fields === null) {
-            return $this->localizeFieldName('caption_all');
-        }
-
-        $fields = array();
-        foreach ($this->getUnrestrictedFields() as $field) {
-            foreach ($this->localizeField($field) as $fields[]);
-        }
-
-        return $fields;
-    }
-
     public function getUnrestrictedFields()
     {
         // TODO Restore search optimization by using "caption_all" field
@@ -109,7 +96,12 @@ class QueryContext
      */
     public function localizeField(Field $field)
     {
-        return $this->localizeFieldName($field->getIndexField());
+        $index_field = $field->getIndexField();
+        if ($field->getType() === Mapping::TYPE_STRING) {
+            return $this->localizeFieldName($index_field);
+        } else {
+            return [$index_field];
+        }
     }
 
     private function localizeFieldName($field)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/TextQueryHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/TextQueryHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\Search;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
+
+class TextQueryHelper
+{
+    private function __construct() {}
+
+    public static function filterCompatibleFields(array $fields, $query_text)
+    {
+        $is_numeric = is_numeric($query_text);
+        $filtered = [];
+        foreach ($fields as $field) {
+            switch ($field->getType()) {
+                case Mapping::TYPE_FLOAT:
+                case Mapping::TYPE_DOUBLE:
+                case Mapping::TYPE_INTEGER:
+                case Mapping::TYPE_LONG:
+                case Mapping::TYPE_SHORT:
+                case Mapping::TYPE_BYTE:
+                    if ($is_numeric) {
+                        $filtered[] = $field;
+                    }
+                    break;
+                case Mapping::TYPE_STRING:
+                case Mapping::TYPE_DATE:
+                default:
+                    $filtered[] = $field;
+            }
+        }
+        return $filtered;
+    }
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Field.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Field.php
@@ -105,16 +105,6 @@ class Field
         );
     }
 
-    public static function toConceptPathIndexFieldArray(array $fields)
-    {
-        $index_fields = [];
-        foreach ($fields as $field) {
-            // TODO Skip fields without inference enabled?
-            $index_fields[] = $field->getConceptPathIndexField();
-        }
-        return $index_fields;
-    }
-
     public function getConceptPathIndexField()
     {
         return sprintf('concept_path.%s', $this->name);

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Field.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Field.php
@@ -101,7 +101,7 @@ class Field
             '%scaption.%s%s',
             $this->is_private ? 'private_' : '',
             $this->name,
-            $raw ? '.raw' : ''
+            $raw && $this->type === Mapping::TYPE_STRING ? '.raw' : ''
         );
     }
 

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/QuotedTextNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/QuotedTextNodeTest.php
@@ -23,9 +23,11 @@ class QuotedTextNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuild()
     {
+        $field = new Field('foo', Mapping::TYPE_STRING, ['private' => false]);
         $query_context = $this->prophesize(QueryContext::class);
-        $query_context->getLocalizedFields()->willReturn(['foo.fr', 'foo.en']);
+        $query_context->getUnrestrictedFields()->willReturn([$field]);
         $query_context->getPrivateFields()->willReturn([]);
+        $query_context->localizeField($field)->willReturn(['foo.fr', 'foo.en']);
 
         $node = new QuotedTextNode('bar');
         $query = $node->buildQuery($query_context->reveal());
@@ -51,10 +53,13 @@ class QuotedTextNodeTest extends \PHPUnit_Framework_TestCase
 
         $query_context = $this->prophesize(QueryContext::class);
         $query_context
+            ->getUnrestrictedFields()
+            ->willReturn([$public_field]);
+        $query_context
             ->getPrivateFields()
             ->willReturn([$private_field]);
         $query_context
-            ->getLocalizedFields()
+            ->localizeField($public_field)
             ->willReturn(['foo.fr', 'foo.en']);
         $query_context
             ->localizeField($private_field)

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/RawNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/RawNodeTest.php
@@ -20,4 +20,53 @@ class RawNodeTest extends \PHPUnit_Framework_TestCase
         $node = new RawNode('foo');
         $this->assertEquals('<raw:"foo">', (string) $node);
     }
+
+    public function testQueryBuildOnSingleField()
+    {
+        $field = $this->prophesize(Field::class);
+        $field->getIndexField(true)->willReturn('foo.raw');
+
+        $query_context = $this->prophesize(QueryContext::class);
+        $query_context->getUnrestrictedFields()->willReturn([$field->reveal()]);
+        $query_context->getPrivateFields()->willReturn([]);
+
+        $node = new RawNode('bar');
+        $query = $node->buildQuery($query_context->reveal());
+
+        $expected = '{
+            "term": {
+                "foo.raw": "bar"
+            }
+        }';
+
+        $this->assertEquals(json_decode($expected, true), $query);
+    }
+
+    public function testQueryBuildOnMultipleFields()
+    {
+        $field_a = $this->prophesize(Field::class);
+        $field_a->getIndexField(true)->willReturn('foo.raw');
+        $field_b = $this->prophesize(Field::class);
+        $field_b->getIndexField(true)->willReturn('bar.raw');
+
+        $query_context = $this->prophesize(QueryContext::class);
+        $query_context->getUnrestrictedFields()->willReturn([
+            $field_a->reveal(),
+            $field_b->reveal()
+        ]);
+        $query_context->getPrivateFields()->willReturn([]);
+
+        $node = new RawNode('baz');
+        $query = $node->buildQuery($query_context->reveal());
+
+        $expected = '{
+            "multi_match": {
+                "query": "baz",
+                "fields": ["foo.raw", "bar.raw"],
+                "analyzer": "keyword"
+            }
+        }';
+
+        $this->assertEquals(json_decode($expected, true), $query);
+    }
 }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TermNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TermNodeTest.php
@@ -35,9 +35,6 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
         $query_context
             ->getPrivateFields()
             ->willReturn([]);
-        $query_context
-            ->getLocalizedFields()
-            ->willReturn(['foo.fr', 'foo.en']);
 
         $node = new TermNode('bar');
         $node->setConcepts([
@@ -59,6 +56,29 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
                         "query": "/qux"
                     }
                 }]
+            }
+        }';
+
+        $this->assertEquals(json_decode($expected, true), $query);
+    }
+
+    public function testQueryBuildWithZeroConcept()
+    {
+        $field = new Field('foo', Mapping::TYPE_STRING, ['private' => false]);
+        $query_context = $this->prophesize(QueryContext::class);
+        $query_context
+            ->getUnrestrictedFields()
+            ->willReturn([$field]);
+        $query_context
+            ->getPrivateFields()
+            ->willReturn([]);
+
+        $node = new TermNode('bar');
+        $query = $node->buildQuery($query_context->reveal());
+
+        $expected = '{
+            "bool": {
+                "should": []
             }
         }';
 

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
@@ -42,9 +42,11 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuild()
     {
+        $field = new Field('foo', Mapping::TYPE_STRING, ['private' => false]);
         $query_context = $this->prophesize(QueryContext::class);
-        $query_context->getLocalizedFields()->willReturn(['foo.fr', 'foo.en']);
+        $query_context->getUnrestrictedFields()->willReturn([$field]);
         $query_context->getPrivateFields()->willReturn([]);
+        $query_context->localizeField($field)->willReturn(['foo.fr', 'foo.en']);
 
         $node = new TextNode('bar', new Context('baz'));
         $query = $node->buildQuery($query_context->reveal());
@@ -70,7 +72,10 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
         $query_context = $this->prophesize(QueryContext::class);
         $query_context
-            ->getLocalizedFields()
+            ->getUnrestrictedFields()
+            ->willReturn([$public_field]);
+        $query_context
+            ->localizeField($public_field)
             ->willReturn(['foo.fr', 'foo.en']);
         $query_context
             ->getPrivateFields()
@@ -115,15 +120,9 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
     {
         $field = new Field('foo', Mapping::TYPE_STRING, ['private' => false]);
         $query_context = $this->prophesize(QueryContext::class);
-        $query_context
-            ->getUnrestrictedFields()
-            ->willReturn([$field]);
-        $query_context
-            ->getPrivateFields()
-            ->willReturn([]);
-        $query_context
-            ->getLocalizedFields()
-            ->willReturn(['foo.fr', 'foo.en']);
+        $query_context->getUnrestrictedFields()->willReturn([$field]);
+        $query_context->getPrivateFields()->willReturn([]);
+        $query_context->localizeField($field)->willReturn(['foo.fr', 'foo.en']);
 
         $node = new TextNode('bar');
         $node->setConcepts([


### PR DESCRIPTION
Search with non numeric content will not hit number field (it breaks elasticsearch and is useless anyway)

- Rename QueryHelper::buildPrivateFieldQueries() to wrapPrivateFieldQuery().
    - Signature changed too, the third parameter is dropped an QueryContext is replaced by an array of Field.
    - Query builder closure is now passed an array of Field, not of index field names.
- Remove Field::toConceptPathIndexFieldArray() because method name was beyond understanding (and also because it wasn't needed anymore)
- Various AST node types have changed due to previous API changes
- Fix facets on non string fields (yeah, that was broken...)
- Fix raw query with "in" query (like those used in facets \o\)