### PR TITLE
Add story cover event

### DIFF
--- a/lib/Alchemy/Phrasea/Core/PhraseaEvents.php
+++ b/lib/Alchemy/Phrasea/Core/PhraseaEvents.php
@@ -26,6 +26,7 @@ final class PhraseaEvents
 
     const RECORD_EDIT = 'record.edit';
     const RECORD_UPLOAD = 'record.upload';
+    const STATUS_CHANGED = 'record.status.changed';
 
     const ACCOUNT_DELETED = 'account.deleted';
     const ACCOUNT_CREATED = 'account.created';

--- a/lib/Alchemy/Phrasea/Core/PhraseaEvents.php
+++ b/lib/Alchemy/Phrasea/Core/PhraseaEvents.php
@@ -27,6 +27,7 @@ final class PhraseaEvents
     const RECORD_EDIT = 'record.edit';
     const RECORD_UPLOAD = 'record.upload';
     const STATUS_CHANGED = 'record.status.changed';
+    const STORY_COVER_CHANGED = 'record.story_cover.changed';
 
     const ACCOUNT_DELETED = 'account.deleted';
     const ACCOUNT_CREATED = 'account.created';

--- a/lib/Alchemy/Phrasea/SearchEngine/Phrasea/PhraseaEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Phrasea/PhraseaEngine.php
@@ -293,7 +293,8 @@ class PhraseaEngine implements SearchEngineInterface
      */
     public function updateRecord(\record_adapter $record)
     {
-        $record->set_binary_status(\databox_status::dec2bin($this->app, bindec($record->get_status()) & ~7 | 4));
+        // change the "toindex" status but don't send the STATUS_CHANGED event
+        $record->set_binary_status(\databox_status::dec2bin($this->app, bindec($record->get_status()) & ~7 | 4), false);
 
         return $this;
     }

--- a/lib/classes/media/subdef.php
+++ b/lib/classes/media/subdef.php
@@ -271,6 +271,35 @@ class media_subdef extends media_abstract implements cache_cacheableInterface
     }
 
     /**
+     * delete a subdef
+     * useful to restore a story as a blue folder icon
+     *
+     * @return $this
+     */
+    public function delete()
+    {
+        $this->remove_file();
+
+        $connbas = $this->record->get_databox()->get_connection();
+
+        $sql = 'DELETE FROM subdef
+                WHERE name = :name AND record_id = :record_id';
+
+        $params = array(
+            ':record_id' => $this->record->get_record_id(),
+            ':name'      => $this->name
+        );
+
+        $stmt = $connbas->prepare($sql);
+        $stmt->execute($params);
+        $stmt->closeCursor();
+
+        $this->delete_data_from_cache();
+
+        return $this;
+    }
+
+    /**
      * Find a substitution file for a sibdef
      *
      * @return \media_subdef


### PR DESCRIPTION
#PHRAS-1008
-add : new event "StoryCoverChanged"
-fix : one "record edit" event when cover is changed (no more one event for both thumbnail and preview substitution)
-add : method to delete the cover of a story (goes back to "blue folder")
-add : "oldstatus" to StatusChanged event so client can detect what sb was modified.
