### PR TITLE
PHRAS-1335_FACETS-ESCAPE-CHARS

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Escaper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Escaper.php
@@ -7,11 +7,9 @@ class Escaper
     public function escapeWord($value)
     {
         // Strip double quotes from values to prevent broken queries
-        // TODO escape double quotes when it will be supported in query parser
-        $value = str_replace('/["\(\)\[\]]+/u', ' ', $value);
-
+        $value = str_replace("\"", "\\\"", $value);
         if (preg_match('/[\s\(\)\[\]]/u', $value)) {
-            return sprintf('"%s"', $value);
+            $value = sprintf('r"%s"', $value);
         }
 
         return $value;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
@@ -78,7 +78,7 @@ class FacetsResponse
             case 'Type_Name':
                 return sprintf('type:%s', $this->escaper->escapeWord($value));
             default:
-                return sprintf('field.%s = %s',
+                return sprintf('field.%s:%s',
                     $this->escaper->escapeWord($name),
                     $this->escaper->escapeWord($value));
         }


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1335: a facet containing a double quote (") generates a syntax error in query. Reason : A dquote inside the value after an "=" operator (ex. field:Keywords="intégrale "anthologie" ") generates syntax error parsing - even escaping internal dquotes as \" -
fix : facet filter query is changed to field:Keywords:r"intégrale \"anthologie\" ", using ":" operator on a raw value r"value".
