### PR TITLE
PHRAS-1091 Pass view instead of order to transformer

### DIFF
--- a/lib/Alchemy/Phrasea/Order/Controller/ApiOrderController.php
+++ b/lib/Alchemy/Phrasea/Order/Controller/ApiOrderController.php
@@ -66,7 +66,8 @@ class ApiOrderController extends BaseOrderController
 
         $this->dispatch(PhraseaEvents::ORDER_CREATE, new OrderEvent($order));
 
-        $resource = new Item($order, $this->getOrderTransformer());
+        $view = $this->getViewBuilder()->buildView($order, []);
+        $resource = new Item($view, $this->getOrderTransformer());
 
         return $this->returnResourceResponse($request, ['elements'], $resource);
     }


### PR DESCRIPTION
## Changelog
### Fixes
  - PHRAS-1091: Orders were created correctly but the API crashed when rendering the response due to the use of the order itself instead of the view