### PR TITLE
PHRAS-1060_CSS-IE9

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/ContentNegotiationSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/ContentNegotiationSubscriber.php
@@ -38,7 +38,7 @@ class ContentNegotiationSubscriber implements EventSubscriberInterface
 
     public function onKernelRequest(GetResponseEvent $event)
     {
-        $priorities = array('text/html', 'application/vnd.phraseanet.record-extended+json', 'application/json');
+        $priorities = array('text/html', 'application/vnd.phraseanet.record-extended+json', 'application/json', 'text/css');
         $format = $this->app['negotiator']->getBest($event->getRequest()->headers->get('accept', '*/*'), $priorities);
 
         if (null === $format) {


### PR DESCRIPTION
PHRAS-1060 #time 20m
### Fixes
-fix : no more error 406 when ie9 downloads css with header Accept=text/css
