### PR TITLE
PHRAS-1279_SUBSTITUTE-UNKNOWN-TYPE

### DIFF
--- a/lib/Alchemy/Phrasea/Media/MediaTypeFactory.php
+++ b/lib/Alchemy/Phrasea/Media/MediaTypeFactory.php
@@ -30,6 +30,8 @@ class MediaTypeFactory
                 return new Type\Document();
             case Type\Type::TYPE_FLASH:
                 return new Type\Flash();
+            case Type\Type::TYPE_UNKNOWN:
+                return new Type\Unknown();
         }
 
         throw new \RuntimeException('Could not create requested media type');

--- a/lib/Alchemy/Phrasea/Media/Subdef/Subdef.php
+++ b/lib/Alchemy/Phrasea/Media/Subdef/Subdef.php
@@ -20,6 +20,7 @@ interface Subdef
     const TYPE_VIDEO = 'video';
     const TYPE_AUDIO = 'audio';
     const TYPE_FLEXPAPER = 'flexpaper';
+    const TYPE_UNKNOWN = 'unknown';
 
     /**
      * One of Subdef Type const

--- a/lib/Alchemy/Phrasea/Media/Subdef/Unknown.php
+++ b/lib/Alchemy/Phrasea/Media/Subdef/Unknown.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Phraseanet
+ *
+ * (c) 2005-2016 Alchemy
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Alchemy\Phrasea\Media\Subdef;
+
+use MediaAlchemyst\Specification\Image as ImageSpecification;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class Unknown extends Provider
+{
+    const OPTION_SIZE = 'size';
+    const OPTION_RESOLUTION = 'resolution';
+    const OPTION_STRIP = 'strip';
+    const OPTION_QUALITY = 'quality';
+    const OPTION_FLATTEN = 'flatten';
+    const OPTION_ICODEC = 'icodec';
+
+    protected $options = [];
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+
+        $this->registerOption(new OptionType\Range($this->translator->trans('Dimension'), self::OPTION_SIZE, 20, 3000, 800));
+        $this->registerOption(new OptionType\Range($this->translator->trans('Resolution'), self::OPTION_RESOLUTION, 50, 300, 72));
+        $this->registerOption(new OptionType\Boolean($this->translator->trans('Remove ICC Profile'), self::OPTION_STRIP, false));
+        $this->registerOption(new OptionType\Boolean($this->translator->trans('Flatten layers'), self::OPTION_FLATTEN, false));
+        $this->registerOption(new OptionType\Range($this->translator->trans('Quality'), self::OPTION_QUALITY, 0, 100, 75));
+        $this->registerOption(new OptionType\Enum('Image Codec', self::OPTION_ICODEC, array('jpeg', 'png', 'tiff'), 'jpeg'));
+    }
+
+    public function getType()
+    {
+        return self::TYPE_IMAGE;
+    }
+
+    public function getDescription()
+    {
+        return $this->translator->trans('Generates an image');
+    }
+
+    public function getMediaAlchemystSpec()
+    {
+        if (! $this->spec) {
+            $this->spec = new ImageSpecification();
+        }
+
+        $size = $this->getOption(self::OPTION_SIZE)->getValue();
+        $resolution = $this->getOption(self::OPTION_RESOLUTION)->getValue();
+
+        $this->spec->setImageCodec($this->getOption(self::OPTION_ICODEC)->getValue());
+        $this->spec->setResizeMode(ImageSpecification::RESIZE_MODE_INBOUND_FIXEDRATIO);
+        $this->spec->setDimensions($size, $size);
+        $this->spec->setQuality($this->getOption(self::OPTION_QUALITY)->getValue());
+        $this->spec->setStrip($this->getOption(self::OPTION_STRIP)->getValue());
+        $this->spec->setFlatten($this->getOption(self::OPTION_FLATTEN)->getValue());
+        $this->spec->setResolution($resolution, $resolution);
+
+        return $this->spec;
+    }
+}

--- a/lib/Alchemy/Phrasea/Media/Type/Unknown.php
+++ b/lib/Alchemy/Phrasea/Media/Type/Unknown.php
@@ -11,14 +11,11 @@
 
 namespace Alchemy\Phrasea\Media\Type;
 
-interface Type
+class Unknown implements Type
 {
-    const TYPE_AUDIO = 'audio';
-    const TYPE_VIDEO = 'video';
-    const TYPE_DOCUMENT = 'document';
-    const TYPE_FLASH = 'flash';
-    const TYPE_IMAGE = 'image';
-    const TYPE_UNKNOWN = 'unknown';
 
-    public function getType();
+    public function getType()
+    {
+        return self::TYPE_UNKNOWN;
+    }
 }

--- a/lib/classes/databox/subdef.php
+++ b/lib/classes/databox/subdef.php
@@ -14,6 +14,7 @@ use Alchemy\Phrasea\Media\Subdef\Audio;
 use Alchemy\Phrasea\Media\Subdef\Video;
 use Alchemy\Phrasea\Media\Subdef\FlexPaper;
 use Alchemy\Phrasea\Media\Subdef\Gif;
+use Alchemy\Phrasea\Media\Subdef\Unknown;
 use Alchemy\Phrasea\Media\Subdef\Subdef as SubdefSpecs;
 use Alchemy\Phrasea\Media\Type\Type as SubdefType;
 use MediaAlchemyst\Specification\SpecificationInterface;
@@ -46,6 +47,7 @@ class databox_subdef
         SubdefType::TYPE_FLASH => [SubdefSpecs::TYPE_IMAGE],
         SubdefType::TYPE_IMAGE => [SubdefSpecs::TYPE_IMAGE],
         SubdefType::TYPE_VIDEO => [SubdefSpecs::TYPE_IMAGE, SubdefSpecs::TYPE_VIDEO, SubdefSpecs::TYPE_ANIMATION],
+        SubdefType::TYPE_UNKNOWN => [SubdefSpecs::TYPE_IMAGE],
     ];
 
     const CLASS_THUMBNAIL = 'thumbnail';
@@ -105,6 +107,9 @@ class databox_subdef
                 break;
             case SubdefSpecs::TYPE_FLEXPAPER:
                 $this->subdef_type = $this->buildFlexPaperSubdef($sd);
+                break;
+            case SubdefSpecs::TYPE_UNKNOWN:
+                $this->subdef_type = $this->buildImageSubdef($sd);
                 break;
         }
     }
@@ -228,6 +233,9 @@ class databox_subdef
                             break;
                         case SubdefSpecs::TYPE_VIDEO:
                             $mediatype_obj = new Video($this->translator);
+                            break;
+                        case SubdefSpecs::TYPE_UNKNOWN:
+                            $mediatype_obj = new Unknown($this->translator);
                             break;
                         default:
                             continue;


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1279: a "unknown"-type document can get subdefs substituted via API

### Adds
  -  added type "unknown" to subviews setup so an "unknown"-type document can have substituted subdefs