### PR TITLE
PHRAS-842_search-logged-as-es

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Api/SearchController.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/SearchController.php
@@ -58,7 +58,7 @@ class SearchController extends Controller
 
         $result = $this->getSearchEngine()->query($query, $options);
 
-        $this->getUserManipulator()->logQuery($this->getAuthenticatedUser(), $result->getQuery());
+        $this->getUserManipulator()->logQuery($this->getAuthenticatedUser(), $result->getUserQuery());
 
         foreach ($options->getDataboxes() as $databox) {
             $colls = array_map(function (\collection $collection) {
@@ -68,7 +68,7 @@ class SearchController extends Controller
             }));
 
             $this->getSearchEngineLogger()
-                ->log($databox, $result->getQuery(), $result->getTotal(), $colls);
+                ->log($databox, $result->getUserQuery(), $result->getTotal(), $colls);
         }
 
         $this->getSearchEngine()->clearCache();

--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -1472,7 +1472,7 @@ class V1Controller extends Controller
 
         $search_result = $this->getSearchEngine()->query((string)$request->get('query'), $options);
 
-        $this->getUserManipulator()->logQuery($this->getAuthenticatedUser(), $search_result->getQuery());
+        $this->getUserManipulator()->logQuery($this->getAuthenticatedUser(), $search_result->getUserQuery());
 
         foreach ($options->getDataboxes() as $databox) {
             $colls = array_map(function (\collection $collection) {
@@ -1482,7 +1482,7 @@ class V1Controller extends Controller
             }));
 
             $this->getSearchEngineLogger()
-                ->log($databox, $search_result->getQuery(), $search_result->getTotal(), $colls);
+                ->log($databox, $search_result->getUserQuery(), $search_result->getTotal(), $colls);
         }
 
         $this->getSearchEngine()->clearCache();

--- a/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
@@ -75,7 +75,7 @@ class QueryController extends Controller
                     return $collection->get_databox()->get_sbas_id() == $databox->get_sbas_id();
                 }));
 
-                $this->getSearchEngineLogger()->log($databox, $result->getQuery(), $result->getTotal(), $collections);
+                $this->getSearchEngineLogger()->log($databox, $result->getUserQuery(), $result->getTotal(), $collections);
             }
 
             $proposals = $firstPage ? $result->getProposals() : false;
@@ -185,7 +185,7 @@ class QueryController extends Controller
             $json['results'] = $this->render($template, ['results'=> $result]);
 
             /** Debug */
-            $json['parsed_query'] = $result->getQuery();
+            $json['parsed_query'] = $result->getEngineQuery();
             /** End debug */
 
             $fieldLabels = [

--- a/lib/Alchemy/Phrasea/Search/V1SearchTransformer.php
+++ b/lib/Alchemy/Phrasea/Search/V1SearchTransformer.php
@@ -36,7 +36,7 @@ abstract class V1SearchTransformer extends TransformerAbstract
                     return $suggestion->toArray();
                 }, $result->getSuggestions()->toArray()),
             'facets' => $result->getFacets(),
-            'query' => $result->getQuery(),
+            'query' => $result->getEngineQuery(),
         ];
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -313,6 +313,7 @@ class ElasticSearchEngine implements SearchEngineInterface
         return new SearchEngineResult(
             $options,
             $results,   // ArrayCollection of results
+            $string,    // the query as typed by the user
             json_encode($query),
             $res['took'],   // duration
             $options->getFirstResult(),

--- a/lib/Alchemy/Phrasea/SearchEngine/SearchEngineResult.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/SearchEngineResult.php
@@ -17,7 +17,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 class SearchEngineResult
 {
     protected $results;
-    protected $query;
+    protected $user_query;
+    protected $engine_query;
     protected $duration;
     protected $offsetStart;
     protected $available;
@@ -39,7 +40,8 @@ class SearchEngineResult
      * SearchEngineResult constructor.
      * @param SearchEngineOptions $options
      * @param ArrayCollection $results
-     * @param string $query
+     * @param string $user_query        query as user typed, "dog"
+     * @param string $engine_query      query parsed for engine, "{"ast":"<text:\"dog\">","query_main" ....
      * @param float $duration
      * @param int $offsetStart
      * @param int $available
@@ -54,7 +56,8 @@ class SearchEngineResult
     public function __construct(
         SearchEngineOptions $options,
         ArrayCollection $results,
-        $query,
+        $user_query,
+        $engine_query,
         $duration,
         $offsetStart,
         $available,
@@ -69,7 +72,8 @@ class SearchEngineResult
         $this->options = $options;
 
         $this->results = $results;
-        $this->query = $query;
+        $this->user_query = $user_query;
+        $this->engine_query = $engine_query;
         $this->duration = (float) $duration;
         $this->offsetStart = (int) $offsetStart;
         $this->available = (int) $available;
@@ -107,7 +111,27 @@ class SearchEngineResult
      */
     public function getQuery()
     {
-        return $this->query;
+        return $this->getEngineQuery();
+    }
+
+    /**
+     * The query related to these results
+     *
+     * @return string
+     */
+    public function getUserQuery()
+    {
+        return $this->user_query;
+    }
+
+    /**
+     * The query related to these results
+     *
+     * @return string
+     */
+    public function getEngineQuery()
+    {
+        return $this->engine_query;
     }
 
     /**

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineResultTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineResultTest.php
@@ -23,7 +23,8 @@ class SearchEngineResultTest extends \PhraseanetTestCase
                     self::$DI['record_2']
                 ]);
 
-        $query = 'Gotainer';
+        $user_query = 'Gotainer';
+        $engine_query = '{text:"Gotainer"}';    // fake, real is really more complex
         $duration = 1 / 3;
         $offsetStart = 23;
         $available = 25;
@@ -31,12 +32,12 @@ class SearchEngineResultTest extends \PhraseanetTestCase
         $error = 'this is an error message';
         $warning = 'this is a warning message';
         $suggestions = new ArrayCollection([
-                        new SearchEngineSuggestion($query, 'Richard', 22)
+                        new SearchEngineSuggestion($user_query, 'Richard', 22)
         ]);
         $propositions = new ArrayCollection();
         $indexes = 'new-index';
 
-        $result = new SearchEngineResult($options, $results, $query, $duration, $offsetStart, $available, $total, $error, $warning, $suggestions, $propositions, $indexes);
+        $result = new SearchEngineResult($options, $results, $user_query, $engine_query, $duration, $offsetStart, $available, $total, $error, $warning, $suggestions, $propositions, $indexes);
 
         $this->assertEquals($warning, $result->getWarning());
         $this->assertEquals(2, $result->getTotalPages(23));
@@ -44,7 +45,8 @@ class SearchEngineResultTest extends \PhraseanetTestCase
         $this->assertEquals($total, $result->getTotal());
         $this->assertEquals($suggestions, $result->getSuggestions());
         $this->assertEquals($results, $result->getResults());
-        $this->assertEquals($query, $result->getQuery());
+        $this->assertEquals($user_query, $result->getUserQuery());
+        $this->assertEquals($engine_query, $result->getEngineQuery());
         $this->assertEquals($propositions, $result->getProposals());
         $this->assertEquals($indexes, $result->getIndexes());
         $this->assertEquals($error, $result->getError());
@@ -60,7 +62,8 @@ class SearchEngineResultTest extends \PhraseanetTestCase
                     self::$DI['record_2']
                 ]);
 
-        $query = 'Gotainer';
+        $user_query = 'Gotainer';
+        $engine_query = '{text:"Gotainer"}';    // fake, real is really more complex
         $duration = 1 / 3;
         $offsetStart = 0;
         $available = 25;
@@ -68,12 +71,12 @@ class SearchEngineResultTest extends \PhraseanetTestCase
         $error = 'this is an error message';
         $warning = 'this is a warning message';
         $suggestions = new ArrayCollection([
-                        new SearchEngineSuggestion($query, 'Richard', 22)
+                        new SearchEngineSuggestion($user_query, 'Richard', 22)
         ]);
         $propositions = new ArrayCollection();
         $indexes = 'new-index';
 
-        $result = new SearchEngineResult($options, $results, $query, $duration, $offsetStart, $available, $total, $error, $warning, $suggestions, $propositions, $indexes);
+        $result = new SearchEngineResult($options, $results, $user_query, $engine_query, $duration, $offsetStart, $available, $total, $error, $warning, $suggestions, $propositions, $indexes);
 
         $this->assertEquals(1, $result->getCurrentPage(10));
         $this->assertEquals(1, $result->getCurrentPage(25));

--- a/tests/classes/PhraseanetAuthenticatedWebTestCase.php
+++ b/tests/classes/PhraseanetAuthenticatedWebTestCase.php
@@ -208,7 +208,8 @@ abstract class PhraseanetAuthenticatedWebTestCase extends \PhraseanetAuthenticat
         $result = new SearchEngineResult(
             new SearchEngineOptions(),
             new ArrayCollection([$elasticsearchRecord]), // Records
-            '', // Query
+            '', // Query as user typed
+            '{}', // Query as engine parsed
             0, // Duration
             0, // offsetStart
             1, // available


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-842: query is logged in a "user" form, before parsing