### PR TITLE
PHRAS-1347_API-SUBSTITUTE-EXTENSION

### DIFF
--- a/lib/Alchemy/Phrasea/Command/Developer/RegenerateSqliteDb.php
+++ b/lib/Alchemy/Phrasea/Command/Developer/RegenerateSqliteDb.php
@@ -432,8 +432,8 @@ class RegenerateSqliteDb extends Command
             if ($i < 3) {
                 /** @var SubdefSubstituer $substituer */
                 $substituer = $this->container['subdef.substituer'];
-                $substituer->substitute($story, 'preview', $media);
-                $substituer->substitute($story, 'thumbnail', $media);
+                $substituer->substituteSubdef($story, 'preview', $media);
+                $substituer->substituteSubdef($story, 'thumbnail', $media);
             }
             $DI['record_story_' . $i] = $story;
         }

--- a/lib/Alchemy/Phrasea/Controller/Prod/LazaretController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/LazaretController.php
@@ -228,8 +228,7 @@ class LazaretController extends Controller
             $media = $this->app->getMediaFromUri($lazaretFileName);
 
             $record = $lazaretFile->getCollection($this->app)->get_databox()->get_record($recordId);
-            $this->getSubDefinitionSubstituer()
-                ->substitute($record, 'document', $media);
+            $this->getSubDefinitionSubstituer()->substituteDocument($record, $media);
             $this->getDataboxLogger($record->getDatabox())->log(
                 $record,
                 \Session_Logger::EVENT_SUBSTITUTE,

--- a/lib/Alchemy/Phrasea/Controller/Prod/ToolsController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/ToolsController.php
@@ -200,7 +200,7 @@ class ToolsController extends Controller
 
                     $media = $this->app->getMediaFromUri($tempoFile);
 
-                    $this->getSubDefinitionSubstituer()->substitute($record, 'document', $media);
+                    $this->getSubDefinitionSubstituer()->substituteDocument($record, $media);
                     $record->insertTechnicalDatas($this->getMediaVorus());
                     $this->getMetadataSetter()->replaceMetadata($this->getMetadataReader() ->read($media), $record);
 
@@ -260,7 +260,7 @@ class ToolsController extends Controller
 
             $media = $this->app->getMediaFromUri($tempoFile);
 
-            $this->getSubDefinitionSubstituer()->substitute($record, 'thumbnail', $media);
+            $this->getSubDefinitionSubstituer()->substituteSubdef($record, 'thumbnail', $media);
             $this->getDataboxLogger($record->getDatabox())
                 ->log($record, \Session_Logger::EVENT_SUBSTITUTE, 'thumbnail', '');
 
@@ -424,7 +424,12 @@ class ToolsController extends Controller
 
         $media = $this->app->getMediaFromUri($fileName);
 
-        $this->getSubDefinitionSubstituer()->substitute($record, $subDefName, $media);
+        if($subDefName == 'document') {
+            $this->getSubDefinitionSubstituer()->substituteDocument($record, $media);
+        }
+        else {
+            $this->getSubDefinitionSubstituer()->substituteSubdef($record, $subDefName, $media);
+        }
         $this->getDataboxLogger($record->getDatabox())
           ->log($record, \Session_Logger::EVENT_SUBSTITUTE, $subDefName, '');
 

--- a/lib/Alchemy/Phrasea/Controller/Prod/UploadController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/UploadController.php
@@ -193,7 +193,7 @@ class UploadController extends Controller
                         file_put_contents($fileName, $dataUri->getData());
                         $media = $this->app->getMediaFromUri($fileName);
 
-                        $this->getSubDefinitionSubstituer()->substitute($elementCreated, 'thumbnail', $media);
+                        $this->getSubDefinitionSubstituer()->substituteSubdef($elementCreated, 'thumbnail', $media);
                         $this->getDataboxLogger($elementCreated->getDatabox())
                             ->log($elementCreated, \Session_Logger::EVENT_SUBSTITUTE, 'thumbnail', '');
 

--- a/lib/Alchemy/Phrasea/TaskManager/Job/ArchiveJob.php
+++ b/lib/Alchemy/Phrasea/TaskManager/Job/ArchiveJob.php
@@ -1003,7 +1003,7 @@ class ArchiveJob extends AbstractJob
         }
 
         $story = \record_adapter::createStory($app, $collection);
-        $app['subdef.substituer']->substitute($story, 'document', $media);
+        $app['subdef.substituer']->substituteDocument($story, $media);
 
         $story->set_metadatas($metadatas->toMetadataArray($metadatasStructure), true);
 

--- a/tests/Alchemy/Tests/Phrasea/Application/OverviewTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Application/OverviewTest.php
@@ -2,6 +2,7 @@
 
 namespace Alchemy\Tests\Phrasea\Application;
 
+use Alchemy\Phrasea\Media\SubdefSubstituer;
 use Alchemy\Phrasea\Model\Entities\Feed;
 use Alchemy\Phrasea\Model\Entities\FeedEntry;
 use Alchemy\Phrasea\Model\Entities\FeedItem;
@@ -254,7 +255,14 @@ class OverviewTest extends \PhraseanetAuthenticatedWebTestCase
             ->method('getFile')
             ->will($this->returnValue($symfoFile));
 
-        self::$DI['app']['subdef.substituer']->substitute($story, $name, $media);
+        /** @var SubdefSubstituer $substituter */
+        $substituter = self::$DI['app']['subdef.substituer'];
+        if($name == 'document') {
+            $substituter->substituteDocument($story, $media);
+        }
+        else {
+            $substituter->substituteSubdef($story, $name, $media);
+        }
 
         $path = self::$DI['app']['url_generator']->generate('datafile', [
             'sbas_id' =>  $story->getDataboxId(),

--- a/tests/Alchemy/Tests/Phrasea/Controller/Prod/LazaretTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Prod/LazaretTest.php
@@ -297,7 +297,7 @@ class LazaretTest extends \PhraseanetAuthenticatedWebTestCase
         //expect one call to substitute the documents
         self::$DI['app']['subdef.substituer']->expects($this->once())
             ->method('substituteDocument')
-            ->with($record, $this->equalTo('document'));
+            ->with($record);
 
         $databox = $this->getMock('databox', [], [], '', false);
 

--- a/tests/Alchemy/Tests/Phrasea/Controller/Prod/LazaretTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Prod/LazaretTest.php
@@ -296,7 +296,7 @@ class LazaretTest extends \PhraseanetAuthenticatedWebTestCase
 
         //expect one call to substitute the documents
         self::$DI['app']['subdef.substituer']->expects($this->once())
-            ->method('substitute')
+            ->method('substituteDocument')
             ->with($record, $this->equalTo('document'));
 
         $databox = $this->getMock('databox', [], [], '', false);


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1347: fix missing ext. when a doc was substituted via api.
  - calls to obsolete SubdefSubstituer::substitute() renamed (method NOT removed, may be used in plugins)
