### PR TITLE
PHRAS-1300_TRONCATURE_MASTER

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
@@ -185,7 +185,7 @@ class QueryController extends Controller
             $json['results'] = $this->render($template, ['results'=> $result]);
 
             /** Debug */
-            $json['parsed_query'] = $result->getEngineQuery();
+            $json['parsed_query'] = json_encode($result->getEngineQuery());
             /** End debug */
 
             $fieldLabels = [

--- a/lib/Alchemy/Phrasea/Search/V1SearchTransformer.php
+++ b/lib/Alchemy/Phrasea/Search/V1SearchTransformer.php
@@ -36,7 +36,7 @@ abstract class V1SearchTransformer extends TransformerAbstract
                     return $suggestion->toArray();
                 }, $result->getSuggestions()->toArray()),
             'facets' => $result->getFacets(),
-            'query' => $result->getEngineQuery(),
+            'query' => json_encode($result->getEngineQuery()),
         ];
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
@@ -20,7 +20,7 @@ class QuotedTextNode extends Node
         $query_builder = function (array $fields) use ($context) {
             $index_fields = [];
             foreach ($fields as $field) {
-                foreach ($context->localizeField($field) as $f) {
+                foreach ($context->localizeField($field, false) as $f) {    // false: don't includeEdgeNgram
                     $index_fields[] = $f;
                 }
             }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -42,7 +42,7 @@ class TextNode extends AbstractTermNode implements ContextAbleInterface
             // Full text
             $index_fields = [];
             foreach (ValueChecker::filterByValueCompatibility($fields, $this->text) as $field) {
-                foreach ($context->localizeField($field) as $f) {
+                foreach ($context->localizeField($field, true) as $f) {     // true: includeEdgeNgram
                     $index_fields[] = $f;
                 }
             }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -303,16 +303,16 @@ class ElasticSearchEngine implements SearchEngineInterface
         /** @var FacetsResponse $facets */
         $facets = $this->facetsResponseFactory->__invoke($res);
 
-        $query['ast'] = $query_compiler->parse($string)->dump();
-        $query['query_main'] = $recordQuery;
-        $query['query'] = $params['body'];
-        $query['query_string'] = json_encode($params['body']);
-
         return new SearchEngineResult(
             $options,
             $results,   // ArrayCollection of results
             $string,    // the query as typed by the user
-            json_encode($query),
+            [           // the query by the search engine
+                'ast' => $query_compiler->parse($string)->dump(),
+                'query_main' => $recordQuery,
+                'query' => $params['body'],
+                'query_string' => json_encode($params['body'])
+            ],
             $res['took'],   // duration
             $options->getFirstResult(),
             $res['hits']['total'],  // available

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Index.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Index.php
@@ -90,6 +90,16 @@ class Index
                     // TODO Maybe replace nfkc_normalizer + asciifolding with icu_folding
                     'filter' => ['nfkc_normalizer', 'asciifolding']
                 ],
+                'my_edge_ngram_analyzer' => [
+                    'type'      => 'custom',
+                    'tokenizer' => 'my_edge_ngram_tokenizer',
+                    'filter'    => ['lowercase', 'stop', 'kstem']
+                ],
+                'my_edge_ngram_analyzer#search' => [
+                    'type'      => 'custom',
+                    'tokenizer' => 'standard',
+                    'filter'    => ['lowercase', 'stop', 'kstem']
+                ],
                 // Lang specific
                 'fr_full' => [
                     'type' => 'custom',
@@ -145,6 +155,12 @@ class Index
                 ]
             ],
             'tokenizer' => [
+                'my_edge_ngram_tokenizer' => [
+                    "type" => "edgeNGram",
+                    "min_gram" => "2",
+                    "max_gram" => "15",
+                    "token_chars" => [ "letter", "digit" ]
+                ],
                 'thesaurus_path' => [
                     'type' => 'path_hierarchy'
                 ]

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Mapping/StringFieldMapping.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Mapping/StringFieldMapping.php
@@ -55,8 +55,13 @@ class StringFieldMapping extends ComplexFieldMapping
     {
         $child = new StringFieldMapping('light');
         $child->setAnalyzer('general_light');
-
         $this->addChild($child);
+
+        $child = new StringFieldMapping('engram');
+        $child->setAnalyzer('my_edge_ngram_analyzer', 'indexing');
+        $child->setAnalyzer('my_edge_ngram_analyzer#search', 'searching');
+        $this->addChild($child);
+
         $this->addLocalizedChildren($locales);
 
         return $this;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
@@ -98,18 +98,18 @@ class QueryContext
     /**
      * @todo Maybe we should put this logic in Field class?
      */
-    public function localizeField(Field $field)
+    public function localizeField(Field $field, $includeEdgeNgram)
     {
         $index_field = $field->getIndexField();
 
         if ($field->getType() === FieldMapping::TYPE_STRING) {
-            return $this->localizeFieldName($index_field);
+            return $this->localizeFieldName($index_field, $includeEdgeNgram);
         } else {
             return [$index_field];
         }
     }
 
-    private function localizeFieldName($field)
+    private function localizeFieldName($field, $includeEdgeNgram)
     {
         $fields = array();
         foreach ($this->locales as $locale) {
@@ -119,6 +119,9 @@ class QueryContext
 
         // TODO Put generic analyzers on main field instead of "light" sub-field
         $fields[] = sprintf('%s.light^10', $field);
+        if($includeEdgeNgram) {
+            $fields[] = sprintf('%s.engram', $field);
+        }
 
         return $fields;
     }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineResultTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineResultTest.php
@@ -24,7 +24,7 @@ class SearchEngineResultTest extends \PhraseanetTestCase
                 ]);
 
         $user_query = 'Gotainer';
-        $engine_query = '{text:"Gotainer"}';    // fake, real is really more complex
+        $engine_query = ['text' => "Gotainer"];    // fake, real is really more complex
         $duration = 1 / 3;
         $offsetStart = 23;
         $available = 25;
@@ -63,7 +63,7 @@ class SearchEngineResultTest extends \PhraseanetTestCase
                 ]);
 
         $user_query = 'Gotainer';
-        $engine_query = '{text:"Gotainer"}';    // fake, real is really more complex
+        $engine_query = ['text' => "Gotainer"];    // fake, real is really more complex
         $duration = 1 / 3;
         $offsetStart = 0;
         $available = 25;

--- a/tests/classes/PhraseanetAuthenticatedWebTestCase.php
+++ b/tests/classes/PhraseanetAuthenticatedWebTestCase.php
@@ -210,7 +210,7 @@ abstract class PhraseanetAuthenticatedWebTestCase extends \PhraseanetAuthenticat
             new SearchEngineOptions(),
             new ArrayCollection([$elasticsearchRecord]), // Records
             '', // Query as user typed
-            '{}', // Query as engine parsed
+            [], // Query as engine parsed (fake)
             0, // Duration
             0, // offsetStart
             1, // available


### PR DESCRIPTION
## Changelog

### Adds
  - PHRAS-1300: search with the beginning of a word, ex. car finds car, carousel, caramel...
"car" (with quotes) only searches "car"

### Fix
  - The "searchengineresults" object now contains php query to ease debugging of es query (not double json encoding anymore)
 
