### PR TITLE
API settings provisioning

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -7,6 +7,7 @@ main:
     languages: []
     key: ''
     api_require_ssl: true
+    api_disabled: true
     database:
         host: 127.0.0.1
         port: 3306

--- a/lib/Alchemy/Phrasea/Command/Setup/ConfigurationEditor.php
+++ b/lib/Alchemy/Phrasea/Command/Setup/ConfigurationEditor.php
@@ -83,10 +83,10 @@ class ConfigurationEditor extends Command
         $configurationRoot = $configurationStore->getConfig();
         $configurationCurrent = & $configurationRoot;
 
-        $output->writeln('<info>Writing configuration entry</info> ' . $parameter);
+        $output->writeln('<info>Writing value to configuration entry</info> ' . $parameter);
 
         foreach ($parameterNodes as $paramName) {
-            if (! isset($mergeConfiguration[$paramName])) {
+            if (! isset($configurationCurrent[$paramName])) {
                 $configurationCurrent[$paramName] = array();
             }
 

--- a/lib/conf.d/configuration.yml
+++ b/lib/conf.d/configuration.yml
@@ -6,6 +6,7 @@ main:
     maintenance: false
     key: ''
     api_require_ssl: true
+    api_disabled: true
     database:
         host: 'sql-host'
         port: 3306

--- a/resources/ansible/roles/app/tasks/main.yml
+++ b/resources/ansible/roles/app/tasks/main.yml
@@ -41,3 +41,18 @@
   with_items: '{{ host_addresses }}'
   args:
     chdir: /vagrant/
+
+- name: Disable API SSL requirement
+  shell: bin/setup system:config set main.api_require_ssl false
+  args:
+    chdir: /vagrant/
+
+- name: Enable API routes
+  shell: bin/setup system:config set main.api_disabled false
+  args:
+    chdir: /vagrant/
+
+- name: Create ElasticSearch indexes
+  shell: bin/console s:i:c
+  args:
+    chdir: /vagrant/


### PR DESCRIPTION
# Changelog
## Changes
- API SSL requirement is now disabled by default in Vagrant VM
- API is enabled by default in Vagrant VM
- API SSL required is enabled in sample configuration files
- API is disabled in sample configuration files
- Default ElasticSearch index is created during provisioning