### PR TITLE
Fix event processor memory usage

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Repositories/WebhookEventRepository.php
+++ b/lib/Alchemy/Phrasea/Model/Repositories/WebhookEventRepository.php
@@ -21,6 +21,9 @@ use Doctrine\ORM\EntityRepository;
  */
 class WebhookEventRepository extends EntityRepository
 {
+    /**
+     * @deprecated This method can overflow available memory when there is a large number of unprocessed events
+     */
     public function findUnprocessedEvents()
     {
         $qb = $this->createQueryBuilder('e');
@@ -28,5 +31,13 @@ class WebhookEventRepository extends EntityRepository
         $qb->where($qb->expr()->eq('e.processed', $qb->expr()->literal(false)));
 
         return $qb->getQuery()->getResult();
+    }
+
+    public function getUnprocessedEventIterator()
+    {
+        $queryBuilder = $this->createQueryBuilder('e')
+            ->where('e.processed = 0');
+
+        return $queryBuilder->getQuery()->iterate();
     }
 }

--- a/lib/Alchemy/Phrasea/TaskManager/Job/WebhookJob.php
+++ b/lib/Alchemy/Phrasea/TaskManager/Job/WebhookJob.php
@@ -102,6 +102,7 @@ class WebhookJob extends AbstractJob
                     $retry = true;
                     if ($response && (null !== $deliverId = parse_url($request->getUrl(), PHP_URL_FRAGMENT))) {
                         $delivery = $app['repo.webhook-delivery']->find($deliverId);
+
                         if ($response->isSuccessful()) {
                             $app['manipulator.webhook-delivery']->deliverySuccess($delivery);
 
@@ -114,17 +115,15 @@ class WebhookJob extends AbstractJob
                         }
 
                         return $retry;
-                    }},
-                    true,
-                    new CurlBackoffStrategy()
-                )
+                    }
+                }, true, new CurlBackoffStrategy())
             )
         ));
 
         /** @var EventProcessorFactory $eventFactory */
         $eventFactory = $app['webhook.processor_factory'];
 
-        foreach ($app['repo.webhook-event']->findUnprocessedEvents() as $event) {
+        foreach ($app['repo.webhook-event']->getUnprocessedEventIterator() as $event) {
             // set event as processed
             $app['manipulator.webhook-event']->processed($event);
 


### PR DESCRIPTION
## Changelog
### Changed
  - Deprecated `WebhookEventRepository::findUnprocessedEvents()`
  
### Fixes
  - Prevents loading all unprocessed rows at once in the webhook job