### PR TITLE
#PHRAS-669 #time 1d

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -134,6 +134,14 @@ class ElasticSearchEngine implements SearchEngineInterface
     /**
      * {@inheritdoc}
      */
+    public function getDefaultSortDirection()
+    {
+        return SearchEngineOptions::SORT_MODE_DESC;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isStemmingEnabled()
     {
         return false;

--- a/lib/Alchemy/Phrasea/SearchEngine/SearchEngineInterface.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/SearchEngineInterface.php
@@ -55,6 +55,11 @@ interface SearchEngineInterface
     public function getDefaultSort();
 
     /**
+     * @return string The default sort direction
+     */
+    public function getDefaultSortDirection();
+
+    /**
      * @return string The default sort
      */
     public function isStemmingEnabled();

--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -318,7 +318,7 @@
                                             </div>
                                             <div id="ADVSRCH_OPTIONS_ZONE">
                                                 <div id="ADVSRCH_SORT_ZONE">
-                                                    <span>{{ 'Trier par' | trans }} {{ app['phraseanet.SE'].getDefaultSort() }}</span>
+                                                    <span>{{ 'Trier par' | trans }}</span>
                                                     <select name="sort" class="input-medium">
                                                         {% set b = (app['phraseanet.SE'].getDefaultSort() == constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_CREATED_ON')) %}
                                                         <option value="{{ constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_CREATED_ON') }}" {% if b %}selected="selected" class="default-selection"{% endif %}>{{ "Date Added"|trans }}</option>

--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -318,22 +318,26 @@
                                             </div>
                                             <div id="ADVSRCH_OPTIONS_ZONE">
                                                 <div id="ADVSRCH_SORT_ZONE">
-                                                    <span>{{ 'Trier par' | trans }}</span>
+                                                    <span>{{ 'Trier par' | trans }} {{ app['phraseanet.SE'].getDefaultSort() }}</span>
                                                     <select name="sort" class="input-medium">
-                                                        <option value="{{ constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_CREATED_ON') }}" {% if app['phraseanet.SE'].getDefaultSort() is empty %}selected="selected default-selection"{% endif %}>{{ "Date Added"|trans }}</option>
-                                                        <option value="{{ constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_RELEVANCE') }}" {% if app['phraseanet.SE'].getDefaultSort() is empty %}selected="selected default-selection"{% endif %}>{{ "Relevance"|trans }}</option>
+                                                        {% set b = (app['phraseanet.SE'].getDefaultSort() == constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_CREATED_ON')) %}
+                                                        <option value="{{ constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_CREATED_ON') }}" {% if b %}selected="selected" class="default-selection"{% endif %}>{{ "Date Added"|trans }}</option>
+                                                        {% set b = (app['phraseanet.SE'].getDefaultSort() == constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_RELEVANCE')) %}
+                                                        <option value="{{ constant('\\Alchemy\\Phrasea\\SearchEngine\\SearchEngineOptions::SORT_RELEVANCE') }}" {% if b %}selected="selected" class="default-selection"{% endif %}>{{ "Relevance"|trans }}</option>
                                                         <optgroup label="{{ 'By field'|trans }}">
                                                         {% for fieldname, sort in search_datas['sort'] %}
+                                                            {% set b = (app['phraseanet.SE'].getDefaultSort() == fieldname) %}
                                                             <option value="{{ fieldname }}"
-                                                                    {% if fieldname == app['phraseanet.SE'].getDefaultSort() %}selected="selected"{% endif %}
-                                                                    class="{% if fieldname == app['phraseanet.SE'].getDefaultSort() %}default-selection {% endif %}dbx db_{{sort['sbas']|join(' db_')}}"
+                                                                    {% if b %}selected="selected"{% endif %}
+                                                                    class="{% if b %}default-selection {% endif %}dbx db_{{sort['sbas']|join(' db_')}}"
                                                                     >{{ fieldname }}</option>
                                                         {% endfor %}
                                                         </optgroup>
                                                     </select>
                                                     <select name="ord" class="input-medium">
                                                         {% for ord, ord_name in app['phraseanet.SE'].getAvailableOrder() %}
-                                                        <option value="{{ ord }}">{{ ord_name }}</option>
+                                                            {% set b = (app['phraseanet.SE'].getDefaultSortDirection() == ord) %}
+                                                            <option value="{{ ord }}" {% if b %}selected="selected" class="default-selection"{% endif %}>{{ ord_name }}</option>
                                                         {% endfor %}
                                                     </select>
                                                 </div>

--- a/www/skins/prod/jquery.main-prod.js
+++ b/www/skins/prod/jquery.main-prod.js
@@ -182,6 +182,7 @@ function checkFilters(save) {
     var adv_box = $('form.phrasea_query .adv_options');
     var container = $("#ADVSRCH_OPTIONS_ZONE");
     var fieldsSort = $('#ADVSRCH_SORT_ZONE select[name=sort]', container);
+    var fieldsSortOrd = $('#ADVSRCH_SORT_ZONE select[name=ord]', container);
     var fieldsSelect = $('#ADVSRCH_FIELDS_ZONE select', container);
     var dateFilterSelect = $('#ADVSRCH_DATE_ZONE select', container);
     var scroll = fieldsSelect.scrollTop();
@@ -258,9 +259,10 @@ function checkFilters(save) {
 
     // --------- sort  --------
 
-    // if no field is selected for sort, select the first option
-    if($("option.dbx:selected:enabled", fieldsSort).length == 0) {
-        $("option:eq(0)", fieldsSort).prop("selected", true);
+    // if no field is selected for sort, select the default option
+    if($("option:selected:enabled", fieldsSort).length == 0) {
+        $("option.default-selection", fieldsSort).prop("selected", true);
+        $("option.default-selection", fieldsSortOrd).prop("selected", true);
     }
 
     //--------- from fields filter ---------
@@ -392,9 +394,18 @@ function clearAnswers() {
 }
 
 function reset_adv_search() {
-    $('#ADVSRCH_OPTIONS_ZONE select[name="sort"]').val($('#ADVSRCH_OPTIONS_ZONE select[name="sort"] option.default-selection').attr('value'));
+    var container = $("#ADVSRCH_OPTIONS_ZONE");
+    var fieldsSort = $('#ADVSRCH_SORT_ZONE select[name=sort]', container);
+    var fieldsSortOrd = $('#ADVSRCH_SORT_ZONE select[name=ord]', container);
+    var dateFilterSelect = $('#ADVSRCH_DATE_ZONE select', container);
+
+    $("option.default-selection", fieldsSort).prop("selected", true);
+    $("option.default-selection", fieldsSortOrd).prop("selected", true);
+
     $('#ADVSRCH_FIELDS_ZONE option').removeAttr("selected");
     $('#ADVSRCH_OPTIONS_ZONE input:checkbox.field_switch').removeAttr('checked');
+
+    $("option:eq(0)", dateFilterSelect).prop("selected", true);
     $('#ADVSRCH_OPTIONS_ZONE .datepicker').val('');
     $('form.adv_search_bind input:text').val('');
     checkBases(true);


### PR DESCRIPTION
fix: the default sort field/direction (defined as relevance/desc for es) is applied at startup & reset button.
add : default direction
todo in 4.0.1 : allow to change in config/admin ?