### PR TITLE
Simpler facet handling in ES structure

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -411,9 +411,7 @@ class ElasticSearchEngine implements SearchEngineInterface
             // document that shouldn't be displayed can go this far.
             $agg = [];
             $agg['terms']['field'] = $field->getIndexField(true);
-            if(($size = $field->getFacetsSize()) !== null) {
-                $agg['terms']['size'] = $size;
-            }
+            $agg['terms']['size'] = $field->getFacetValuesLimit();
             $aggs[$name] = AggregationHelper::wrapPrivateFieldAggregation($field, $agg);
         }
 

--- a/lib/classes/databox/field.php
+++ b/lib/classes/databox/field.php
@@ -108,6 +108,9 @@ class databox_field implements cache_cacheableInterface
     const DCES_COVERAGE = 'Coverage';
     const DCES_RIGHTS = 'Rights';
 
+    const FACET_DISABLED = 0;
+    const FACET_NO_LIMIT = -1;
+
     /**
      * @param Application $app
      * @param databox     $databox
@@ -191,10 +194,16 @@ class databox_field implements cache_cacheableInterface
 
     public function isAggregable()
     {
-        return $this->aggregable != 0;
+        return $this->aggregable !== self::FACET_DISABLED;
     }
 
-    public function getAggregableSize()
+    /**
+     * A value of "0" means no facets (in that case, isAggregable() returns false too)
+     * "-1" means all facet values should be returned (no limit)
+     *
+     * @return integer Maximum expected number of values on this facet
+     */
+    public function getFacetValuesLimit()
     {
         return $this->aggregable;
     }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/FieldTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/FieldTest.php
@@ -79,8 +79,8 @@ class FieldTest extends \PHPUnit_Framework_TestCase
      */
     public function testMixedFacetEligibilityMerge()
     {
-        $field = new Field('foo', Mapping::TYPE_STRING, ['facet' => true]);
-        $other = new Field('foo', Mapping::TYPE_STRING, ['facet' => false]);
+        $field = new Field('foo', Mapping::TYPE_STRING, ['facet' => Field::FACET_NO_LIMIT]);
+        $other = new Field('foo', Mapping::TYPE_STRING, ['facet' => Field::FACET_DISABLED]);
         $field->mergeWith($other);
     }
 

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
@@ -94,8 +94,8 @@ class StructureTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFacetFields()
     {
-        $facet = new Field('foo', Mapping::TYPE_STRING, ['facet' => true]);
-        $not_facet = new Field('bar', Mapping::TYPE_STRING, ['facet' => false]);
+        $facet = new Field('foo', Mapping::TYPE_STRING, ['facet' => Field::FACET_NO_LIMIT]);
+        $not_facet = new Field('bar', Mapping::TYPE_STRING, ['facet' => Field::FACET_DISABLED]);
         $structure = new Structure();
         $structure->add($facet);
         $this->assertContains($facet, $structure->getFacetFields());


### PR DESCRIPTION
- Single property for facet settings in Field, we can’t have a limit
with disabled faceting.
- Fixes bug when fields having incompatible limit but are still merged together.
- Use constants for special limit values (i.e. no limit)