### PR TITLE
PHRAS-1192 quarantaine by filenames

### DIFF
--- a/lib/Alchemy/Phrasea/Border/Checker/Filename.php
+++ b/lib/Alchemy/Phrasea/Border/Checker/Filename.php
@@ -13,6 +13,7 @@ namespace Alchemy\Phrasea\Border\Checker;
 
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Border\File;
+use Alchemy\Phrasea\Model\Entities\LazaretFile;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -49,6 +50,25 @@ class Filename extends AbstractChecker
         ));
 
         return new Response($boolean, $this);
+    }
+
+    /**
+     * @param Application $app
+     * @param LazaretFile $file
+     * @return \record_adapter[]
+     */
+    public static function listConflicts(Application $app, LazaretFile $file)
+    {
+        return \record_adapter::get_records_by_originalname(
+            $file->getCollection($app)->get_databox(), $file->getOriginalName(), false, 0, 1000
+        );
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public static function getReason(TranslatorInterface $translator)
+    {
+        return $translator->trans('same filename');
     }
 
     /**

--- a/lib/Alchemy/Phrasea/Border/Checker/Sha256.php
+++ b/lib/Alchemy/Phrasea/Border/Checker/Sha256.php
@@ -13,6 +13,7 @@ namespace Alchemy\Phrasea\Border\Checker;
 
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Border\File;
+use Alchemy\Phrasea\Model\Entities\LazaretFile;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -36,6 +37,25 @@ class Sha256 extends AbstractChecker
         $boolean = empty($file->getCollection()->get_databox()->getRecordRepository()->findBySha256($file->getSha256()));
 
         return new Response($boolean, $this);
+    }
+
+    /**
+     * @param Application $app
+     * @param LazaretFile $file
+     * @return \record_adapter[]
+     */
+    public static function listConflicts(Application $app, LazaretFile $file)
+    {
+        $databox = $file->getCollection($app)->get_databox();
+
+        return $databox->getRecordRepository()->findBySha256($file->getSha256());
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public static function getReason(TranslatorInterface $translator)
+    {
+        return $translator->trans('same checksum');
     }
 
     /**

--- a/lib/Alchemy/Phrasea/Border/Checker/UUID.php
+++ b/lib/Alchemy/Phrasea/Border/Checker/UUID.php
@@ -13,6 +13,7 @@ namespace Alchemy\Phrasea\Border\Checker;
 
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Border\File;
+use Alchemy\Phrasea\Model\Entities\LazaretFile;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -35,6 +36,26 @@ class UUID extends AbstractChecker
         $boolean = empty($file->getCollection()->get_databox()->getRecordRepository()->findByUuid($file->getUUID()));
 
         return new Response($boolean, $this);
+    }
+
+    /**
+     * @param Application $app
+     * @param LazaretFile $file
+     * @return \record_adapter[]
+     */
+    public static function listConflicts(Application $app, LazaretFile $file)
+    {
+        $databox = $file->getCollection($app)->get_databox();
+
+        return $databox->getRecordRepository()->findByUuid($file->getUUID());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getReason(TranslatorInterface $translator)
+    {
+        return $translator->trans('same UUID');
     }
 
     /**

--- a/lib/Alchemy/Phrasea/Controller/Prod/RecordController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/RecordController.php
@@ -114,7 +114,7 @@ class RecordController extends Controller
                 'record'        => $record,
             ]),
             "pos"           => $record->getNumber(),
-            "title"         => str_replace(array('[[em]]', '[[/em]]'), array('<em>', '</em>'), $record->get_title($query, $searchEngine)),
+            "title"         => $record->get_title(),
             "databox_name" => $record->getDatabox()->get_dbname(),
             "collection_name" => $record->getCollection()->get_name(),
             "collection_logo" => $record->getCollection()->getLogo($record->getBaseId(), $this->app),

--- a/lib/Alchemy/Phrasea/Model/Entities/LazaretCheck.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/LazaretCheck.php
@@ -10,7 +10,9 @@
 
 namespace Alchemy\Phrasea\Model\Entities;
 
+use Alchemy\Phrasea\Application;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @ORM\Table(name="LazaretChecks")
@@ -91,4 +93,33 @@ class LazaretCheck
     {
         return $this->lazaretFile;
     }
+
+    /**
+     * @param TranslatorInterface $translator
+     * @return string   the reason why a record is in lazaret
+     */
+    public function getReason(TranslatorInterface $translator)
+    {
+        $className = $this->getCheckClassname();
+        if (method_exists($className, "getReason")) {
+            return $className::getReason($translator);
+        } else {
+            return '';
+        }
+    }
+
+    /**
+     * @param Application $app
+     * @return \record_adapter[]  the records conflicting with this check
+     */
+    public function listConflicts(Application $app)
+    {
+        $className = $this->getCheckClassname();
+        if (method_exists($className, "listConflicts")) {
+            return $className::listConflicts($app, $this->lazaretFile);
+        } else {
+            return [];
+        }
+    }
+
 }

--- a/lib/Alchemy/Phrasea/Model/Entities/LazaretFile.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/LazaretFile.php
@@ -14,6 +14,7 @@ namespace Alchemy\Phrasea\Model\Entities;
 use Alchemy\Phrasea\Application;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use \record_adapter;
 
 /**
  * @ORM\Table(name="LazaretFiles")
@@ -421,24 +422,34 @@ class LazaretFile
     /**
      * Get an array of records that can be substitued by the Lazaret file
      *
-     * @return \record_adapter[]
+     * @return record_adapter[]
      */
-    public function getRecordsToSubstitute(Application $app)
+    public function getRecordsToSubstitute(Application $app, $includeReason = false)
     {
-        $ret = [];
+        $merged = [];
+        /** @var LazaretCheck $check */
+        foreach($this->getChecks() as $check) {
+            /** @var record_adapter $record */
+            $conflicts = $check->listConflicts($app);
+            foreach ($conflicts as $record) {
+                // turn the record_adapter to a elasticsearchrecord so we can display it as a diapo
+                // $esrecord = new
 
-        $repository = $this->getCollection($app)->get_databox()->getRecordRepository();
-        $shaRecords = $repository->findBySha256($this->getSha256());
-        $uuidRecords = $repository->findByUuid($this->getUuid());
-
-        $merged = array_merge($uuidRecords, $shaRecords);
-
-        foreach ($merged as $record) {
-            if ( ! in_array($record, $ret)) {
-                $ret[] = $record;
+                if($includeReason) {
+                    if (!array_key_exists($record->getRecordId(), $merged)) {
+                        $merged[$record->getRecordId()] = [
+                            'record' => $record,
+                            'reasons' => []
+                        ];
+                    }
+                    $merged[$record->getRecordId()]['reasons'][] = $check->getReason($app['translator']);
+                }
+                else {
+                    $merged[$record->getRecordId()] = $record;
+                }
             }
         }
 
-        return $ret;
+        return $merged;
     }
 }

--- a/lib/classes/caption/record.php
+++ b/lib/classes/caption/record.php
@@ -165,7 +165,7 @@ class caption_record implements cache_cacheableInterface
      * @param bool $includeBusiness
      * @return array
      */
-    public function get_highlight_fields($highlight = '', array $grep_fields = null, $includeBusiness = false)
+    public function get_highlight_fields(array $grep_fields = null, $includeBusiness = false)
     {
         $fields = [];
 
@@ -177,11 +177,13 @@ class caption_record implements cache_cacheableInterface
                     'from_thesaurus' => false,
                     'qjs' => null,
                  ];
+                /*
                 if ($highlight) {
                     $v->highlight_thesaurus();
                     $values[$metaId]['from_thesaurus'] = $v->isThesaurusValue();
                     $values[$metaId]['qjs'] = $v->getQjs();
                 }
+                */
             }
             $fields[$field->get_name()] = [
                 'values'    => $values,

--- a/lib/classes/media/Permalink/Adapter.php
+++ b/lib/classes/media/Permalink/Adapter.php
@@ -416,7 +416,7 @@ class media_Permalink_Adapter implements cache_cacheableInterface
             $data[] = [
                 'subdef_id' => $media_subdef->get_subdef_id(),
                 'token' => $generator->generateString(64, TokenManipulator::LETTERS_AND_NUMBERS),
-                'label' => $records[$media_subdef->get_record_id()]->get_title(false, null, true),
+                'label' => $records[$media_subdef->get_record_id()]->get_title(['removeExtension' => true]),
             ];
         }
 

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -802,6 +802,16 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
         return $this;
     }
 
+    /**
+     * get the title (concat "thumbtitle" fields which match locale, with "-")
+     * fallback to the filename, possibly with extension removed
+     *
+     * @param string $locale
+     * @param $options[]
+     *      'removeExtension' : boolean
+     *
+     * @return string
+     */
     public function getTitle($locale = null, Array $options = [])
     {
         $removeExtension = !!igorw\get_in($options, ['removeExtension'], false);

--- a/lib/classes/record/preview.php
+++ b/lib/classes/record/preview.php
@@ -264,10 +264,10 @@ class record_preview extends record_adapter
 
             case "RESULT":
                 $this->title .= $this->app->trans('resultat numero %number%', ['%number%' => '<span id="current_result_n">' . ($this->getNumber() + 1) . '</span> : ']);
-                $this->title .= parent::get_title($highlight, $searchEngine);
+                $this->title .= parent::get_title();
                 break;
             case "BASK":
-                $this->title .= $this->name . ' - ' . parent::get_title($highlight, $searchEngine)
+                $this->title .= $this->name . ' - ' . parent::get_title()
                     . ' (' . $this->getNumber() . '/' . $this->total . ') ';
                 break;
             case "REG":
@@ -281,7 +281,7 @@ class record_preview extends record_adapter
                 }
                 break;
             default:
-                $this->title .= parent::get_title($highlight, $searchEngine);
+                $this->title .= parent::get_title();
                 break;
         }
 

--- a/lib/classes/record/preview.php
+++ b/lib/classes/record/preview.php
@@ -252,7 +252,8 @@ class record_preview extends record_adapter
      *
      * @return String
      */
-    public function get_title($highlight = false, SearchEngineInterface $searchEngine = null, $removeExtension = null, SearchEngineOptions $options = null)
+//    public function get_title($highlight = false, SearchEngineInterface $searchEngine = null, $removeExtension = null, SearchEngineOptions $options = null)
+    public function get_title(Array $options = [])
     {
         if ($this->title) {
             return $this->title;
@@ -264,14 +265,14 @@ class record_preview extends record_adapter
 
             case "RESULT":
                 $this->title .= $this->app->trans('resultat numero %number%', ['%number%' => '<span id="current_result_n">' . ($this->getNumber() + 1) . '</span> : ']);
-                $this->title .= parent::get_title();
+                $this->title .= parent::get_title($options);
                 break;
             case "BASK":
-                $this->title .= $this->name . ' - ' . parent::get_title()
+                $this->title .= $this->name . ' - ' . parent::get_title($options)
                     . ' (' . $this->getNumber() . '/' . $this->total . ') ';
                 break;
             case "REG":
-                $title = parent::get_title();
+                $title = parent::get_title($options);
                 if ($this->getNumber() == 0) {
                     $this->title .= $title;
                 } else {
@@ -281,7 +282,7 @@ class record_preview extends record_adapter
                 }
                 break;
             default:
-                $this->title .= parent::get_title();
+                $this->title .= parent::get_title($options);
                 break;
         }
 

--- a/lib/classes/set/export.php
+++ b/lib/classes/set/export.php
@@ -130,7 +130,7 @@ class set_export extends set_abstract
                             $app,
                             $child_basrec->getDataboxId(),
                             $record_id,
-                            $record->get_title(null, null, true) . '_' . $n,
+                            $record->get_title(['removeExtension' => true]) . '_' . $n,
                             $remain_hd[$base_id]
                         );
                         $this->add_element($current_element);

--- a/lib/classes/set/export.php
+++ b/lib/classes/set/export.php
@@ -444,8 +444,7 @@ SQL;
             $extension = isset($infos['extension']) ? $infos['extension'] : '';
 
             if ($rename_title) {
-                $title = strip_tags($download_element->get_title(null, null, true));
-
+                $title = strip_tags($download_element->get_title(['removeExtension' => true]));
                 $files[$id]['export_name'] = $unicode->remove_nonazAZ09($title, true, true, true);
             } else {
                 $files[$id]["export_name"] = $infos['filename'];

--- a/templates/web/common/macros.html.twig
+++ b/templates/web/common/macros.html.twig
@@ -103,7 +103,7 @@
 {% endmacro %}
 
 {% macro format_caption(record, highlight, search_engine, include_business, bounceable, technical_data) %}
-    {% for field in record.get_caption().get_highlight_fields(highlight, null, include_business) %}
+    {% for field in record.get_caption().get_highlight_fields(null, include_business) %}
         {% set extra_classes = ['pair'] %}
         {% if loop.index is odd %}
             {% set extra_classes = ['impair'] %}

--- a/templates/web/prod/results/macro.html.twig
+++ b/templates/web/prod/results/macro.html.twig
@@ -4,13 +4,13 @@
     {% set thumb_w = 256 %}
     {% set thumb_h = 256 %}
 
-    {% set thumbnail = record.subdefs.thumbnail|default(null) %}
-    {% if thumbnail is not none %}
-        {% set thumb_w = thumbnail.width %}
-        {% set thumb_h = thumbnail.height %}
+    {% set thumbnailSize = record_subdef_size(record, "thumbnail") %}
+    {%  if thumbnailSize is not null %}
+        {% set thumb_w = thumbnailSize.width %}
+        {% set thumb_h = thumbnailSize.height %}
     {% endif %}
 
-    {% set url = record_thumbnail_url(record) %}
+    {% set url = record_subdef_url(record, "thumbnail") %}
 
     {% set box_w = box_w|round %}
     {% set box_h = box_h|default(box_w)|round %}

--- a/templates/web/prod/results/record.html.twig
+++ b/templates/web/prod/results/record.html.twig
@@ -5,14 +5,12 @@
 <div style="width:{{ settings.images_size + 30}}px;"
      sbas="{{ record.databoxId }}"
      id="{{ prefix|default('IMGT') }}_{{ record.id }}"
-     class="IMGT diapo {% if record.story %}grouping{% endif %} type-{{ record.type }} open-preview-action"
+     class="IMGT diapo {% if record.story %}grouping{% endif %} type-{{ record.type }} {% if settings.handle_dblclick %}open-preview-action{% endif %}"
      data-kind="{{ record.story ? 'REG' : 'RESULT' }}"
      data-position="{{ record.position|default(0) }}"
      data-id="{{ record.id }}"
-        {% if settings.handle_dblclick %}
-            onDblClick="openPreview(this, '{{ record.story ? 'REG' : 'RESULT' }}', '{{ record.position|default(0) }}', '{{ record.id }}');"
-        {% endif %}
-        >
+     data-databox_id="{{ record.databoxId }}"
+     data-record_id="{{ record.recordId }}" >
     <div style="padding: 4px;">
         <div style="height:40px; position: relative; z-index: 95;margin-bottom:0;border-bottom:none;">
             <div class="title" style="max-height:100%" title="{{ record.getTitle(app.locale) }}">
@@ -80,7 +78,7 @@
                     <td style="text-align:right;width:{{l_width}}px;" valign="bottom">
 
                         {% if settings.rollover_thumbnail == 'caption' %}
-                            {% if record.subdefs.preview is defined and has_access_subdef(record, 'preview') %}
+                            {% if record_subdef_url(record, 'preview') is not null and has_access_subdef(record, 'preview') %}
                                 <span class="icon-stack previewTips" tooltipsrc="{{ path('prod_tooltip_preview', { 'sbas_id' : record.databoxId, 'record_id' : record.recordId }) }}">
                                   <i class="icon-circle icon-stack-base"></i>
                                   <i class="icon-search icon-light"></i>
@@ -106,7 +104,7 @@
                                   tooltipsrc="{{ path('prod_tooltip_technical_data', { 'sbas_id' : record.databoxId, 'record_id' : record.recordId }) }}">
                               <i class="icon-circle icon-stack-base"></i>
                               <i class="icon-ellipsis-horizontal icon-light"></i>
-                        </span>
+                            </span>
                             <table cellspacing="0" cellpadding="0" style="display:none;" id="answerContext_{{record.id}}" class="contextMenu answercontextmenu">
                                 <tbody>
                                 <tr>

--- a/templates/web/prod/results/record.html.twig
+++ b/templates/web/prod/results/record.html.twig
@@ -1,6 +1,7 @@
 {% import 'prod/results/macro.html.twig' as result_macro %}
 {% import 'common/macros.html.twig' as macro %}
 
+
 <div style="width:{{ settings.images_size + 30}}px;"
      sbas="{{ record.databoxId }}"
      id="{{ prefix|default('IMGT') }}_{{ record.id }}"
@@ -8,11 +9,14 @@
      data-kind="{{ record.story ? 'REG' : 'RESULT' }}"
      data-position="{{ record.position|default(0) }}"
      data-id="{{ record.id }}"
-     >
+        {% if settings.handle_dblclick %}
+            onDblClick="openPreview(this, '{{ record.story ? 'REG' : 'RESULT' }}', '{{ record.position|default(0) }}', '{{ record.id }}');"
+        {% endif %}
+        >
     <div style="padding: 4px;">
         <div style="height:40px; position: relative; z-index: 95;margin-bottom:0;border-bottom:none;">
-            <div class="title" style="max-height:100%" title="{{ record.title(app.locale) }}">
-                {{ record.title(app.locale)|highlight }}
+            <div class="title" style="max-height:100%" title="{{ record.getTitle(app.locale) }}">
+                {{ record.getTitle(app.locale)|highlight }}
             </div>
             <div class="status">
                 {% for flag in record_flags(record) %}
@@ -25,7 +29,7 @@
 
         <div class="thumb captionTips"
              {% if settings.rollover_thumbnail == 'caption' %}title="{{ macro.caption(record, can_see_business, false) | e }}"{% endif %}
-             {% if settings.rollover_thumbnail == 'preview' %}tooltipsrc="{{ path('prod_tooltip_preview', { 'sbas_id' : record.databoxId, 'record_id' : record.recordId }) }}"{% endif %}
+                {% if settings.rollover_thumbnail == 'preview' %}tooltipsrc="{{ path('prod_tooltip_preview', { 'sbas_id' : record.databoxId, 'record_id' : record.recordId }) }}"{% endif %}
              style="height:{{ settings.images_size }}px; z-index:90;">
             <div class="doc_infos">
                 {% if settings.doctype_display == '1' %}
@@ -58,9 +62,9 @@
                     <td style="text-align:left;text-overflow:ellipsis;overflow:hidden;">
                         {% set collectionLogo = collection_logo(record.baseId) %}
                         {% if collectionLogo is empty %}
-                        {{ record.collectionName }}
+                            {{ record.getCollectionName() }}
                         {% else %}
-                        {{ collectionLogo|raw }}
+                            {{ collectionLogo|raw }}
                         {% endif %}
                     </td>
 
@@ -97,52 +101,54 @@
                             </span>
                         {% endif %}
 
-                        <span class="icon-stack contextMenuTrigger"  id="contextTrigger_{{record.id}}"
-                              tooltipsrc="{{ path('prod_tooltip_technical_data', { 'sbas_id' : record.databoxId, 'record_id' : record.recordId }) }}">
+                        {%  if settings.show_context_menu %}
+                            <span class="icon-stack contextMenuTrigger"  id="contextTrigger_{{record.id}}"
+                                  tooltipsrc="{{ path('prod_tooltip_technical_data', { 'sbas_id' : record.databoxId, 'record_id' : record.recordId }) }}">
                               <i class="icon-circle icon-stack-base"></i>
                               <i class="icon-ellipsis-horizontal icon-light"></i>
                         </span>
-                        <table cellspacing="0" cellpadding="0" style="display:none;" id="answerContext_{{record.id}}" class="contextMenu answercontextmenu">
-                            <tbody>
-                            <tr>
-                                <td>
-                                    <div class="context-menu context-menu-theme-vista">
-                                        {% if granted_on_collection(record.baseId, 'canputinalbum') and not record.story %}
-                                            <div title="" class="context-menu-item">
-                                                <div class="context-menu-item-inner record-add-to-basket-action" data-db-id="{{record.databoxId}}" data-record-id="{{record.recordId}}">
-                                                    {{ 'action : ajouter au panier' | trans }}
-                                                </div>
-                                            </div>
-                                        {% endif %}
-                                        {% if granted_on_collection(record.baseId, 'candwnldpreview') or granted_on_collection(record.baseId, 'candwnldhd') %}
-                                            <div title="" class="context-menu-item">
-                                                <div class="context-menu-item-inner record-export-action" data-kind="record" data-id="{{record.id}}">
-                                                    {{ 'action : exporter' | trans }}
-                                                </div>
-                                            </div>
-                                        {% endif %}
-                                        <div title="" class="context-menu-item">
-                                            <div class="context-menu-item-inner record-print-action"
-                                                 data-kind="record" data-id="{{record.id}}">
-                                                {{ 'action : print' | trans }}
-                                            </div>
-                                        </div>
-                                        {% if app['conf'].get(['registry', 'actions', 'social-tools']) == 'all'
-                                        or (app['conf'].get(['registry', 'actions', 'social-tools']) == 'publishers'
-                                        and granted_on_databox(record.databoxId, 'bas_chupub')) %}
-                                            {% if record.story is empty %}
+                            <table cellspacing="0" cellpadding="0" style="display:none;" id="answerContext_{{record.id}}" class="contextMenu answercontextmenu">
+                                <tbody>
+                                <tr>
+                                    <td>
+                                        <div class="context-menu context-menu-theme-vista">
+                                            {% if granted_on_collection(record.baseId, 'canputinalbum') and not record.story %}
                                                 <div title="" class="context-menu-item">
-                                                    <div class="context-menu-item-inner share-record-action" data-db="{{record.baseId}}" data-record-id="{{record.recordId}}">
-                                                        {{ 'reponses:: partager' | trans }}
+                                                    <div class="context-menu-item-inner record-add-to-basket-action" data-db-id="{{record.databoxId}}" data-record-id="{{record.recordId}}">
+                                                        {{ 'action : ajouter au panier' | trans }}
                                                     </div>
                                                 </div>
                                             {% endif %}
-                                        {% endif %}
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
+                                            {% if granted_on_collection(record.baseId, 'candwnldpreview') or granted_on_collection(record.baseId, 'candwnldhd') %}
+                                                <div title="" class="context-menu-item">
+                                                    <div class="context-menu-item-inner record-export-action" data-kind="record" data-id="{{record.id}}">
+                                                        {{ 'action : exporter' | trans }}
+                                                    </div>
+                                                </div>
+                                            {% endif %}
+                                            <div title="" class="context-menu-item">
+                                                <div class="context-menu-item-inner record-print-action"
+                                                     data-kind="record" data-id="{{record.id}}">
+                                                    {{ 'action : print' | trans }}
+                                                </div>
+                                            </div>
+                                            {% if app['conf'].get(['registry', 'actions', 'social-tools']) == 'all'
+                                            or (app['conf'].get(['registry', 'actions', 'social-tools']) == 'publishers'
+                                            and granted_on_databox(record.databoxId, 'bas_chupub')) %}
+                                                {% if record.story is empty %}
+                                                    <div title="" class="context-menu-item">
+                                                        <div class="context-menu-item-inner share-record-action" data-db="{{record.baseId}}" data-record-id="{{record.recordId}}">
+                                                            {{ 'reponses:: partager' | trans }}
+                                                        </div>
+                                                    </div>
+                                                {% endif %}
+                                            {% endif %}
+                                        </div>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        {% endif %}
                     </td>
                 </tr>
             </table>

--- a/templates/web/prod/results/records.html.twig
+++ b/templates/web/prod/results/records.html.twig
@@ -28,7 +28,9 @@
                             'images_size': images_size,
                             'technical_display': technical_display,
                             'rollover_thumbnail': rollover_thumbnail,
-                            'doctype_display': doctype_display
+                            'doctype_display': doctype_display,
+                            'handle_dblclick' : true,
+                            'show_context_menu': true
                         }
                     } %}
                 {% endblock %}

--- a/templates/web/prod/upload/lazaret.html.twig
+++ b/templates/web/prod/upload/lazaret.html.twig
@@ -314,7 +314,7 @@
 
 {% macro lazaretElement(app, file) %}
     {% import "common/thumbnail.html.twig" as thumb %}
-    {% set records = file.getRecordsToSubstitute(app) %}
+    {% set records = file.getRecordsToSubstitute(app, true) %}
     <div class="lazaret-file span4">
         <h5>{{ "Last uploaded version" | trans }}</h5>
         <ul class="thumbnails">
@@ -370,6 +370,8 @@
             </h5>
             <ul class="thumbnails">
                 {% for record in records %}
+                    {% set reasons = record['reasons'] %}
+                    {% set record = record['record'] %}
                     {% if app.getAclForUser(app.getAuthenticatedUser()).has_right_on_base(record.get_base_id(), "canaddrecord")
                         and app.getAclForUser(app.getAuthenticatedUser()).has_right_on_base(record.get_base_id(), "candeleterecord") %}
                         <li class="records-subititution span3">
@@ -380,8 +382,26 @@
                                 </div>
                                 <div class="caption">
                                     <p><b>{{ record.get_title() }}</b></p>
+                                    {% for reason in reasons %}
+                                    <p>{{ reason }}</p>
+                                    {% endfor %}
                                 </div>
                             </div>
+
+
+                            {% include 'prod/results/record.html.twig' with {
+                            'record': record,
+                            'settings': {
+                            'images_size': 169,
+                            'technical_display': '1',
+                            'rollover_thumbnail': 'caption',
+                            'doctype_display': '1',
+                            'handle_dblclick' : false,
+                            'show_context_menu': false
+                            }
+                            } %}
+
+
                         </li>
                     {% endif %}
                 {% endfor %}

--- a/templates/web/prod/upload/lazaret.html.twig
+++ b/templates/web/prod/upload/lazaret.html.twig
@@ -92,13 +92,16 @@
             }
         }
 
-        $(".records-subititution", scope).bind('click', function(){
-            $(this).closest('.lazaret-proposals').find('.records-subititution').removeClass("thumb-selected");
-            $(this).closest('.lazaret-proposals').find('.thumbnail').css({'border-color': 'white'})
-            $(this).find('.thumbnail').css({'border-color': 'blue'});
-            $(this).addClass("thumb-selected");
-        });
+        $(".records-subititution .diapo", scope)
+            .bind('click', function(e){
+                $(this).closest('.lazaret-proposals').find('.diapo').removeClass('selected');
+                $(this).addClass('selected');
+            }
+        );
 
+        $(".records-subititution .captionTips", scope).tooltip();
+        $(".records-subititution .infoTips", scope).tooltip();
+        $(".records-subititution .previewTips", scope).tooltip();
 
         var emptying = false;   // true=emptying, set to false to stop
 
@@ -198,14 +201,14 @@
                         var html = _.template($("#alert_error_tpl").html(), {
                              content:data.message
                         });
-                        that.closest(".thumbnail").append(html);
+                        that.closest(".diapo").append(html);
                     }
                 },
                 error: function(){
                    var html = _.template($("#alert_error_tpl").html(), {
                         content:language.errorAjaxRequest
                    });
-                   that.closest(".thumbnail").append(html);
+                   that.closest(".diapo").append(html);
                 },
                 complete: function(){
                     stopAjax(that);
@@ -233,14 +236,14 @@
                        var html = _.template($("#alert_error_tpl").html(), {
                             content:data.message
                        });
-                       that.closest(".thumbnail").append(html);
+                       that.closest(".diapo").append(html);
                     }
                 },
                 error: function(){
                     var html = _.template($("#alert_error_tpl").html(), {
                         content:language.errorAjaxRequest
                     });
-                    that.closest(".thumbnail").append(html);
+                    that.closest(".diapo").append(html);
                 },
                 complete: function(){
                     stopAjax(that);
@@ -253,14 +256,18 @@
         $("button.subtitute-lazaret", scope).bind('click', function(){
             var that = $(this);
             var lazaretId = getLazaretId(that);
-            var nbProposals = $('.records-subititution', $(this).closest('.wrapper-item')).length;
+            var container = $(this).closest('.wrapper-item');
+
+            var nbProposals = $('.records-subititution', container).length;
+            var elements = [];
+            var nbElement = 0;
 
             if(nbProposals > 1){ // we got more than one proposals
-                var elements = $(".thumb-selected", $(this).closest('.wrapper-item'));
-                var nbElement = elements.length;
+                elements = $(".selected", container);
+                nbElement = elements.length;
             }else if(nbProposals == 1){
-                var elements = $(this).closest('.wrapper-item').find(".records-subititution");
-                var nbElement = 1
+                elements = container.find(".records-subititution");
+                nbElement = 1
             }
             else{
                 return false;
@@ -274,8 +281,7 @@
                 return false;
             }
 
-            var recorThumb = elements.first().find('.record-thumb');
-            var recordId = recorThumb.find('input[name=record_id]').val();
+            var recordId = elements.first().attr("data-record_id");
 
             $.ajax({
                 type : 'POST',
@@ -294,14 +300,14 @@
                         var html = _.template($("#alert_error_tpl").html(), {
                             content:data.message
                         });
-                        that.closest(".thumbnail").append(html);
+                        that.closest(".diapo").append(html);
                     }
                 },
                 error: function(){
                     var html = _.template($("#alert_error_tpl").html(), {
                         content:language.errorAjaxRequest
                     });
-                    that.closest(".thumbnail").append(html);
+                    that.closest(".diapo").append(html);
                 },
                 complete: function(){
                     stopAjax(that);
@@ -311,6 +317,11 @@
         });
     });
 </script>
+<style>
+    .lazaret-proposals .diapo {
+        float:none;
+    }
+</style>
 
 {% macro lazaretElement(app, file) %}
     {% import "common/thumbnail.html.twig" as thumb %}
@@ -374,21 +385,7 @@
                     {% set record = record['record'] %}
                     {% if app.getAclForUser(app.getAuthenticatedUser()).has_right_on_base(record.get_base_id(), "canaddrecord")
                         and app.getAclForUser(app.getAuthenticatedUser()).has_right_on_base(record.get_base_id(), "candeleterecord") %}
-                        <li class="records-subititution span3">
-                            <div class="thumbnail">
-                                <div class="record-thumb" style="text-align:center;">
-                                    {{ thumb.format(record.get_thumbnail(), 169, 180, "", false, false) }}
-                                    <input name="record_id" value="{{ record.get_record_id() }}" type="hidden"/>
-                                </div>
-                                <div class="caption">
-                                    <p><b>{{ record.get_title() }}</b></p>
-                                    {% for reason in reasons %}
-                                    <p>{{ reason }}</p>
-                                    {% endfor %}
-                                </div>
-                            </div>
-
-
+                        <li class="records-subititution span3" style="width:210px">
                             {% include 'prod/results/record.html.twig' with {
                             'record': record,
                             'settings': {
@@ -400,8 +397,11 @@
                             'show_context_menu': false
                             }
                             } %}
-
-
+                            <div class="caption">
+                            {% for reason in reasons %}
+                                <p>{{ reason }}</p>
+                            {% endfor %}
+                            </div>
                         </li>
                     {% endif %}
                 {% endfor %}

--- a/tests/classes/record/adapterTest.php
+++ b/tests/classes/record/adapterTest.php
@@ -290,8 +290,8 @@ class record_adapterTest extends \PhraseanetAuthenticatedTestCase
 
     public function testGet_title()
     {
-        // Test was marked skipped for unknown reason
         $this->assertEquals('test001.jpg', $this->getRecord1()->get_title());
+        $this->assertEquals('test001',     $this->getRecord1()->get_title(['removeExtension' => true]));
     }
 
     public function testGet_preview()


### PR DESCRIPTION
## Changelog
  
### Fixes
  - records conflicting on filename are shown on quarantine (no more empty list on right side)

### Adds
  - better thumbnails in quarantine by reusing the "record" template from prod/answers.
  - reason of quarantine is indicated under thumbnail

### Removes
  - highlight in title (dead code)

