### PR TITLE
Remove rotation subdef wording on 3.8

### DIFF
--- a/locale/ar_SA/LC_MESSAGES/phraseanet.po
+++ b/locale/ar_SA/LC_MESSAGES/phraseanet.po
@@ -6670,11 +6670,6 @@ msgstr ""
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr ""
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr ""
-
 msgid "Chargement"
 msgstr ""
 

--- a/locale/de_DE/LC_MESSAGES/phraseanet.po
+++ b/locale/de_DE/LC_MESSAGES/phraseanet.po
@@ -6837,11 +6837,6 @@ msgstr "Sammelkörbe durchsuchen"
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr "Dieses Feld wird als einen Dublin Core Element beschrieben"
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr "Drehungen werden nur für die Unterauflösungen \"Bilder\" angewendet."
-
 msgid "Chargement"
 msgstr "Ladend"
 

--- a/locale/en_GB/LC_MESSAGES/phraseanet.po
+++ b/locale/en_GB/LC_MESSAGES/phraseanet.po
@@ -6731,13 +6731,6 @@ msgstr "Browse Baskets"
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr "This field has a Dublin Core link"
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-
 msgid "Chargement"
 msgstr "Loading..."
 

--- a/locale/es_ES/LC_MESSAGES/phraseanet.po
+++ b/locale/es_ES/LC_MESSAGES/phraseanet.po
@@ -6656,11 +6656,6 @@ msgstr ""
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr ""
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr ""
-
 msgid "Chargement"
 msgstr "Cargando..."
 

--- a/locale/fr_FR/LC_MESSAGES/phraseanet.po
+++ b/locale/fr_FR/LC_MESSAGES/phraseanet.po
@@ -6838,13 +6838,6 @@ msgstr "Parcourir les paniers"
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr "Ce champ est décrit comme un élément DublinCore"
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr ""
-"Les rotations ne sont appliquées qu'aux sous-définitions des documents de "
-"type image."
-
 msgid "Chargement"
 msgstr "Chargement..."
 

--- a/locale/nl_NL/LC_MESSAGES/phraseanet.po
+++ b/locale/nl_NL/LC_MESSAGES/phraseanet.po
@@ -6807,13 +6807,6 @@ msgstr "Mandjes doorbladeren"
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr "Dit veld is beschreven als een DublinCore element"
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr ""
-"Veranderingen in de rotatie zullen enkel op de thumbnail van het type \"beeld"
-"\" worden toegepast."
-
 msgid "Chargement"
 msgstr "Laden"
 

--- a/locale/phraseanet.pot
+++ b/locale/phraseanet.pot
@@ -6601,11 +6601,6 @@ msgstr ""
 msgid "Ce champ est decrit comme un element DublinCore"
 msgstr ""
 
-msgid ""
-"Changes for rotation will be applied only on the sub-definitions of \"image"
-"\" type."
-msgstr ""
-
 msgid "Chargement"
 msgstr ""
 

--- a/templates/web/prod/actions/Tools/index.html.twig
+++ b/templates/web/prod/actions/Tools/index.html.twig
@@ -174,9 +174,6 @@
     {% endif %}
 
     <div id="image" class="tabBox">
-      <div class="text-info">
-        <i class=" icon-info-sign"></i> {% trans %}Changes for rotation will be applied only on the sub-definitions of "image" type.{% endtrans %}
-      </div>
       <form name="formpushdoc" action="{{ path('prod_tools_rotate') }}" method="post">
         <fieldset style='border:1px solid #999;padding:20px;'>
           <legend style='color:#EEE'>&nbsp;<b>{% trans "image rotation" %}</b>&nbsp;</legend>


### PR DESCRIPTION
## Changelog

### Removes
  - PHRAS-1224 : Remove rotation subdef wording on 3.8
