### PR TITLE
Avoid many calls to cache layer

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Provider/ConfigurationServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/ConfigurationServiceProvider.php
@@ -69,7 +69,7 @@ class ConfigurationServiceProvider implements ServiceProviderInterface
         });
 
         $app['conf.restrictions'] = $app->share(function (SilexApplication $app) {
-            return new AccessRestriction($app['cache'], $app['conf'], $app->getApplicationBox(), $app['monolog']);
+            return new AccessRestriction($app['conf'], $app->getApplicationBox(), $app['monolog']);
         });
     }
 

--- a/lib/classes/ACL.php
+++ b/lib/classes/ACL.php
@@ -730,11 +730,7 @@ class ACL implements cache_cacheableInterface
                     continue;
                 }
 
-                try {
-                    $ret[$base_id] = collection::getByBaseId($this->app, $base_id);
-                } catch (\Exception $e) {
-
-                }
+                $ret[$base_id] = $collection;
             }
         }
 

--- a/lib/classes/appbox.php
+++ b/lib/classes/appbox.php
@@ -335,7 +335,7 @@ class appbox extends base
     /**
      * @return AccessRestriction
      */
-    private function getAccessRestriction()
+    public function getAccessRestriction()
     {
         return $this->app['conf.restrictions'];
     }

--- a/tests/Alchemy/Tests/Phrasea/Core/Configuration/AccessRestrictionTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Core/Configuration/AccessRestrictionTest.php
@@ -21,7 +21,7 @@ class AccessRestrictionTest extends \PhraseanetTestCase
         $conf = new MockArrayConf($conf);
         $logger = $this->createLoggerMock();
 
-        $restriction = new AccessRestriction(new ArrayCache(), new PropertyAccess($conf), self::$DI['app']['phraseanet.appbox'], $logger);
+        $restriction = new AccessRestriction(new PropertyAccess($conf), self::$DI['app']['phraseanet.appbox'], $logger);
         $this->assertEquals($restricted, $restriction->isRestricted());
 
         foreach ($collAccess as $coll) {


### PR DESCRIPTION
Getting collection calls access_restriction which is not properly cached.

Remove use of cache in AccessRestriction and use instance memory cache instead.
Beware static keyword declares variable static for the class, not the instance