### PR TITLE
PHRAS-1205_DOUBLE-EXTENSIONS_4.0_redo

### DIFF
--- a/lib/classes/set/export.php
+++ b/lib/classes/set/export.php
@@ -386,36 +386,37 @@ class set_export extends set_abstract
     /**
      * @param User $user
      * @param Filesystem $filesystem
-     * @param array $subdefs
-     * @param bool $rename_title
-     * @param bool $includeBusinessFields
+     * @param array $wantedSubdefs
+     * @param $rename_title
+     * @param $includeBusinessFields
      * @return array
      * @throws Exception
      */
-    public function prepare_export(User $user, Filesystem $filesystem, array $subdefs, $rename_title, $includeBusinessFields)
+    public function prepare_export(User $user, Filesystem $filesystem, Array $wantedSubdefs, $rename_title, $includeBusinessFields)
     {
-        if (!is_array($subdefs)) {
+        if (!is_array($wantedSubdefs)) {
             throw new Exception('No subdefs given');
         }
 
         $includeBusinessFields = (bool) $includeBusinessFields;
-        $files = [];
+        $files = array();
         $n_files = 0;
-        $file_names = [];
+        $file_names = array();
         $size = 0;
-        $unicode = new \unicode();
+        $unicode = $this->app['unicode'];
 
         /** @var record_exportElement $download_element */
-        foreach ($this->get_elements() as $download_element) {
+        foreach ($this->elements as $download_element) {
+
             $id = count($files);
 
-            $files[$id] = [
-                'base_id' => $download_element->getBaseId(),
-                'record_id' => $download_element->getRecordId(),
+            $files[$id] = array(
+                'base_id'       => $download_element->get_base_id(),
+                'record_id'     => $download_element->get_record_id(),
                 'original_name' => '',
-                'export_name' => '',
-                'subdefs' => [],
-            ];
+                'export_name'   => '',
+                'subdefs'       => array()
+            );
 
             $BF = false;
 
@@ -423,263 +424,229 @@ class set_export extends set_abstract
                 $BF = true;
             }
 
-            $desc = $this->app['serializer.caption']->serialize($download_element->get_caption(), CaptionSerializer::SERIALIZE_XML, $BF);
+            // $original_name : the original_name WITHOUT extension (ex. "DSC_1234")
+            // $extension     : the extension WITHOUT DOT (ex. "jpg")
+            // $export_name   : the export name WITHOUT extension, (ex. "Hollydays_2016_DSC_1234")
 
-            $files[$id]['original_name'] =
-            $files[$id]['export_name'] =
-                $download_element->get_original_name(false);
+            //
+            // build the original_name
+            //
+            $original_name = trim($download_element->get_original_name(false));   // false: don't remove extension
+            if($original_name !== '') {
+                $infos = pathinfo($original_name);  // pathinfo DOES USE the last '.' to find extension
+                $original_name = $infos['filename'];
+                $extension = isset($infos['extension']) ? $infos['extension'] : '';
+            }
+            else {
+                $extension = '';
+            }
+            if($original_name == '') {
+                $original_name = (string)$id;
+            }
+            $files[$id]['original_name'] = $original_name;
 
-            $files[$id]['original_name'] =
-                trim($files[$id]['original_name']) != '' ?
-                    $files[$id]['original_name'] : $id;
-
-            $infos = pathinfo($files[$id]['original_name']);
-
-            $extension = isset($infos['extension']) ? $infos['extension'] :
-                substr($files[$id]['original_name'], 0 - strrpos($files[$id]['original_name'], '.'));
-
+            //
+            // build the export_name
+            //
             if ($rename_title) {
-                $title = strip_tags($download_element->get_title(['removeExtension' => true]));
-                $files[$id]['export_name'] = $unicode->remove_nonazAZ09($title, true, true, true);
+                // use the title (may be a concat of fields)
+                $export_name = strip_tags($download_element->get_title(['removeExtension' => true]));
+                // if the "title" ends up with a "filename-like" field, remove extension
+                if (strtolower(substr($export_name, -strlen($extension)-1)) === '.'.strtolower($extension)) {
+                    $export_name = substr($export_name, 0, strlen($export_name)-1-strlen($extension));
+                }
             } else {
-                $files[$id]["export_name"] = $infos['filename'];
+                $export_name = $original_name;
             }
 
-            if (substr(strrev($files[$id]['export_name']), 0, strlen($extension)) != strrev($extension)) {
-                $files[$id]['export_name'] .= '.' . $extension;
+            // cleanup the exportname so it can be used as a filename (even if it came from the originale_name)
+            $export_name = str_replace([' ', "\t", "\r", "\n"], '_', $export_name);
+            $export_name = $unicode->remove_nonazAZ09($export_name, true, true, true);  // keep '_', '-', '.'
+            // really no luck if nothing left
+            if($export_name == '') {
+                $export_name = (string)$id;
             }
 
-            $sizeMaxAjout = 0;
-            $sizeMaxExt = 0;
-
-            foreach ($download_element->get_downloadable() as $name => $properties) {
-                if ($properties === false || !in_array($name, $subdefs)) {
+            //
+            // loop on subdefs to be downloaded (this may change the export_name)
+            //
+            $sizeMaxAjout = $sizeMaxExt = 0;
+            $sd = $download_element->get_subdefs();
+            foreach ($download_element->get_downloadable() as $subdefName => $properties) {
+                if ($properties === false || !in_array($subdefName, $wantedSubdefs)) {
+                    continue;
+                }
+                if (!in_array($subdefName, ['caption', 'caption-yaml']) && !isset($sd[$subdefName])) {
                     continue;
                 }
 
-                $subdef = null;
-                if (!in_array($name, ['caption', 'caption-yaml'])) {
-                    try {
-                        // get_subdef() can throw a 404
-                        $subdef = $download_element->get_subdef($name);
-                    }
-                    catch(\Exception $e) {
-                        continue;
-                    }
-                }
-
                 set_time_limit(100);
-                $subdef_export = $subdef_alive = false;
+                $subdef_ok = false;
 
                 $n_files++;
 
-                $tmp_pathfile = ['path' => null, 'file' => null];
+                $tmp_pathfile = [
+                    'path' => null,
+                    'file' => null
+                ];
 
                 switch ($properties['class']) {
                     case 'caption':
                     case 'caption-yaml':
-                        $subdef_export = true;
-                        $subdef_alive = true;
+                        $subdef_ok = true;
                         break;
                     case 'thumbnail':
+                        $subdef_ok = true;
                         $tmp_pathfile = [
-                            'path' => $subdef->get_path(),
-                            'file' => $subdef->get_file(),
+                            'path' => $sd[$subdefName]->get_path(),
+                            'file' => $sd[$subdefName]->get_file()
                         ];
-                        $subdef_export = true;
-                        $subdef_alive = true;
                         break;
                     case 'document':
-                        $subdef_export = true;
-                        $path = \recordutils_image::stamp($this->app, $subdef);
+                        $subdef_ok = true;
                         $tmp_pathfile = [
-                            'path' => $subdef->get_path(),
-                            'file' => $subdef->get_file(),
+                            'path' => $sd[$subdefName]->get_path(),
+                            'file' => $sd[$subdefName]->get_file()
                         ];
+                        $path = \recordutils_image::stamp($this->app , $sd[$subdefName]);
                         if (file_exists($path)) {
                             $tmp_pathfile = [
                                 'path' => dirname($path),
-                                'file' => basename($path),
+                                'file' => basename($path)
                             ];
-                            $subdef_alive = true;
                         }
                         break;
-
                     case 'preview':
-                        $subdef_export = true;
-
                         $tmp_pathfile = [
-                            'path' => $subdef->get_path(),
-                            'file' => $subdef->get_file(),
+                            'path' => $sd[$subdefName]->get_path(),
+                            'file' => $sd[$subdefName]->get_file()
                         ];
+
                         if (!$this->app->getAclForUser($user)->has_right_on_base($download_element->getBaseId(), \ACL::NOWATERMARK)
                             && !$this->app->getAclForUser($user)->has_preview_grant($download_element)
-                            && $subdef->get_type() == media_subdef::TYPE_IMAGE
-                        ) {
-                            $path = recordutils_image::watermark($this->app, $subdef);
+                            && $sd[$subdefName]->get_type() == media_subdef::TYPE_IMAGE )
+                        {
+                            $path = recordutils_image::watermark($this->app, $sd[$subdefName]);
                             if (file_exists($path)) {
                                 $tmp_pathfile = [
                                     'path' => dirname($path),
-                                    'file' => basename($path),
+                                    'file' => basename($path)
                                 ];
-                                $subdef_alive = true;
+                                $subdef_ok = true;
                             }
-                        } else {
-                            $subdef_alive = true;
+                        }
+                        else {
+                            $subdef_ok = true;
                         }
                         break;
                 }
 
-                if ($subdef_export === true && $subdef_alive === true) {
+                if ($subdef_ok) {
                     switch ($properties['class']) {
                         case 'caption':
-                            if ($name == 'caption-yaml') {
-                                $suffix = '_captionyaml';
-                                $extension = 'yml';
-                                $mime = 'text/x-yaml';
+                            $ajout = '_caption';
+                            if ($subdefName == 'caption-yaml') {
+                                $ext = 'txt';
+                                $mime = 'text/plain';
                             } else {
-                                $suffix = '_caption';
-                                $extension = 'xml';
+                                $ext = 'xml';
                                 $mime = 'text/xml';
                             }
 
-                            $files[$id]["subdefs"][$name]["ajout"] = $suffix;
-                            $files[$id]["subdefs"][$name]["exportExt"] = $extension;
-                            $files[$id]["subdefs"][$name]["label"] = $properties['label'];
-                            $files[$id]["subdefs"][$name]["path"] = null;
-                            $files[$id]["subdefs"][$name]["file"] = null;
-                            $files[$id]["subdefs"][$name]["size"] = 0;
-                            $files[$id]["subdefs"][$name]["folder"] = $download_element->get_directory();
-                            $files[$id]["subdefs"][$name]["mime"] = $mime;
+                            $files[$id]["subdefs"][$subdefName]["ajout"] = $ajout;
+                            $files[$id]["subdefs"][$subdefName]["exportExt"] = $ext;
+                            $files[$id]["subdefs"][$subdefName]["label"] = $properties['label'];
+                            $files[$id]["subdefs"][$subdefName]["path"] = null;
+                            $files[$id]["subdefs"][$subdefName]["file"] = null;
+                            $files[$id]["subdefs"][$subdefName]["size"] = 0;
+                            $files[$id]["subdefs"][$subdefName]["mime"] = $mime;
+                            $files[$id]["subdefs"][$subdefName]["folder"] = $download_element->get_directory();
 
                             break;
+
                         case 'document':
                         case 'preview':
                         case 'thumbnail':
-                            $infos = pathinfo(p4string::addEndSlash($tmp_pathfile["path"]) .
-                                $tmp_pathfile["file"]);
+                            $ajout = $subdefName == 'document' ? '' : ("_" . $subdefName);
+                            $infos = pathinfo(p4string::addEndSlash($tmp_pathfile["path"]) . $tmp_pathfile["file"]);
+                            $ext = isset($infos['extension']) ? $infos['extension'] : '';
 
-                            $files[$id]["subdefs"][$name]["ajout"] = $name == 'document' ? '' : "_" . $name;
-                            $files[$id]["subdefs"][$name]["path"] = $tmp_pathfile["path"];
-                            $files[$id]["subdefs"][$name]["file"] = $tmp_pathfile["file"];
-                            $files[$id]["subdefs"][$name]["label"] = $properties['label'];
-                            $files[$id]["subdefs"][$name]["size"] = $subdef->get_size();
-                            $files[$id]["subdefs"][$name]["mime"] = $subdef->get_mime();
-                            $files[$id]["subdefs"][$name]["folder"] = $download_element->get_directory();
-                            $files[$id]["subdefs"][$name]["exportExt"] = isset($infos['extension']) ? $infos['extension'] : '';
+                            $files[$id]["subdefs"][$subdefName]["ajout"] = $ajout;
+                            $files[$id]["subdefs"][$subdefName]["exportExt"] = $ext;
+                            $files[$id]["subdefs"][$subdefName]["label"] = $properties['label'];
+                            $files[$id]["subdefs"][$subdefName]["path"] = $tmp_pathfile["path"];
+                            $files[$id]["subdefs"][$subdefName]["file"] = $tmp_pathfile["file"];
+                            $files[$id]["subdefs"][$subdefName]["size"] = $sd[$subdefName]->get_size();
+                            $files[$id]["subdefs"][$subdefName]["mime"] = $sd[$subdefName]->get_mime();
+                            $files[$id]["subdefs"][$subdefName]["folder"] = $download_element->get_directory();
 
-                            $size += $subdef->get_size();
+                            $size += $sd[$subdefName]->get_size();
 
+                            break;
+
+                        default:    // should no happen
+                            $ajout = $ext = '';
                             break;
                     }
 
-                    $longueurAjoutCourant =
-                        mb_strlen($files[$id]["subdefs"][$name]["ajout"]);
-                    $sizeMaxAjout = max($longueurAjoutCourant, $sizeMaxAjout);
-
-                    $longueurExtCourant =
-                        mb_strlen($files[$id]["subdefs"][$name]["exportExt"]);
-                    $sizeMaxExt = max($longueurExtCourant, $sizeMaxExt);
+                    $sizeMaxAjout = max($sizeMaxAjout, mb_strlen($ajout));
+                    $sizeMaxExt   = max($sizeMaxExt, mb_strlen($ext));
                 }
-            }
+            } // end loop on downloadable subdefs
 
-            $max_length = self::$maxFilenameLength - 1 - $sizeMaxExt - $sizeMaxAjout;
-
-            $name = $files[$id]["export_name"];
-
-            $start_length = mb_strlen($name);
-            if ($start_length > $max_length)
-                $name = mb_substr($name, 0, $max_length);
-
+            // check that no exportNames are double, else add a number
+            // also truncate exportName so the whole filename will not be too long
+            //     "aTooLongName_caption.xml" --> "aTooLo_caption-2.xml"
             $n = 1;
-
-            while (in_array(mb_strtolower($name), $file_names)) {
+            do {
+                $nSuffix = ($n==1) ? '' : ('#'.$n);
+                $maxExportNameLength = self::$maxFilenameLength - $sizeMaxAjout - strlen($nSuffix) - 1 - $sizeMaxExt;
+                $newExportName = mb_substr($export_name, 0, $maxExportNameLength).$nSuffix;
+                $kName = mb_strtolower($newExportName);
                 $n++;
-                $suffix = "-" . $n; // pour diese si besoin
-                $max_length = self::$maxFilenameLength - 1 - $sizeMaxExt - $sizeMaxAjout - mb_strlen($suffix);
-                $name = mb_strtolower($files[$id]["export_name"]);
-                if ($start_length > $max_length)
-                    $name = mb_substr($name, 0, $max_length) . $suffix;
-                else
-                    $name = $name . $suffix;
             }
-            $file_names[] = mb_strtolower($name);
-            $files[$id]["export_name"] = $name;
+            while(in_array($kName, $file_names));
 
-            $files[$id]["export_name"] = $unicode->remove_nonazAZ09($files[$id]["export_name"], true, true, true);
-            $files[$id]["original_name"] = $unicode->remove_nonazAZ09($files[$id]["original_name"], true, true, true);
+            // here we have a unique exportName
+            $file_names[] = $kName;
 
-            $i = 0;
-            $name = utf8_decode($files[$id]["export_name"]);
-            $tmp_name = "";
-            $good_keys = [
-                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
-                'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
-                'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3',
-                '4', '5', '6', '7', '8', '9', '-', '_', '.', '#',
-            ];
+            $files[$id]["export_name"] = $newExportName;
 
-            while (isset($name[$i])) {
-                if (!in_array(mb_strtolower($name[$i]), $good_keys))
-                    $tmp_name .= '_';
-                else
-                    $tmp_name .= $name[$i];
+            //
+            // add files for caption and/or caption-yaml ?
+            //
+            $caption_dir = null;
+            foreach(['caption'=>CaptionSerializer::SERIALIZE_XML, 'caption-yaml'=>CaptionSerializer::SERIALIZE_YAML]
+                    as $subdefName => $serializeMethod)
+            {
+                if (in_array($subdefName, $wantedSubdefs)) {
+                    if (!$caption_dir) {
+                        // do this only once
+                        $caption_dir = $this->app['tmp.caption.path'] . '/' . time() . $this->app->getAuthenticatedUser()->getId() . '/';
+                        $filesystem->mkdir($caption_dir, 0750);
+                    }
 
-                $tmp_name = str_replace('__', '_', $tmp_name);
+                    $file = $files[$id]["export_name"]
+                        . $files[$id]["subdefs"][$subdefName]["ajout"] . '.'
+                        . $files[$id]["subdefs"][$subdefName]["exportExt"];
 
-                $i++;
-            }
-            $files[$id]["export_name"] = $tmp_name;
+                    $desc = $this->app['serializer.caption']->serialize($download_element->get_caption(), $serializeMethod, $BF);
+                    file_put_contents($caption_dir . $file, $desc);
 
-            if (in_array('caption', $subdefs)) {
-                $caption_dir = $this->app['tmp.caption.path'] . '/' . time() . $this->app->getAuthenticatedUser()->getId() . '/';
-
-                $filesystem->mkdir($caption_dir, 0750);
-
-                $desc = $this->app['serializer.caption']->serialize($download_element->get_caption(), CaptionSerializer::SERIALIZE_XML, $BF);
-
-                $file = $files[$id]["export_name"]
-                    . $files[$id]["subdefs"]['caption']["ajout"] . '.'
-                    . $files[$id]["subdefs"]['caption']["exportExt"];
-
-                $path = $caption_dir;
-
-                file_put_contents($path . $file, $desc);
-
-                $files[$id]["subdefs"]['caption']["path"] = $path;
-                $files[$id]["subdefs"]['caption']["file"] = $file;
-                $files[$id]["subdefs"]['caption']["size"] = filesize($path . $file);
-                $files[$id]["subdefs"]['caption']['businessfields'] = $BF ? '1' : '0';
-            }
-
-            if (in_array('caption-yaml', $subdefs)) {
-                $caption_dir = $this->app['tmp.caption.path'] . '/' . time() . $this->app->getAuthenticatedUser()->getId() . '/';
-
-                $filesystem->mkdir($caption_dir, 0750);
-
-                $desc = $this->app['serializer.caption']->serialize($download_element->get_caption(), CaptionSerializer::SERIALIZE_YAML, $BF);
-
-                $file = $files[$id]["export_name"]
-                    . $files[$id]["subdefs"]['caption-yaml']["ajout"] . '.'
-                    . $files[$id]["subdefs"]['caption-yaml']["exportExt"];
-
-                $path = $caption_dir;
-
-                file_put_contents($path . $file, $desc);
-
-                $files[$id]["subdefs"]['caption-yaml']["path"] = $path;
-                $files[$id]["subdefs"]['caption-yaml']["file"] = $file;
-                $files[$id]["subdefs"]['caption-yaml']["size"] = filesize($path . $file);
-                $files[$id]["subdefs"]['caption-yaml']['businessfields'] = $BF ? '1' : '0';
+                    $files[$id]["subdefs"][$subdefName]["path"] = $caption_dir;
+                    $files[$id]["subdefs"][$subdefName]["file"] = $file;
+                    $files[$id]["subdefs"][$subdefName]["size"] = filesize($caption_dir . $file);
+                    $files[$id]["subdefs"][$subdefName]['businessfields'] = $BF ? '1' : '0';
+                }
             }
         }
 
-        $this->list = [
+        $this->list = array(
             'files' => $files,
             'names' => $file_names,
-            'size' => $size,
-            'count' => $n_files,
-        ];
+            'size'  => $size,
+            'count' => $n_files
+        );
 
         return $this->list;
     }

--- a/lib/classes/unicode.php
+++ b/lib/classes/unicode.php
@@ -15,8 +15,30 @@ class unicode
     const CONVERT_TO_ND   = 'nd';           // no-diacritics
     const CONVERT_TO_LCND = 'lcnd';         // lowercase no-diacritics
 
-    protected static $map = [
-        self::CONVERT_TO_LC => [
+    private $maps = [];
+
+    private function &getMap($mapId)
+    {
+        if(array_key_exists($mapId, $this->maps)) {
+            return $this->maps[$mapId];
+        }
+        switch($mapId) {
+            case self::CONVERT_TO_LC:
+                $this->setMap_LC();
+                return $this->maps[self::CONVERT_TO_LC];
+            case self::CONVERT_TO_ND:
+                $this->setMap_ND();
+                return $this->maps[self::CONVERT_TO_ND];
+            case self::CONVERT_TO_LCND:
+                $this->setMap_LCND();
+                return $this->maps[self::CONVERT_TO_LCND];
+        }
+        return [];
+    }
+
+    private function setMap_LC()
+    {
+        $this->maps[self::CONVERT_TO_LC] = [
             "\x41"     => "\x61"        ,  /* U+0041: LATIN CAPITAL LETTER A                                   -> U+0061: LATIN SMALL LETTER A                                   */
             "\x42"     => "\x62"        ,  /* U+0042: LATIN CAPITAL LETTER B                                   -> U+0062: LATIN SMALL LETTER B                                   */
             "\x43"     => "\x63"        ,  /* U+0043: LATIN CAPITAL LETTER C                                   -> U+0063: LATIN SMALL LETTER C                                   */
@@ -481,9 +503,12 @@ class unicode
             "\xD5\x94" => "\xD6\x84"    ,  /* U+0554: ARMENIAN CAPITAL LETTER KEH                              -> U+0584: ARMENIAN SMALL LETTER KEH                              */
             "\xD5\x95" => "\xD6\x85"    ,  /* U+0555: ARMENIAN CAPITAL LETTER OH                               -> U+0585: ARMENIAN SMALL LETTER OH                               */
             "\xD5\x96" => "\xD6\x86"       /* U+0556: ARMENIAN CAPITAL LETTER FEH                              -> U+0586: ARMENIAN SMALL LETTER FEH                              */
-        ],
+        ];
+    }
 
-        self::CONVERT_TO_ND => [
+    private function setMap_ND()
+    {
+        $this->maps[self::CONVERT_TO_ND] = [
             "\xC2\xA0" => "\x20"    ,  /* U+00A0: NO-BREAK SPACE                                           -> U+0020: SPACE                                            */
             "\xC2\xA8" => "\x20"    ,  /* U+00A8: DIAERESIS                                                -> U+0020: SPACE                                            */
             "\xC2\xAA" => "\x61"    ,  /* U+00AA: FEMININE ORDINAL INDICATOR                               -> U+0061: LATIN SMALL LETTER A                             */
@@ -859,9 +884,12 @@ class unicode
             "\xD3\xB5" => "\xD1\x87",  /* U+04F5: CYRILLIC SMALL LETTER CHE WITH DIAERESIS                 -> U+0447: CYRILLIC SMALL LETTER CHE                        */
             "\xD3\xB8" => "\xD0\xAB",  /* U+04F8: CYRILLIC CAPITAL LETTER YERU WITH DIAERESIS              -> U+042B: CYRILLIC CAPITAL LETTER YERU                     */
             "\xD3\xB9" => "\xD1\x8B"   /* U+04F9: CYRILLIC SMALL LETTER YERU WITH DIAERESIS                -> U+044B: CYRILLIC SMALL LETTER YERU                       */
-        ],
+        ];
+    }
 
-        self::CONVERT_TO_LCND => [
+    private function setMap_LCND()
+    {
+        $this->maps[self::CONVERT_TO_LCND] = [
             "\x41"     => "\x61"        ,  /* U+0041: LATIN CAPITAL LETTER A                                   -> U+0061: LATIN SMALL LETTER A                               */
             "\x42"     => "\x62"        ,  /* U+0042: LATIN CAPITAL LETTER B                                   -> U+0062: LATIN SMALL LETTER B                               */
             "\x43"     => "\x63"        ,  /* U+0043: LATIN CAPITAL LETTER C                                   -> U+0063: LATIN SMALL LETTER C                               */
@@ -1538,8 +1566,8 @@ class unicode
             "\xD5\x94" => "\xD6\x84"    ,  /* U+0554: ARMENIAN CAPITAL LETTER KEH                              -> U+0584: ARMENIAN SMALL LETTER KEH                          */
             "\xD5\x95" => "\xD6\x85"    ,  /* U+0555: ARMENIAN CAPITAL LETTER OH                               -> U+0585: ARMENIAN SMALL LETTER OH                           */
             "\xD5\x96" => "\xD6\x86"       /* U+0556: ARMENIAN CAPITAL LETTER FEH                              -> U+0586: ARMENIAN SMALL LETTER FEH                          */
-        ]
-    ];
+        ];
+    }
 
     protected $endCharacters_utf8 = "\t\r\n !\"#\$%&'()+,-./:;<=>@[\\]^_`{|}~£§¨°";
 
@@ -1555,7 +1583,7 @@ class unicode
      */
     public function convert($string, $target)
     {
-        $ok_methods = array_keys(self::$map);
+        $ok_methods = [self::CONVERT_TO_LC, self::CONVERT_TO_ND, self::CONVERT_TO_LCND];
 
         if (!in_array($target, $ok_methods)) {
             throw new Exception_InvalidArgument(
@@ -1570,7 +1598,7 @@ class unicode
         }
 
         $out = '';
-        $_map = &self::$map[$target];   // faster in loop
+        $_map = $this->getMap($target);   // faster in loop
         $length = mb_strlen($string, 'UTF-8');
 
         for ($i = 0; $i < $length; $i++) {
@@ -1614,28 +1642,16 @@ class unicode
 
     public function remove_nonazAZ09($string, $keep_underscores = true, $keep_minus = true, $keep_dot = false)
     {
-        $regexp = '/[a-zA-Z0-9';
-        if ($keep_minus === true) {
-            $regexp .= '-';
-        }
-        if ($keep_underscores === true) {
-            $regexp .= '_';
-        }
-        if ($keep_dot === true) {
-            $regexp .= '\.';
-        }
-
-        $regexp .= ']{1}/';
-
         $string = $this->remove_diacritics($string);
 
         $out = '';
-
         $l = mb_strlen($string);
         for ($i = 0; $i < $l; $i ++) {
             $c = mb_substr($string, $i, 1);
-            if (preg_match($regexp, $c))
+            if(($c>='a'&&$c<='z')||($c>='A'&&$c<='Z')||($c>='0'&&$c<='9')
+                ||($keep_underscores&&$c=='_')||($keep_dot&&$c=='.')||($keep_minus&&$c=='-')) {
                 $out .= $c;
+            }
         }
 
         return $out;

--- a/tests/classes/media/subdefTest.php
+++ b/tests/classes/media/subdefTest.php
@@ -281,11 +281,11 @@ class media_subdefTest extends \PhraseanetTestCase
 
         // because rotate may cause round errors we check with +-1?
 
-        $this->assertGreaterThanOrEqual(self::$objectPresent->get_height(), $width_before-1);
-        $this->assertLessThanOrEqual(self::$objectPresent->get_height(), $width_before+1);
+        $this->assertGreaterThanOrEqual($width_before-1, self::$objectPresent->get_height());
+        $this->assertLessThanOrEqual($width_before+1, self::$objectPresent->get_height());
 
-        $this->assertGreaterThanOrEqual(self::$objectPresent->get_width(), $height_before-1);
-        $this->assertLessThanOrEqual(self::$objectPresent->get_width(), $height_before+1);
+        $this->assertGreaterThanOrEqual($height_before-1, self::$objectPresent->get_width());
+        $this->assertLessThanOrEqual($height_before+1, self::$objectPresent->get_width());
     }
 
     /**

--- a/tests/classes/media/subdefTest.php
+++ b/tests/classes/media/subdefTest.php
@@ -279,8 +279,13 @@ class media_subdefTest extends \PhraseanetTestCase
 
         self::$objectPresent->rotate(90, self::$DI['app']['media-alchemyst'], self::$DI['app']['mediavorus']);
 
-        $this->assertEquals($width_before, self::$objectPresent->get_height());
-        $this->assertEquals($height_before, self::$objectPresent->get_width());
+        // because rotate may cause round errors we check with +-1?
+
+        $this->assertGreaterThanOrEqual(self::$objectPresent->get_height(), $width_before-1);
+        $this->assertLessThanOrEqual(self::$objectPresent->get_height(), $width_before+1);
+
+        $this->assertGreaterThanOrEqual(self::$objectPresent->get_width(), $height_before-1);
+        $this->assertLessThanOrEqual(self::$objectPresent->get_width(), $height_before+1);
     }
 
     /**

--- a/tests/classes/unicodeTest.php
+++ b/tests/classes/unicodeTest.php
@@ -13,8 +13,12 @@ class unicodeTest extends \PhraseanetTestCase
 
     public function setUp()
     {
-        parent::setUp();
         $this->object = new unicode();
+    }
+
+    public function tearDown()
+    {
+        // no-op
     }
 
     /**
@@ -22,9 +26,10 @@ class unicodeTest extends \PhraseanetTestCase
      */
     public function testConvert()
     {
-        $this->assertEquals('éléphant à rôtir', $this->object->convert('ÉLÉPHANT à rôtir', unicode::CONVERT_TO_LC));
-        $this->assertEquals('ELEPHANT a rotir', $this->object->convert('ÉLÉPHANT à rôtir', unicode::CONVERT_TO_ND));
-        $this->assertEquals('elephant a rotir', $this->object->convert('ÉLÉPHANT à rôtir', unicode::CONVERT_TO_LCND));
+        $testStr = 'ÉLÉPHANT à rôtir';
+        $this->assertEquals('éléphant à rôtir', $this->object->convert($testStr, unicode::CONVERT_TO_LC));
+        $this->assertEquals('ELEPHANT a rotir', $this->object->convert($testStr, unicode::CONVERT_TO_ND));
+        $this->assertEquals('elephant a rotir', $this->object->convert($testStr, unicode::CONVERT_TO_LCND));
     }
 
     /**
@@ -33,7 +38,7 @@ class unicodeTest extends \PhraseanetTestCase
      */
     public function testConvertError()
     {
-        $this->object->convert('ÉLÉPHANT à rôtir', 'unexistant contant');
+        $this->object->convert('ÉLÉPHANT à rôtir', 'UNDEFINED_CONSTANT');
     }
 
     /**
@@ -41,9 +46,8 @@ class unicodeTest extends \PhraseanetTestCase
      */
     public function testRemove_diacritics()
     {
-        $this->assertEquals('Elephant', $this->object->remove_diacritics('Éléphant'));
-        $this->assertEquals('&e"\'(-eE_ca)=$*u:;,?./§%μ£°0987654321Œ3~#{[|^`@]}e32÷×¿',$this->object->remove_diacritics('&é"\'(-èÉ_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿'));
-        $this->assertEquals('PeTARDS', $this->object->remove_diacritics('PéTARDS'));
+        $testStr = '&é"\'(-èÉ_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿';
+        $this->assertEquals('&e"\'(-eE_ca)=$*u:;,?./§%μ£°0987654321Œ3~#{[|^`@]}e32÷×¿',$this->object->remove_diacritics($testStr));
     }
 
     /**
@@ -51,12 +55,12 @@ class unicodeTest extends \PhraseanetTestCase
      */
     public function testRemove_nonazAZ09()
     {
-        $this->assertEquals('Elephant', $this->object->remove_nonazAZ09('Eléphant'));
-        $this->assertEquals('Ee-e_cau.09876543213e32', $this->object->remove_nonazAZ09('É&é"\'(-è_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿', true, true, true));
-        $this->assertEquals('Ee-e_cau09876543213e32', $this->object->remove_nonazAZ09('É&é"\'(-è_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿', true, true, false));
-        $this->assertEquals('Eee_cau.09876543213e32', $this->object->remove_nonazAZ09('É&é"\'(-è_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿', true, false, true));
-        $this->assertEquals('Ee-ecau.09876543213e32', $this->object->remove_nonazAZ09('É&é"\'(-è_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿', false, true, true));
-        $this->assertEquals('Eeecau09876543213e32', $this->object->remove_nonazAZ09('É&é"\'(-è_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿', false, false, false));
+        $testStr = 'É&é"\'(-è_çà)=$*ù:;,?./§%µ£°0987654321Œ3~#{[|^`@]}ê³²÷×¿';
+        $this->assertEquals('Ee-e_cau.09876543213e32', $this->object->remove_nonazAZ09($testStr, true, true, true));
+        $this->assertEquals('Ee-e_cau09876543213e32' , $this->object->remove_nonazAZ09($testStr, true, true, false));
+        $this->assertEquals('Eee_cau.09876543213e32' , $this->object->remove_nonazAZ09($testStr, true, false, true));
+        $this->assertEquals('Ee-ecau.09876543213e32' , $this->object->remove_nonazAZ09($testStr, false, true, true));
+        $this->assertEquals('Eeecau09876543213e32'   , $this->object->remove_nonazAZ09($testStr, false, false, false));
     }
 
     /**


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1205: export filenames are fixed (no more double extension, replace blank by '_', doubles are numbered with '#', ...)
  - faster unicode
  - faster unicodeTests
