### PR TITLE
PHRAS-1284_MAX-DURATION-TASK-PARAMETER

### DIFF
--- a/lib/Alchemy/Phrasea/TaskManager/Editor/SubdefsEditor.php
+++ b/lib/Alchemy/Phrasea/TaskManager/Editor/SubdefsEditor.php
@@ -53,6 +53,7 @@ class SubdefsEditor extends AbstractEditor
   <flush>5</flush>
   <maxrecs>20</maxrecs>
   <maxmegs>256</maxmegs>
+  <maxduration>3600</maxduration>
 </tasksettings>
 EOF;
     }

--- a/lib/Alchemy/Phrasea/TaskManager/TaskList.php
+++ b/lib/Alchemy/Phrasea/TaskManager/TaskList.php
@@ -49,6 +49,17 @@ class TaskList implements TaskListInterface
             $arguments[] = $this->phpConf;
         }
 
+        $maxmegs     = 128;     // default (Mo) if not set in xml
+        $maxduration = 1800;    // default (seconds) if not set in xml
+        if( ($sxSettings = @simplexml_load_string($task->getSettings())) ) {
+            if( ($v = (int)($sxSettings->maxmegs)) && $v > 0) {
+                $maxmegs = $v;
+            }
+            if( ($v = (int)($sxSettings->maxduration)) && $v > 0) {
+                $maxduration = $v;
+            }
+        }
+
         $arguments[] = '-f';
         $arguments[] = $this->root . '/bin/console';
         $arguments[] = '--';
@@ -57,9 +68,9 @@ class TaskList implements TaskListInterface
         $arguments[] = $task->getId();
         $arguments[] = '--listen-signal';
         $arguments[] = '--max-duration';
-        $arguments[] = '1800';
+        $arguments[] = $maxduration;
         $arguments[] = '--max-memory';
-        $arguments[] = 128 << 20;
+        $arguments[] = $maxmegs << 20;
 
         $builder = ProcessBuilder::create($arguments);
         $builder->setTimeout(0);


### PR DESCRIPTION
## Changelog

### Change
  - default subdef task has a maxduration of 3600 sec (1h)

### Adds
  - parameters "maxmeg" and "maxduration" (if present) in xml task settings are passed to task:run as --max-memory and --max-duration