### PR TITLE
PHRAS-1180 Add configuration entry to enable CORS on custom paths

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -191,6 +191,7 @@ api_cors:
   expose_headers: []
   max_age: 0
   hosts: []
+api_cors_paths: []
 session:
   idle: 0
   lifetime: 604800 # 1 week

--- a/lib/Alchemy/Phrasea/Core/MetaProvider/HttpStackMetaProvider.php
+++ b/lib/Alchemy/Phrasea/Core/MetaProvider/HttpStackMetaProvider.php
@@ -93,6 +93,11 @@ class HttpStackMetaProvider implements ServiceProviderInterface
                     $paths['/api/v\d+/'] = $config;
                     $paths['/download/'] = $config;
                 }
+                if (isset($app['phraseanet.configuration']['api_cors_paths'])) {
+                    foreach ($app['phraseanet.configuration']['api_cors_paths'] as $path) {
+                        $paths[$path] = $config;
+                    }
+                }
             }
 
             return new DefaultProvider($paths, []);


### PR DESCRIPTION
## Changelog
### Adds
  - PHRAS-1180: It's now possible to enable CORS on custom paths via the "api_cors_paths" configuration node.


