### PR TITLE
Fix undefined property error

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Provider/ManipulatorServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/ManipulatorServiceProvider.php
@@ -42,7 +42,12 @@ class ManipulatorServiceProvider implements ServiceProviderInterface
         });
 
         $app['manipulator.token'] = $app->share(function ($app) {
-            return new TokenManipulator($app['orm.em'], $app['random.medium'], $app['repo.tokens']);
+            return new TokenManipulator(
+                $app['orm.em'],
+                $app['random.medium'],
+                $app['repo.tokens'],
+                $app['tmp.download.path']
+            );
         });
 
         $app['manipulator.preset'] = $app->share(function ($app) {

--- a/lib/Alchemy/Phrasea/Model/Manipulator/TokenManipulator.php
+++ b/lib/Alchemy/Phrasea/Model/Manipulator/TokenManipulator.php
@@ -39,11 +39,18 @@ class TokenManipulator implements ManipulatorInterface
     private $random;
     private $repository;
 
-    public function __construct(ObjectManager $om, Generator $random, TokenRepository $repository)
+    private $temporaryDownloadPath;
+
+    public function __construct(
+        ObjectManager $om,
+        Generator $random,
+        TokenRepository $repository,
+        $temporaryDownloadPath)
     {
         $this->om = $om;
         $this->random = $random;
         $this->repository = $repository;
+        $this->temporaryDownloadPath = $temporaryDownloadPath;
     }
 
     /**
@@ -205,7 +212,7 @@ class TokenManipulator implements ManipulatorInterface
             switch ($token->getType()) {
                 case 'download':
                 case 'email':
-                    $file = $this->app['tmp.download.path'].'/' . $token->getValue() . '.zip';
+                    $file = $this->temporaryDownloadPath . '/' . $token->getValue() . '.zip';
                     if (is_file($file)) {
                         unlink($file);
                     }

--- a/tests/Alchemy/Tests/Phrasea/Model/Manipulator/TokenManipulatorTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Model/Manipulator/TokenManipulatorTest.php
@@ -18,7 +18,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
     {
         $user = $user ? self::$DI['user'] : null;
 
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->create($user, $type, $expiration, $data);
 
         $this->assertSame($user, $token->getUser());
@@ -41,7 +41,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateBasketValidationToken()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createBasketValidationToken(self::$DI['basket_4'], self::$DI['user_1']);
 
         $this->assertSame(self::$DI['basket_4']->getId(), $token->getData());
@@ -52,7 +52,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateBasketValidationTokenWithoutUser()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createBasketValidationToken(self::$DI['basket_4']);
 
         $this->assertSame(self::$DI['basket_4']->getId(), $token->getData());
@@ -63,14 +63,14 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateBasketValidationTokenWithInvalidBasket()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $this->setExpectedException('InvalidArgumentException', 'A validation token requires a validation basket.');
         $manipulator->createBasketValidationToken(self::$DI['basket_1']);
     }
 
     public function testCreateBasketAccessToken()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createBasketAccessToken(self::$DI['basket_4'], self::$DI['user']);
 
         $this->assertSame(self::$DI['basket_4']->getId(), $token->getData());
@@ -81,7 +81,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateFeedEntryToken()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createFeedEntryToken(self::$DI['user'], self::$DI['feed_public_entry']);
 
         $this->assertSame(self::$DI['feed_public_entry']->getId(), $token->getData());
@@ -93,7 +93,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
     public function testCreateDownloadToken()
     {
         $data = serialize(['some' => 'data']);
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createDownloadToken(self::$DI['user'], $data);
 
         $this->assertSame($data, $token->getData());
@@ -105,7 +105,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
     public function testCreateEmailExportToken()
     {
         $data = serialize(['some' => 'data']);
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createEmailExportToken($data);
 
         $this->assertSame($data, $token->getData());
@@ -116,7 +116,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateResetEmailToken()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createResetEmailToken(self::$DI['user'], 'newemail@phraseanet.com');
 
         $this->assertSame('newemail@phraseanet.com', $token->getData());
@@ -127,7 +127,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateAccountUnlockToken()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createAccountUnlockToken(self::$DI['user']);
 
         $this->assertNull($token->getData());
@@ -138,7 +138,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
 
     public function testCreateResetPasswordToken()
     {
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $token = $manipulator->createResetPasswordToken(self::$DI['user']);
 
         $this->assertNull($token->getData());
@@ -158,7 +158,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
         $em->expects($this->once())
             ->method('flush');
 
-        $manipulator = new TokenManipulator($em, self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator($em, self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $manipulator->update($token);
     }
 
@@ -173,7 +173,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
         $em->expects($this->once())
             ->method('flush');
 
-        $manipulator = new TokenManipulator($em, self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator($em, self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path']);
         $manipulator->delete($token);
     }
 
@@ -181,7 +181,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
     {
         $this->assertCount(4, self::$DI['app']['repo.tokens']->findAll());
 
-        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens']);
+        $manipulator = new TokenManipulator(self::$DI['app']['orm.em'], self::$DI['app']['random.low'], self::$DI['app']['repo.tokens'], self::$DI['app']['tmp.download.path'], self::$DI['app']['tmp.download.path']);
         $manipulator->removeExpiredTokens();
 
         $this->assertCount(3, self::$DI['app']['repo.tokens']->findAll());


### PR DESCRIPTION
When there are expired tokens in the database, the app crashes due to an undefined property error ($app in TokenManipulator) introduced a while ago.