### PR TITLE
Register checkers with similar type

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Entities/LazaretCheck.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/LazaretCheck.php
@@ -1,9 +1,8 @@
 <?php
-
-/*
+/**
  * This file is part of Phraseanet
  *
- * (c) 2005-2014 Alchemy
+ * (c) 2005-2016 Alchemy
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,7 +11,6 @@
 namespace Alchemy\Phrasea\Model\Entities;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @ORM\Table(name="LazaretChecks")

--- a/lib/classes/eventsmanager/notify/uploadquarantine.php
+++ b/lib/classes/eventsmanager/notify/uploadquarantine.php
@@ -16,7 +16,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 class eventsmanager_notify_uploadquarantine extends eventsmanager_notifyAbstract
 {
     /**
-     *
      * @return string
      */
     public function icon_url()
@@ -25,10 +24,9 @@ class eventsmanager_notify_uploadquarantine extends eventsmanager_notifyAbstract
     }
 
     /**
-     *
-     * @param  Array   $datas
-     * @param  boolean $unread
-     * @return Array
+     * @param array $data
+     * @param bool $unread
+     * @return array
      */
     public function datas(array $data, $unread)
     {
@@ -55,7 +53,6 @@ class eventsmanager_notify_uploadquarantine extends eventsmanager_notifyAbstract
     }
 
     /**
-     *
      * @return string
      */
     public function get_name()
@@ -64,7 +61,6 @@ class eventsmanager_notify_uploadquarantine extends eventsmanager_notifyAbstract
     }
 
     /**
-     *
      * @return string
      */
     public function get_description()


### PR DESCRIPTION
There are currently no ways to register 2 checkers of same type but applying them to a different set of collections/base. This remove the registering by checker type

PHRAS-957
