### PR TITLE
Add search engine settings configuration during setup

### DIFF
--- a/lib/Alchemy/Phrasea/Command/Developer/IniReset.php
+++ b/lib/Alchemy/Phrasea/Command/Developer/IniReset.php
@@ -202,7 +202,8 @@ class IniReset extends Command
                 $credentials['password'],
                 $databox->get_dbname()
             );
-            $output->writeln('Mounting database "'.$databox->get_dbname().'"...<info>OK</info>');
+
+            $output->writeln('Mounting database "' . $databox->get_dbname() . '"...<info>OK</info>');
         }
 
         if ($input->getOption('run-patches') || false === $this->container['phraseanet.configuration']->isUpToDate()) {

--- a/lib/Alchemy/Phrasea/Controller/SetupController.php
+++ b/lib/Alchemy/Phrasea/Controller/SetupController.php
@@ -12,6 +12,7 @@ namespace Alchemy\Phrasea\Controller;
 
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Core\Connection\ConnectionSettings;
+use Alchemy\Phrasea\Setup\Installer;
 use Alchemy\Phrasea\Setup\RequirementCollectionInterface;
 use Alchemy\Phrasea\Setup\Requirements\BinariesRequirements;
 use Alchemy\Phrasea\Setup\Requirements\FilesystemRequirements;
@@ -154,6 +155,7 @@ class SetupController extends Controller
         $dataPath = $request->request->get('datapath_noweb');
 
         try {
+            /** @var Installer $installer */
             $installer = $this->app['phraseanet.installer'];
 
             $binaryData = [

--- a/lib/Alchemy/Phrasea/ControllerProvider/Admin/SearchEngine.php
+++ b/lib/Alchemy/Phrasea/ControllerProvider/Admin/SearchEngine.php
@@ -24,7 +24,7 @@ class SearchEngine implements ControllerProviderInterface, ServiceProviderInterf
     public function register(Application $app)
     {
         $app['controller.admin.search-engine'] = $app->share(function (PhraseaApplication $app) {
-            return new SearchEngineController($app);
+            return new SearchEngineController($app, $app['elasticsearch.management-service'], $app['form_factory']);
         });
     }
 

--- a/lib/Alchemy/Phrasea/Core/Connection/ConnectionSettings.php
+++ b/lib/Alchemy/Phrasea/Core/Connection/ConnectionSettings.php
@@ -6,6 +6,21 @@ class ConnectionSettings
 {
 
     /**
+     * @param array $configuration
+     * @return self
+     */
+    public static function fromArray(array $configuration)
+    {
+        return new self(
+            $configuration['host'],
+            $configuration['port'],
+            $configuration['user'],
+            $configuration['password'],
+            isset($configuration['dbname']) ? $configuration['dbname'] : ''
+        );
+    }
+
+    /**
      * @var string
      */
     protected $host;
@@ -33,11 +48,11 @@ class ConnectionSettings
     /**
      * @param string $host
      * @param int|null $port
-     * @param string $databaseName
      * @param string $user
      * @param string $password
+     * @param string $databaseName
      */
-    public function __construct($host, $port, $databaseName, $user, $password)
+    public function __construct($host, $port, $user, $password, $databaseName)
     {
         $this->host = (string) $host;
         $this->port = ((int) $port) > 0 ? (int) $port : null;
@@ -86,15 +101,23 @@ class ConnectionSettings
         return $this->password;
     }
 
+    /**
+     * @return array
+     */
     public function toArray()
     {
-        return [
-            'dbname' => $this->databaseName,
+        $settings = [
             'host' => $this->host,
             'port' => $this->port,
             'user' => $this->user,
             'password' => $this->password
         ];
+
+        if ($this->databaseName) {
+            $settings['dbname'] = $this->databaseName;
+        }
+
+        return $settings;
     }
 
 }

--- a/lib/Alchemy/Phrasea/Core/Provider/ORMServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/ORMServiceProvider.php
@@ -13,6 +13,8 @@ namespace Alchemy\Phrasea\Core\Provider;
 
 use Alchemy\Phrasea\Application as PhraseaApplication;
 use Alchemy\Phrasea\Core\Connection\ConnectionPoolManager;
+use Alchemy\Phrasea\Core\Connection\ConnectionSettings;
+use Alchemy\Phrasea\Databox\DataboxConnectionSettings;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
@@ -529,7 +531,15 @@ class ORMServiceProvider implements ServiceProviderInterface
         });
 
         // Returns a new DBALConnection instance using configuration parameters
-        $app['dbal.provider'] = $app->protect(function (array $info) use ($app) {
+        $app['dbal.provider'] = $app->protect(function ($info) use ($app) {
+            if ($info instanceof ConnectionSettings) {
+                $info = $info->toArray();
+            }
+
+            if (! is_array($info)) {
+                throw new \InvalidArgumentException('$info must be an array or a ConnectionSettings instance');
+            }
+
             $info = $app['db.info']($info);
 
             /** @var ConnectionPoolManager $manager */

--- a/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
@@ -13,6 +13,7 @@ namespace Alchemy\Phrasea\Core\Provider;
 
 use Alchemy\Phrasea\Controller\LazyLocator;
 use Alchemy\Phrasea\SearchEngine\Elastic\DataboxFetcherFactory;
+use Alchemy\Phrasea\SearchEngine\Elastic\ElasticSearchManagementService;
 use Alchemy\Phrasea\SearchEngine\Elastic\ElasticsearchOptions;
 use Alchemy\Phrasea\SearchEngine\Elastic\Index;
 use Alchemy\Phrasea\SearchEngine\Elastic\IndexLocator;
@@ -237,6 +238,10 @@ class SearchEngineServiceProvider implements ServiceProviderInterface
             }
 
             return $options;
+        });
+
+        $app['elasticsearch.management-service'] = $app->share(function ($app) {
+            return new ElasticSearchManagementService($app['elasticsearch.indexer'], $app['conf']);
         });
 
         return $app;

--- a/lib/Alchemy/Phrasea/Databox/DataboxConnectionSettings.php
+++ b/lib/Alchemy/Phrasea/Databox/DataboxConnectionSettings.php
@@ -2,85 +2,14 @@
 
 namespace Alchemy\Phrasea\Databox;
 
-class DataboxConnectionSettings
+use Alchemy\Phrasea\Core\Connection\ConnectionSettings;
+
+/**
+ * Class DataboxConnectionSettings
+ * @package Alchemy\Phrasea\Databox
+ * @deprecated Use ConnectionSettings instead
+ */
+class DataboxConnectionSettings extends ConnectionSettings
 {
-    /**
-     * @param array $configuration
-     * @return DataboxConnectionSettings
-     */
-    public static function fromArray(array $configuration)
-    {
-        return new self(
-            $configuration['host'],
-            $configuration['port'],
-            $configuration['user'],
-            $configuration['password']
-        );
-    }
-
-    /**
-     * @var string
-     */
-    private $host;
-
-    /**
-     * @var int
-     */
-    private $port;
-
-    /**
-     * @var string
-     */
-    private $user;
-
-    /**
-     * @var string
-     */
-    private $password;
-
-    /**
-     * @param string $host
-     * @param int $port
-     * @param string $user
-     * @param string $password
-     */
-    public function __construct($host, $port, $user, $password)
-    {
-        $this->host = $host;
-        $this->port = $port;
-        $this->user = $user;
-        $this->password = $password;
-    }
-
-    /**
-     * @return string
-     */
-    public function getHost()
-    {
-        return $this->host;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPort()
-    {
-        return $this->port;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUser()
-    {
-        return $this->user;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPassword()
-    {
-        return $this->password;
-    }
+    // Stub class for BC
 }

--- a/lib/Alchemy/Phrasea/Databox/DataboxService.php
+++ b/lib/Alchemy/Phrasea/Databox/DataboxService.php
@@ -4,6 +4,7 @@ namespace Alchemy\Phrasea\Databox;
 
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Core\Configuration\PropertyAccess;
+use Alchemy\Phrasea\Core\Connection\ConnectionSettings;
 use Alchemy\Phrasea\Model\Entities\User;
 use Doctrine\DBAL\Connection;
 
@@ -82,24 +83,18 @@ class DataboxService
         $databaseName,
         $dataTemplate,
         User $owner,
-        DataboxConnectionSettings $connectionSettings = null
+        ConnectionSettings $connectionSettings = null
     ) {
         $this->validateDatabaseName($databaseName);
 
         $dataTemplate = new \SplFileInfo($this->rootPath . '/lib/conf.d/data_templates/' . $dataTemplate . '.xml');
-        $connectionSettings = $connectionSettings ?: DataboxConnectionSettings::fromArray(
+        $connectionSettings = $connectionSettings ?: ConnectionSettings::fromArray(
             $this->configuration->get(['main', 'database'])
         );
 
         $factory = $this->connectionFactory;
         /** @var Connection $connection */
-        $connection = $factory([
-            'host' => $connectionSettings->getHost(),
-            'port' => $connectionSettings->getPort(),
-            'user' => $connectionSettings->getUser(),
-            'password' => $connectionSettings->getPassword(),
-            'dbname' => $databaseName
-        ]);
+        $connection = $factory($connectionSettings->toArray());
 
         $connection->connect();
 
@@ -121,7 +116,7 @@ class DataboxService
     {
         $this->validateDatabaseName($databaseName);
 
-        $connectionSettings = $connectionSettings ?: DataboxConnectionSettings::fromArray(
+        $connectionSettings = $connectionSettings ?: ConnectionSettings::fromArray(
             $this->configuration->get(['main', 'database'])
         );
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchManagementService.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchManagementService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic;
+
+use Alchemy\Phrasea\Core\Configuration\PropertyAccess;
+
+class ElasticSearchManagementService
+{
+    /**
+     * @var Indexer
+     */
+    private $indexer;
+
+    /**
+     * @var PropertyAccess
+     */
+    private $configuration;
+
+    /**
+     * @param Indexer $indexer
+     * @param PropertyAccess $configuration
+     */
+    public function __construct(Indexer $indexer, PropertyAccess $configuration)
+    {
+        $this->indexer = $indexer;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Creates all configured indices
+     */
+    public function createIndices()
+    {
+        if (! $this->indexer->indexExists()) {
+            $this->indexer->createIndex();
+        }
+    }
+
+    /**
+     * Drops all configured indices
+     */
+    public function dropIndices()
+    {
+        if ($this->indexer->indexExists()) {
+            $this->indexer->deleteIndex();
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function indexExists()
+    {
+        return $this->indexer->indexExists();
+    }
+
+    public function getCurrentConfiguration()
+    {
+        $options = ElasticsearchOptions::fromArray($this->configuration->get(['main', 'search-engine', 'options'], []));
+
+        if (empty($options->getIndexName())) {
+            $options->setIndexName(strtolower(sprintf(
+                'phraseanet_%s',
+                str_replace([ '/', '.' ], [ '', '' ], $this->configuration->get(['main', 'key']))
+            )));
+        }
+
+        return $options;
+    }
+
+    /**
+     * Updates the search engine server configuration
+     *
+     * @param ElasticsearchOptions $options
+     */
+    public function updateConfiguration(ElasticsearchOptions $options)
+    {
+        $this->configuration->set(['main', 'search-engine', 'options'], $options->toArray());
+    }
+}

--- a/lib/Alchemy/Phrasea/Setup/Installer.php
+++ b/lib/Alchemy/Phrasea/Setup/Installer.php
@@ -123,6 +123,7 @@ class Installer
 
             }
         }
+
         if (null !== $dbConn) {
             foreach ($databox->tables->table as $table) {
                 try {

--- a/lib/classes/appbox.php
+++ b/lib/classes/appbox.php
@@ -55,11 +55,11 @@ class appbox extends base
         $connection = $app['db.provider']($connectionConfig);
 
         $connectionSettings = new ConnectionSettings(
-            $connectionConfig['host'],
-            $connectionConfig['port'],
-            $connectionConfig['dbname'],
+            $connectionConfig['host'], 
+            $connectionConfig['port'], 
             $connectionConfig['user'],
-            $connectionConfig['password']
+            $connectionConfig['password'], 
+            $connectionConfig['dbname']
         );
 
         $versionRepository = new AppboxVersionRepository($connection);

--- a/lib/classes/databox.php
+++ b/lib/classes/databox.php
@@ -291,17 +291,14 @@ class databox extends base implements ThumbnailedElement
         $connectionConfig = $connectionConfigs[$sbas_id];
         $connection = $app['db.provider']($connectionConfig);
 
-        $connectionSettings = new ConnectionSettings(
-            $connectionConfig['host'],
-            $connectionConfig['port'],
-            $connectionConfig['dbname'],
-            $connectionConfig['user'],
-            $connectionConfig['password']
-        );
-
         $versionRepository = new DataboxVersionRepository($connection);
 
-        parent::__construct($app, $connection, $connectionSettings, $versionRepository);
+        parent::__construct(
+            $app, 
+            $connection, 
+            ConnectionSettings::fromArray($connectionConfig),
+            $versionRepository
+        );
 
         $this->loadFromRow($row);
     }

--- a/templates/web/admin/search-engine/elastic-search.html.twig
+++ b/templates/web/admin/search-engine/elastic-search.html.twig
@@ -12,11 +12,6 @@
 {% block javascript %}
 <script type="text/javascript" src="{{ path('minifier', { 'f' : '/scripts/apps/admin/search-engine/views/es_config.js' }) }}"></script>
 <script type="text/javascript">
-    {% if indexer.indexExists() %}
-    var elasticSearchIndexExists = true;
-    {% else %}
-    var elasticSearchIndexExists = false;
-    {% endif %}
-    searchEngineConfigurationFormInit(elasticSearchIndexExists);
+    searchEngineConfigurationFormInit({{ elasticSearchIndexExists ? 'true' : 'false' }});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Changelog
### Changed
  - Extract a management service for search engine settings from the search engine admin controller

### Adds
  - PHRAS-1242: Search engine settings are not configurable during setup
