### PR TITLE
#PHRAS-1277_substitution-event_3.8

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Event/MediaSubstituted.php
+++ b/lib/Alchemy/Phrasea/Core/Event/MediaSubstituted.php
@@ -15,18 +15,26 @@ use Symfony\Component\EventDispatcher\Event as SfEvent;
 use record_adapter;
 
 
-class RecordDocumentSubstituted extends SfEvent
+class MediaSubstituted extends SfEvent
 {
     /** @var  record_adapter */
     private $record;
+    /** @var  string */
+    private $subdefName;
 
-    public function __construct(record_adapter $record)
+    public function __construct(record_adapter $record, $subdefName)
     {
         $this->record = $record;
+        $this->subdefName = $subdefName;
     }
 
     public function getRecord()
     {
         return $this->record;
+    }
+
+    public function getName()
+    {
+        return $this->subdefName;
     }
 }

--- a/lib/Alchemy/Phrasea/Core/PhraseaEvents.php
+++ b/lib/Alchemy/Phrasea/Core/PhraseaEvents.php
@@ -29,7 +29,8 @@ final class PhraseaEvents
     const STATUS_CHANGED = 'record.status.changed';
     const STORY_COVER_CHANGED = 'record.story_cover.changed';
     const RECORD_CREATED = 'record.created';
-    const RECORD_DOCUMENT_SUBSTITUTED = 'record.document.substituted';
+
+    const MEDIA_SUBSTITUTED = 'media.substituted';
 
     const ACCOUNT_DELETED = 'account.deleted';
     const ACCOUNT_CREATED = 'account.created';

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -13,7 +13,7 @@ use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Border\File;
 use Alchemy\Phrasea\Core\Event\StatusChanged;
 use Alchemy\Phrasea\Core\Event\RecordCreated;
-use Alchemy\Phrasea\Core\Event\RecordDocumentSubstituted;
+use Alchemy\Phrasea\Core\Event\MediaSubstituted;
 use Alchemy\Phrasea\Core\PhraseaEvents;
 use Alchemy\Phrasea\Metadata\Tag\TfFilename;
 use Alchemy\Phrasea\Metadata\Tag\TfBasename;
@@ -993,7 +993,7 @@ class record_adapter implements record_Interface, cache_cacheableInterface
             $this->rebuild_subdefs();
         }
 
-        $this->dispatch(PhraseaEvents::RECORD_DOCUMENT_SUBSTITUTED, new RecordDocumentSubstituted($this));
+        $this->dispatch(PhraseaEvents::MEDIA_SUBSTITUTED, new MediaSubstituted($this, $name));
 
         return $this;
     }

--- a/tmp/cache/profiler/.gitignore
+++ b/tmp/cache/profiler/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Changelog

### Changed
  - RECORD_DOCUMENT_SUBSTITUTED changed to MEDIA_SUBSTITUTED to better conform with 4.0
  
### Adds
  - name of subdef to MEDIA_SUBSTITUTED event parms