### PR TITLE
PHRAS-1340_FACETS-TECH-FIELDS

### DIFF
--- a/grammar/query.pp
+++ b/grammar/query.pp
@@ -14,10 +14,10 @@
 
 // Strings
 %token  quote_          "        -> string
-%token  string:quoted   [^"]+
+%token  string:quoted   ((\\")|[^"])+
 %token  string:_quote   "        -> default
 %token  raw_quote_      r"       -> raw
-%token  raw:raw_quoted  (?:(?>[^"\\]+)|\\.)+
+%token  raw:raw_quoted   ((\\")|[^"])+
 %token  raw:_raw_quote  "        -> default
 
 // Operators (too bad we can't use preg "i" flag)
@@ -117,6 +117,7 @@ key:
 #value:
     word_or_keyword()+
   | quoted_string()
+  | raw_quoted_string()
 
 group:
     ::space::? ::parenthese_:: ::space::? primary() ::space::? ::_parenthese:: ::space::?
@@ -183,3 +184,4 @@ symbol:
   | <bracket_>
   | <_bracket>
   | <colon>
+  | <equal>

--- a/lib/Alchemy/Phrasea/Command/SearchEngine/Debug/QueryParseCommand.php
+++ b/lib/Alchemy/Phrasea/Command/SearchEngine/Debug/QueryParseCommand.php
@@ -69,21 +69,23 @@ class QueryParseCommand extends Command
         $stopwatch = new Stopwatch();
         $stopwatch->start('parsing');
 
+        $out = [];
         if ($input->getOption('compiler-dump')) {
-            $dump = $compiler->dump($string, $postprocessing);
-        } else {
-            $query = $compiler->parse($string, $postprocessing);
-            $dump = $query->dump();
+            $out[] = $compiler->dump($string, $postprocessing);
         }
+        $query = $compiler->parse($string, $postprocessing);
+        $out[] = $query->dump();
 
         $event = $stopwatch->stop('parsing');
 
+        foreach($out as $s) {
+            $output->writeln($s);
+            if (!$raw) {
+                $output->writeln(str_repeat('-', 20));
+            }
+        }
         if (!$raw) {
-            $output->writeln($dump);
-            $output->writeln(str_repeat('-', 20));
             $output->writeln(sprintf("Took %sms", $event->getDuration()));
-        } else {
-            $output->write($dump);
         }
     }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/AbstractTermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/AbstractTermNode.php
@@ -16,7 +16,7 @@ abstract class AbstractTermNode extends Node implements TermInterface
 
     public function __construct($text, Context $context = null)
     {
-        $this->text = $text;
+        $this->text = StringHelper::unescape($text);
         $this->context = $context;
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/EqualExpression.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/EqualExpression.php
@@ -5,6 +5,7 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue\FieldKey;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue\Key;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Node;
+use Alchemy\Phrasea\SearchEngine\Elastic\AST\StringHelper;
 use Alchemy\Phrasea\SearchEngine\Elastic\Exception\QueryException;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryHelper;
@@ -18,7 +19,7 @@ class EqualExpression extends Node
     public function __construct(Key $key, $value)
     {
         $this->key = $key;
-        $this->value = $value;
+        $this->value = StringHelper::unescape($value);
     }
 
     public function buildQuery(QueryContext $context)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/MatchExpression.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/MatchExpression.php
@@ -3,6 +3,7 @@
 namespace Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Node;
+use Alchemy\Phrasea\SearchEngine\Elastic\AST\StringHelper;
 use Alchemy\Phrasea\SearchEngine\Elastic\Exception\QueryException;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Assert\Assertion;
@@ -16,7 +17,7 @@ class MatchExpression extends Node
     {
         Assertion::string($value);
         $this->key = $key;
-        $this->value = $value;
+        $this->value = StringHelper::unescape($value);
     }
 
     public function buildQuery(QueryContext $context)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/RangeExpression.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/RangeExpression.php
@@ -2,6 +2,7 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue;
 
+use Alchemy\Phrasea\SearchEngine\Elastic\AST\StringHelper;
 use Assert\Assertion;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue\FieldKey;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\KeyValue\Key;
@@ -46,9 +47,9 @@ class RangeExpression extends Node
         Assertion::nullOrScalar($hb);
         Assertion::boolean($hi);
         $this->key = $key;
-        $this->lower_bound = $lb;
+        $this->lower_bound = is_string($lb) ? StringHelper::unescape($lb) : null;
         $this->lower_inclusive = $li;
-        $this->higher_bound = $hb;
+        $this->higher_bound = is_string($hb) ?  StringHelper::unescape($hb) : null;
         $this->higher_inclusive = $hi;
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/RangeExpression.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/RangeExpression.php
@@ -47,9 +47,9 @@ class RangeExpression extends Node
         Assertion::nullOrScalar($hb);
         Assertion::boolean($hi);
         $this->key = $key;
-        $this->lower_bound = is_string($lb) ? StringHelper::unescape($lb) : null;
+        $this->lower_bound = StringHelper::unescape($lb);
         $this->lower_inclusive = $li;
-        $this->higher_bound = is_string($hb) ?  StringHelper::unescape($hb) : null;
+        $this->higher_bound = StringHelper::unescape($hb);
         $this->higher_inclusive = $hi;
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
@@ -12,7 +12,7 @@ class QuotedTextNode extends Node
 
     public function __construct($text)
     {
-        $this->text = $text;
+        $this->text = StringHelper::unescape($text);
     }
 
     public function buildQuery(QueryContext $context)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/RawNode.php
@@ -11,20 +11,9 @@ class RawNode extends Node
     private $text;
     private $index_fields_callback;
 
-    public static function createFromEscaped($escaped)
-    {
-        $unescaped = str_replace(
-            ['\\\\', '\\"'],
-            ['\\', '"'],
-            $escaped
-        );
-
-        return new self($unescaped);
-    }
-
     public function __construct($text)
     {
-        $this->text = $text;
+        $this->text = StringHelper::unescape($text);
     }
 
     public function buildQuery(QueryContext $context)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/StringHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/StringHelper.php
@@ -7,11 +7,11 @@ class StringHelper
 {
     public static function escape($s)
     {
-        return str_replace(["\"", "\\"], ["\\\"", "\\\\"], $s);
+        return is_string($s) ? str_replace(["\"", "\\"], ["\\\"", "\\\\"], $s) : $s;
     }
 
     public static function unescape($s)
     {
-        return str_replace(["\\\"", "\\\\"], ["\"", "\\"], $s);
+        return is_string($s) ? str_replace(["\\\"", "\\\\"], ["\"", "\\"], $s) : $s;
     }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/StringHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/StringHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
+
+
+class StringHelper
+{
+    public static function escape($s)
+    {
+        return str_replace(["\"", "\\"], ["\\\"", "\\\\"], $s);
+    }
+
+    public static function unescape($s)
+    {
+        return str_replace(["\\\"", "\\\\"], ["\"", "\\"], $s);
+    }
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
@@ -40,7 +40,7 @@ class QueryVisitor implements Visit
                 return new AST\QuotedTextNode($value);
 
             case NodeTypes::TOKEN_RAW_STRING:
-                return AST\RawNode::createFromEscaped($value);
+                return new AST\RawNode($value);
 
             default:
                 // Generic handling off other tokens for unresctricted text


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1340: fix query parser to better handle escaped dbl-quotes ("). Now " is a string delimiter, a real " must be escaped with anti-slash, especially in strict queries like Field:r"a value \\"including\\" quotes".
  - better output of bin/console/searchengine:query:parse

