### PR TITLE
spelling error in Configuration.php

### DIFF
--- a/lib/Alchemy/Phrasea/Command/Compile/Configuration.php
+++ b/lib/Alchemy/Phrasea/Command/Compile/Configuration.php
@@ -26,7 +26,7 @@ class Configuration extends Command
     protected function doExecute(InputInterface $input, OutputInterface $output)
     {
         $this->container['configuration.store']->compileAndWrite();
-        $output->writeln("Confguration compiled.");
+        $output->writeln("Configuration compiled.");
 
         return 0;
     }


### PR DESCRIPTION
## Changelog
### Fixes
  - Fixes spelling error in compile configuration command


