### PR TITLE
PHRAS-1178_edit-story-and-records_4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/RecordEditSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/RecordEditSubscriber.php
@@ -17,6 +17,7 @@ use Alchemy\Phrasea\Core\Event\RecordEdit;
 use Alchemy\Phrasea\Core\PhraseaEvents;
 use Alchemy\Phrasea\Metadata\Tag\TfEditdate;
 use Alchemy\Phrasea\Model\RecordInterface;
+use caption_Field_Value;
 use Assert\Assertion;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -50,24 +51,35 @@ class RecordEditSubscriber implements EventSubscriberInterface
 
     public function onEdit(RecordEdit $event)
     {
-        $record = $event->getRecord();
+        static $into = false;
+        static $editDateFields = [];    // array of fields "tfEditDate", by databox_id
+
+        // prevent recursion
+        if ($into) {
+            return;
+        }
+        $into = true;
+
         $recordAdapter = $this->convertToRecordAdapter($event->getRecord());
 
         $databox = $recordAdapter->getDatabox();
+        $sbas_id = $databox->get_sbas_id();
+        if (!array_key_exists($sbas_id, $editDateFields)) {
+            $editDateFields[$sbas_id] = [];
 
-        $metaStructure = $databox->get_meta_structure();
-        $editDateField = false;
-        foreach ($metaStructure->get_elements() as $meta) {
-            if ($meta->get_tag() instanceof TfEditdate) {
-                $editDateField = $meta;
+            $metaStructure = $databox->get_meta_structure();
+            foreach ($metaStructure->get_elements() as $meta) {
+                if ($meta->get_tag() instanceof TfEditdate) {
+                    $editDateFields[$sbas_id][] = $meta;
+                }
             }
         }
 
-        if ($editDateField instanceof \databox_field) {
-            $this->updateRecord($recordAdapter, $editDateField);
+        if (!empty($editDateFields[$sbas_id])) {
+            $this->updateRecord($recordAdapter, $editDateFields[$sbas_id], new \DateTime());
         }
 
-        $recordAdapter->clearStampCache();
+        $into = false;
     }
 
     /**
@@ -89,36 +101,65 @@ class RecordEditSubscriber implements EventSubscriberInterface
         return $callable();
     }
 
-    private function updateRecord(\record_adapter $record, $field)
+    /**
+     * @param \record_adapter $record
+     * @param \databox_field[] $editFields
+     * @param \DateTime $date
+     * @throws \Exception_InvalidArgument
+     */
+    private function updateRecord(\record_adapter $record, array $editFields, \DateTime $date)
     {
         if (false === $record->isStory()) {
+            // if a record is updated, every "parent" story is considered as updated too
             foreach ($record->get_grouping_parents() as $story) {
-                $this->updateEditField($story, $field);
+                $this->updateEditFields($story, $editFields, $date);
             }
         }
-        $this->updateEditField($record, $field);
+        $this->updateEditFields($record, $editFields, $date);
     }
 
-    private function updateEditField(\record_adapter $record, \databox_field $editField)
+    /**
+     * @param \record_adapter $record
+     * @param \databox_field[] $editFields
+     * @param \DateTime $date
+     * @throws \Exception_InvalidArgument
+     */
+    private function updateEditFields(\record_adapter $record, array $editFields, \DateTime $date)
     {
-        $fields = $record->get_caption()->get_fields(array($editField->get_name()), true);
-        $field = array_pop($fields);
+        static $updated = [];
+        $id = $record->getId();
 
-        $metaId = null;
-
-        if ($field && !$field->is_multi()) {
-            $values = $field->get_values();
-            $metaId = array_pop($values)->getId();
+        // no need to update the same record twice (may happen is the record belongs to many stories)
+        if(in_array($id, $updated)) {
+            return;
         }
 
-        $date = new \DateTime();
-        $record->set_metadatas(array(
-            array(
-                'meta_struct_id' => $editField->get_id(),
-                'meta_id'        => $metaId,
-                'value'          => $date->format('Y-m-d H:i:s'),
-            )
-        ), true);
+        foreach($editFields as $editField) {
+            $metaId = null;
+            try {
+                $field = $record->get_caption()->get_field($editField->get_name(), true);
+                if ($field) {
+                    $values = $field->get_values();
+                    /** @var caption_Field_Value $value */
+                    $value = array_slice($values, -1)[0];   // if multivalued, only the last value will be updated
+                    $metaId = $value->getId();
+                }
+            } catch (\Exception $e) {
+                // field not found, $metaId==null -> value will be created
+            }
+
+            $record->set_metadatas(array(
+                array(
+                    'meta_struct_id' => $editField->get_id(),
+                    'meta_id' => $metaId,
+                    'value' => $date->format('Y-m-d H:i:s'),
+                )
+            ), true);
+        }
+
+        $record->clearStampCache();
+
+        $updated[] = $id;
     }
 
     /**

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -933,6 +933,7 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
         $databox_field = $databox->get_meta_structure()->get_element($params['meta_struct_id']);
 
         $caption_field = new caption_field($this->app, $databox_field, $this);
+        $caption_field->delete_data_from_cache();
 
         $vocab = $vocab_id = null;
 


### PR DESCRIPTION
## Changelog
  
### Fixes
  - cache is now invalidated after editing records
  - recordeditsuscriber can't run into recursion anymore

### Adds
  - PHRAS-1178: if a record is updated, every "parent" story is considered as updated too (editDateField(s) set)
