### PR TITLE
Remove record ids in stories elements search API

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -1275,7 +1275,7 @@ class V1Controller extends Controller
                 'dc:title'       => $format($caption, \databox_Field_DCESAbstract::Title),
                 'dc:type'        => $format($caption, \databox_Field_DCESAbstract::Type),
             ],
-            'records'       => $this->listRecords($request, $story->getChildren()->get_elements()),
+            'records'       => $this->listRecords($request, array_values($story->getChildren()->get_elements())),
         ];
     }
 


### PR DESCRIPTION
## Changelog
### Fixes
  - PHRAS-1085: only take array_values when serializing element collection
