### PR TITLE
PHRAS-828_CTERMS-NOT-PURGED

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer.php
@@ -142,6 +142,7 @@ class Indexer
             }
 
             if ($what & self::RECORDS) {
+                $databox->clearCandidates();
                 $this->recordIndexer->populateIndex($bulk, $databox);
 
                 // Final flush


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-828: cterms are cleared before reindexation (admin button) or populate (cli) ; terms in "stock" are preserved.
 nb.: rejected terms (red) are also purged so a term may pop-up again as candidate even if it had been rejected before.