### PR TITLE
Fix mail notification for order managers

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/OrderSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/OrderSubscriber.php
@@ -14,6 +14,7 @@ namespace Alchemy\Phrasea\Core\Event\Subscriber;
 use Alchemy\Phrasea\Core\Event\OrderDeliveryEvent;
 use Alchemy\Phrasea\Core\Event\OrderEvent;
 use Alchemy\Phrasea\Core\PhraseaEvents;
+use Alchemy\Phrasea\Model\Entities\Order;
 use Alchemy\Phrasea\Model\Entities\OrderElement;
 use Alchemy\Phrasea\Model\Entities\User;
 use Alchemy\Phrasea\Notification\Emitter;
@@ -21,6 +22,7 @@ use Alchemy\Phrasea\Notification\Mail\MailInfoNewOrder;
 use Alchemy\Phrasea\Notification\Mail\MailInfoOrderCancelled;
 use Alchemy\Phrasea\Notification\Mail\MailInfoOrderDelivered;
 use Alchemy\Phrasea\Notification\Receiver;
+use Alchemy\Phrasea\Order\ValidationNotifier\CompositeNotifier;
 use Alchemy\Phrasea\Order\ValidationNotifierRegistry;
 
 class OrderSubscriber extends AbstractNotificationSubscriber
@@ -59,6 +61,13 @@ class OrderSubscriber extends AbstractNotificationSubscriber
             'usr_id'   => $event->getOrder()->getUser()->getId(),
             'order_id' => $event->getOrder()->getId(),
         ]);
+
+        if ($event->getOrder()->getNotificationMethod() !== Order::NOTIFY_MAIL) {
+            $notifier = new CompositeNotifier([
+                $this->notifierRegistry->getNotifier(Order::NOTIFY_MAIL),
+                $notifier
+            ]);
+        }
 
         foreach ($users as $user) {
             $notified = false;

--- a/lib/Alchemy/Phrasea/Order/ValidationNotifier/CompositeNotifier.php
+++ b/lib/Alchemy/Phrasea/Order/ValidationNotifier/CompositeNotifier.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Alchemy\Phrasea\Order\ValidationNotifier;
+
+use Alchemy\Phrasea\Model\Entities\Order;
+use Alchemy\Phrasea\Model\Entities\User;
+use Alchemy\Phrasea\Order\OrderDelivery;
+use Alchemy\Phrasea\Order\ValidationNotifier;
+use Assert\Assertion;
+
+class CompositeNotifier implements ValidationNotifier
+{
+
+    /**
+     * @var ValidationNotifier[]
+     */
+    private $notifiers = [];
+
+    public function __construct(array $notifiers)
+    {
+        Assertion::allIsInstanceOf($notifiers, ValidationNotifier::class);
+
+        $this->notifiers = $notifiers;
+    }
+
+    /**
+     * @param Order $order
+     * @param User $recipient
+     */
+    public function notifyCreation(Order $order, User $recipient)
+    {
+        foreach ($this->notifiers as $notifier) {
+            $notifier->notifyCreation($order, $recipient);
+        }
+    }
+
+    /**
+     * @param OrderDelivery $delivery
+     */
+    public function notifyDelivery(OrderDelivery $delivery)
+    {
+        foreach ($this->notifiers as $notifier) {
+            $notifier->notifyDelivery($delivery);
+        }
+    }
+
+    /**
+     * @param OrderDelivery $delivery
+     */
+    public function notifyDenial(OrderDelivery $delivery)
+    {
+        foreach ($this->notifiers as $notifier) {
+            $notifier->notifyDenial($delivery);
+        }
+    }
+}


### PR DESCRIPTION
## Changelog
### Fixes
  - Order managers are not notified when orders are created via the API