### PR TITLE
Add configuration option to disable SSL requirement on API

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -6,6 +6,7 @@ main:
     maintenance: false
     languages: []
     key: ''
+    api_require_ssl: true
     database:
         host: 127.0.0.1
         port: 3306

--- a/lib/Alchemy/Phrasea/Controller/Api/OAuth2Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/OAuth2Controller.php
@@ -16,6 +16,7 @@ use Alchemy\Phrasea\Authentication\Exception\AccountLockedException;
 use Alchemy\Phrasea\Authentication\Exception\RequireCaptchaException;
 use Alchemy\Phrasea\Authentication\Phrasea\PasswordAuthenticationInterface;
 use Alchemy\Phrasea\Controller\Controller;
+use Alchemy\Phrasea\Core\Configuration\PropertyAccess;
 use Alchemy\Phrasea\Core\Event\PostAuthenticate;
 use Alchemy\Phrasea\Core\Event\PreAuthenticate;
 use Alchemy\Phrasea\Core\PhraseaEvents;
@@ -174,8 +175,11 @@ class OAuth2Controller extends Controller
      */
     public function tokenAction(Request $request)
     {
-        if ( ! $request->isSecure()) {
-            throw new HttpException(400, 'This route requires the use of the https scheme', null, ['content-type' => 'application/json']);
+        /** @var PropertyAccess $config */
+        $config = $this->app['conf'];
+
+        if ( ! $request->isSecure() && $config->get(['main', 'api_require_ssl'], true) == true) {
+            throw new HttpException(400, 'This route requires the use of the https scheme: ' . $config->get(['main', 'api_require_ssl']), null, ['content-type' => 'application/json']);
         }
 
         $this->oAuth2Adapter->grantAccessToken($request);

--- a/lib/conf.d/configuration.yml
+++ b/lib/conf.d/configuration.yml
@@ -5,6 +5,7 @@ languages:
 main:
     maintenance: false
     key: ''
+    api_require_ssl: true
     database:
         host: 'sql-host'
         port: 3306

--- a/resources/vagrant/config/phraseanet/configuration.yml
+++ b/resources/vagrant/config/phraseanet/configuration.yml
@@ -5,6 +5,7 @@ languages:
 main:
     maintenance: false
     key: ''
+    api_require_ssl: true
     database:
         host: 'sql-host'
         port: 3306


### PR DESCRIPTION
## Changelog
### Adds
  - Configuration key "api_require_ssl" can be set to false in "main" section of configuration.yml to disable the SSL requirement on the API auth routes. This setting should only be used for development purposes.

