### PR TITLE
Slash in permalink labels

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/PermalinkController.php
+++ b/lib/Alchemy/Phrasea/Controller/PermalinkController.php
@@ -87,7 +87,7 @@ class PermalinkController extends AbstractDelivery
                 'sbas_id'   => $sbas_id,
                 'record_id' => $record_id,
                 'subdef'    => $subdefName,
-                'label'     => $record->get_title(),
+                'label'     => str_replace('/', '_', $record->get_title()),
                 'token'     => $token,
             ]
         );

--- a/lib/classes/media/Permalink/Adapter.php
+++ b/lib/classes/media/Permalink/Adapter.php
@@ -118,7 +118,7 @@ class media_Permalink_Adapter implements cache_cacheableInterface
             'record_id' => $this->media_subdef->get_record_id(),
             'subdef' => $this->media_subdef->get_name(),
             /** @Ignore */
-            'label' => $label,
+            'label' => str_replace('/', '_', $label),
             'token' => $this->get_token(),
         ]));
     }


### PR DESCRIPTION
## Changelog
### Fixes
  - PHRAS-1079: replace slashes in labels of permalinks by underscores
