### PR TITLE
Fix archive path when downloading orders via API

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Prod/DoDownloadController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/DoDownloadController.php
@@ -162,7 +162,7 @@ class DoDownloadController extends Controller
                 $this->app,
                 $token,
                 $list,
-                sprintf($this->app['tmp.download.path'].'/%s.zip', $token->getValue()) // Dest file
+                sprintf('%s/%s.zip', $this->app['tmp.download.path'], $token->getValue()) // Dest file
             );
         } else {
             $list['complete'] = true;

--- a/lib/Alchemy/Phrasea/Databox/DataboxRepository.php
+++ b/lib/Alchemy/Phrasea/Databox/DataboxRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Phraseanet
  *
@@ -7,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Alchemy\Phrasea\Databox;
 
 interface DataboxRepository

--- a/lib/Alchemy/Phrasea/Order/Controller/ApiOrderController.php
+++ b/lib/Alchemy/Phrasea/Order/Controller/ApiOrderController.php
@@ -177,7 +177,7 @@ class ApiOrderController extends BaseOrderController
             PhraseaEvents::EXPORT_CREATE,
             new ExportEvent($user, $basket->getId(), implode(';', $lst), $subdefs, $exportName)
         );
-        
+
         set_time_limit(0);
         ignore_user_abort(true);
         $file = \set_export::build_zip($this->app, $token, $exportData, $exportName);
@@ -335,7 +335,7 @@ class ApiOrderController extends BaseOrderController
         $subdefNames = [
             'document' => true,
         ];
-        $this->getApplicationBox()->get_collection($file['base_id'])->get_databox()->get_sbas_id();
+        
         foreach ($this->getApplicationBox()->get_databoxes() as $databox) {
             foreach ($databox->get_subdef_structure() as $subdefGroup) {
                 /** @var \databox_subdef $subdef */


### PR DESCRIPTION
## Changelog
### Fixes
  - Archives for orders were generated using a relative path which prevented them from being downloaded via the API