### PR TITLE
PHRAS-1388_Invalid-geonameId

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Entities/User.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/User.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Phraseanet
  *

--- a/lib/Alchemy/Phrasea/Model/Entities/User.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/User.php
@@ -527,7 +527,7 @@ class User
      */
     public function setGeonameId($geonameId)
     {
-        if (null !== $geonameId && $geonameId < 1) {
+        if ('' !== $geonameId && null !== $geonameId && $geonameId < 1) {
             throw new InvalidArgumentException(sprintf('Invalid geonameid %s.', $geonameId));
         }
 


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1388: message "invalid geoname id" is not displayed anymore for empty fields

