### PR TITLE
PHRAS-1155_UPDATE-3.8-4.0-FAILS

### DIFF
--- a/lib/Alchemy/Phrasea/Setup/DoctrineMigrations/OrderMigration.php
+++ b/lib/Alchemy/Phrasea/Setup/DoctrineMigrations/OrderMigration.php
@@ -11,6 +11,7 @@
 
 namespace Alchemy\Phrasea\Setup\DoctrineMigrations;
 
+use Alchemy\Phrasea\Model\Entities\Order;
 use Doctrine\DBAL\Schema\Schema;
 
 class OrderMigration extends AbstractMigration
@@ -23,6 +24,8 @@ class OrderMigration extends AbstractMigration
     public function doUpSql(Schema $schema)
     {
         $this->addSql("CREATE TABLE Orders (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, basket_id INT DEFAULT NULL, order_usage VARCHAR(2048) NOT NULL, todo INT DEFAULT NULL, deadline DATETIME NOT NULL, created_on DATETIME NOT NULL, INDEX IDX_E283F8D8A76ED395 (user_id), UNIQUE INDEX UNIQ_E283F8D81BE1FB52 (basket_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
+        $this->addSql(sprintf("ALTER TABLE Orders ADD COLUMN notification_method VARCHAR(32) NOT NULL DEFAULT '%s'", Order::NOTIFY_MAIL));
+        $this->addSql("ALTER TABLE Orders ALTER COLUMN notification_method DROP DEFAULT");
         $this->addSql("CREATE TABLE OrderElements (id INT AUTO_INCREMENT NOT NULL, order_master INT DEFAULT NULL, order_id INT DEFAULT NULL, base_id INT NOT NULL, record_id INT NOT NULL, deny TINYINT(1) DEFAULT NULL, INDEX IDX_8C7066C8EE86B303 (order_master), INDEX IDX_8C7066C88D9F6D38 (order_id), UNIQUE INDEX unique_ordercle (base_id, record_id, order_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
         $this->addSql("ALTER TABLE Orders ADD CONSTRAINT FK_E283F8D8A76ED395 FOREIGN KEY (user_id) REFERENCES Users (id)");
         $this->addSql("ALTER TABLE Orders ADD CONSTRAINT FK_E283F8D81BE1FB52 FOREIGN KEY (basket_id) REFERENCES Baskets (id)");

--- a/lib/Alchemy/Phrasea/Setup/DoctrineMigrations/Version20160511160640.php
+++ b/lib/Alchemy/Phrasea/Setup/DoctrineMigrations/Version20160511160640.php
@@ -18,9 +18,7 @@ class Version20160511160640 extends BaseMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql(sprintf("ALTER TABLE Orders ADD COLUMN notification_method VARCHAR(32) NOT NULL DEFAULT '%s'", Order::NOTIFY_MAIL));
-        $this->addSql("ALTER TABLE Orders ALTER COLUMN notification_method DROP DEFAULT");
+        // no-op
     }
 
     /**
@@ -30,7 +28,6 @@ class Version20160511160640 extends BaseMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
-        $this->addSql("ALTER TABLE Orders DROP COLUMN notification_method");
+        // no-op
     }
 }

--- a/lib/classes/patch/390alpha1a.php
+++ b/lib/classes/patch/390alpha1a.php
@@ -83,10 +83,7 @@ class patch_390alpha1a extends patchAbstract
         $em->getEventManager()->removeEventSubscriber(new TimestampableListener());
 
         foreach ($rs as $row) {
-            $sql = 'SELECT count(id) as todo
-                    FROM order_elements
-                    WHERE deny = NULL
-                        AND order_id = :id';
+            $sql = "SELECT count(id) as todo FROM order_elements WHERE deny = NULL AND order_id = :id";
 
             $stmt = $conn->prepare($sql);
             $stmt->execute([':id' => $row['id']]);
@@ -116,9 +113,7 @@ class patch_390alpha1a extends patchAbstract
 
             $em->persist($order);
 
-            $sql = 'SELECT base_id, record_id, order_master_id, deny
-                    FROM order_elements
-                    WHERE order_id = :id';
+            $sql = "SELECT base_id, record_id, order_master_id, deny FROM order_elements WHERE order_id = :id";
 
             $stmt = $conn->prepare($sql);
             $stmt->execute([':id' => $row['id']]);


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1155 : The patch "OrderMigration" is fixed (the new column "Orders.notification_method" creation (2016...) is moved to an older patch (2013...) since this patch runs on 2016 orm object "Orders").