### PR TITLE
Fix provisioning errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install_assets:
 	rm -rf ./www/assets
 	rm -rf ./www/bower_components
 	npm install
-	./node_modules/bin/gulp build
+	./node_modules/.bin/gulp build
 
 config:
 	@php bin/console compile:configuration

--- a/resources/ansible/roles/elasticsearch/tasks/main.yml
+++ b/resources/ansible/roles/elasticsearch/tasks/main.yml
@@ -28,8 +28,6 @@
   when: not is_installed
 
 - name: Install plugins
-  become: yes
-  become_user: elasticsearch
   shell: /usr/share/elasticsearch/bin/plugin install {{ item.name }}/{{ item.version }}
   when: not is_installed
   with_items: "{{ elasticsearch.plugins }}"


### PR DESCRIPTION
## Changelog
### Fixes
  - Gulp command path was incorrect in Makefile
  - Installing ES plugins as an unprivileged user during Ansible provisioning triggered errors with Ansible 2