### PR TITLE
Logging

### DIFF
--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -267,6 +267,7 @@ class Application extends SilexApplication
         $this['phraseanet.exception_handler'] = $this->share(function ($app) {
             $handler =  PhraseaExceptionHandler::register($app['debug']);
             $handler->setTranslator($app['translator']);
+            $handler->setLogger($app['monolog']);
 
             return $handler;
         });

--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -84,6 +84,7 @@ use MediaVorus\Media\MediaInterface;
 use MediaVorus\MediaVorus;
 use MediaVorus\MediaVorusServiceProvider;
 use Monolog\Handler\NullHandler;
+use Monolog\Handler\SyslogHandler;
 use Monolog\Logger;
 use Monolog\Processor\IntrospectionProcessor;
 use MP4Box\MP4BoxServiceProvider;
@@ -1051,13 +1052,8 @@ class Application extends SilexApplication
     {
         $this['monolog.name'] = 'phraseanet';
         $this['monolog.handler'] = $this->share(function () {
-            return new NullHandler();
+            return new SyslogHandler('phraseanet', LOG_SYSLOG, Logger::ERROR);
         });
-        $this['monolog'] = $this->share($this->extend('monolog', function (Logger $logger) {
-            $logger->pushProcessor(new IntrospectionProcessor());
-
-            return $logger;
-        }));
     }
 
     private function setupEventDispatcher()

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/ApiOauth2ErrorsSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/ApiOauth2ErrorsSubscriber.php
@@ -61,7 +61,7 @@ class ApiOauth2ErrorsSubscriber implements EventSubscriberInterface
             $msg = json_encode(['msg'  => $msg, 'code' => $code]);
             $event->setResponse(new Response($msg, $code, $headers));
         } else {
-            $response = $this->handler->createResponseBasedOnRequest($event->getRequest(), $event->getException());
+            $response = $this->handler->createResponse($event->getException());
             $response->headers->set('Content-Type', 'text/html');
             $event->setResponse($response);
         }

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/PhraseaExceptionHandlerSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/PhraseaExceptionHandlerSubscriber.php
@@ -38,7 +38,7 @@ class PhraseaExceptionHandlerSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->setResponse($this->handler->createResponseBasedOnRequest($event->getRequest(), $event->getException()));
+        $event->setResponse($this->handler->createResponse($event->getException()));
     }
 
     /**


### PR DESCRIPTION
Current version provides very little insight on errors happening in production, as all caught exceptions are inhibited by the exception handler.

This P/R aims to fix that by:

- Using a SyslogHandler with Monolog to push messages with a level of Error or more to syslog
- Log exceptions with a 500 status code as errors
- Remove introspection handler which adds little value to the logs and has a performance penalty