### PR TITLE
Remove "install" tests from Travis suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: require
 env:
   - SETUP_MODE=update TEST_SUITE=1
   - SETUP_MODE=update TEST_SUITE=2
-  - SETUP_MODE=install TEST_SUITE=1
-  - SETUP_MODE=install TEST_SUITE=2
 
 php:
   - 5.5


### PR DESCRIPTION
They are already run on CircleCI, so running them on Travis is redundant. This should also help reducing build times, and freeing up the queue faster for other builds.