### PR TITLE
EmptyCollectionJob should accept bas_id setting.

### DIFF
--- a/lib/Alchemy/Phrasea/TaskManager/Job/EmptyCollectionJob.php
+++ b/lib/Alchemy/Phrasea/TaskManager/Job/EmptyCollectionJob.php
@@ -1,9 +1,9 @@
 <?php
 
-/*
+/**
  * This file is part of Phraseanet
  *
- * (c) 2005-2014 Alchemy
+ * (c) 2005-2016 Alchemy
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -59,7 +59,7 @@ class EmptyCollectionJob extends AbstractJob
 
         $settings = simplexml_load_string($task->getSettings());
 
-        $baseId = (string) $settings->base_id;
+        $baseId = (string) $settings->bas_id;
 
         $collection = \collection::getByBaseId($app, $baseId);
         $collection->empty_collection(200);

--- a/tests/Alchemy/Tests/Phrasea/TaskManager/Job/EmptyCollectionJobTest.php
+++ b/tests/Alchemy/Tests/Phrasea/TaskManager/Job/EmptyCollectionJobTest.php
@@ -2,16 +2,33 @@
 
 namespace Alchemy\Tests\Phrasea\TaskManager\Job;
 
+use Alchemy\Phrasea\Application;
+use Alchemy\Phrasea\TaskManager\Job\AbstractJob;
 use Alchemy\Phrasea\TaskManager\Job\EmptyCollectionJob;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Translation\TranslatorInterface;
 
-/**
- * @group functional
- * @group legacy
- */
-class EmptyCollectionJobTest extends JobTestCase
+class EmptyCollectionJobTest extends \PHPUnit_Framework_TestCase
 {
-    protected function getJob()
+    /**
+     * @var ObjectProphecy
+     */
+    private $translator;
+
+    /**
+     * @var EmptyCollectionJob
+     */
+    private $sut;
+
+    protected function setUp()
     {
-        return new EmptyCollectionJob($this->createTranslatorMock());
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+
+        $this->sut = new EmptyCollectionJob($this->translator->reveal());
+    }
+
+    public function testItExtendsAbstractJob()
+    {
+        $this->assertInstanceOf(AbstractJob::class, $this->sut);
     }
 }


### PR DESCRIPTION
Could not refactor the job as there are static calls preventing mocks.