### PR TITLE
PHRAS-1355 Add subdef pressets on subdef admin form

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Admin/SubdefsController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SubdefsController.php
@@ -22,105 +22,7 @@ class SubdefsController extends Controller
      */
     function indexAction($sbas_id) {
         $databox = $this->findDataboxById((int) $sbas_id);
-
-        $config = array(
-            "image" => array(
-                "definitions" => array(
-                    "JPG"                                    => null,
-                    "160px JPG"                              => array("160", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "320 px JPG (thumbnail Phraseanet)"      => array("320", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "640px JPG"                              => array("640", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "1280px JPG (preview Phraseanet)"        => array("1280", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "2560px JPG"                             => array("2560", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "PNG"                                    => null,
-                    "160px PNG 8 bits"                       => array("160", "75", "yes", "yes", "75", "png", ["all"]),
-                    "320px PNG 8 bits"                       => array("320", "75", "yes", "yes", "75", "png", ["all"]),
-                    "640px PNG 8 bits"                       => array("640", "75", "yes", "yes", "75", "png", ["all"]),
-                    "1280px PNG 8 bits"                      => array("1280", "75", "yes", "yes", "75", "png", ["all"]),
-                    "2560px PNG 8 bits"                      => array("2560", "75", "yes", "yes", "75", "png", ["all"]),
-                    "TIFF"                                   => null,
-                    "1280 TIFF"                              => array("1280", "75", "yes", "yes", "75", "tiff", ["all"]),
-                    "2560px TIFF"                            => array("2560", "75", "yes", "yes", "75", "tiff", ["all"]),
-                ),
-
-                "form" => array(
-                    "size"          => "slide",
-                    "resolution"    => "slide",
-                    "strip"         => "radio",
-                    "flatten"       => "radio",
-                    "quality"       => "slide",
-                    "icodec"        => "select",
-                    "devices"       => "checkbox",
-                ),
-            ),
-            "video" => array(
-                "definitions" => array(
-                    "video codec H264"                  => null,
-                    "144P H264 128 kbps ACC 128kbps"    => array("128", "44100", "256", "25", "128", "25", "libx264", "libfaac", ["all"]),
-                    "240P H264 256 kbps ACC 128kbps"    => array("128", "44100", "426", "25", "256", "25", "libx264", "libfaac", ["all"]),
-                    "360P H264 576 kbps ACC 128kbps"    => array("128", "44100", "480", "25", "576", "25", "libtheora", "libfaac", ["all"]),
-                    "480P H264 750 kbps ACC 128kbps"    => array("128", "44100", "854", "25", "750", "25", "libx264", "libfaac", ["all"]),
-                    "720P H264 1492 kbps ACC 128kbps"   => array("128", "44100", "1280", "25", "1492", "25", "libx264", "libfaac", ["all"]),
-                    "1080P H264 2420 kbps ACC 128kbps"  => array("128", "44100", "1920", "25", "2420", "25", "libx264", "libfaac", ["all"]),
-                    "video codec libvpx"                => null,
-                    "144P webm 128 kbps ACC 128kbps"    => array("128", "44100", "256", "25", "128", "25", "libvpx", "libfaac", ["all"]),
-                    "240P webm 256 kbps ACC 128kbps"    => array("128", "44100", "426", "25", "256", "25", "libvpx", "libfaac", ["all"]),
-                    "360P webm 576 kbps ACC 128kbps"    => array("128", "44100", "480", "25", "576", "25", "libvpx", "libfaac", ["all"]),
-                    "480P webm 750 kbps ACC 128kbps"    => array("128", "44100", "854", "25", "750", "25", "libvpx", "libfaac", ["all"]),
-                    "720P webm 1492 kbps ACC 128kbps"   => array("128", "44100", "1280", "25", "1492", "25", "libvpx", "libfaac", ["all"]),
-                    "1080P webm 2420 kbps ACC 128kbps"  => array("128", "44100", "1920", "25", "2420", "25", "libvpx", "libfaac", ["all"]),
-                ),
-
-                "form" => array(
-                    "audiobitrate"      => "slide",
-                    "audiosamplerate"   => "select",
-                    "bitrate"           => "slide",
-                    "GOPsize"           => "slide",
-                    "size"              => "slide",
-                    "fps"               => "slide",
-                    "vcodec"            => "select",
-                    "acodec"            => "select",
-                    "devices"           => "checkbox",
-                ),
-            ),
-            "gif" => array(
-                "definitions" => array(
-                    "256 px fast 200 ms"        => array("256", "200", ["all"]),
-                    "256 px very fast 120 ms"   => array("256", "120", ["all"]),
-                    "320 px fast 200 ms"        => array("320", "200", ["all"]),
-                ),
-
-                "form" => array(
-                    "size"          => "slide",
-                    "delay"         => "slide",
-                    "devices"       => "checkbox",
-                ),
-            ),
-            "audio" => array(
-                "definitions" => array(
-                    "Low AAC 96 kbit/s"      => array("100", "8000", "libmp3lame", ["all"]),
-                    "Normal AAC 128 kbit/s"  => array("180", "44100", "libmp3lame", ["all"]),
-                    "High AAC 320 kbit/s"    => array("230", "50000", "libmp3lame", ["all"]),
-                ),
-
-                "form" => array(
-                    "audiobitrate"      => "slide",
-                    "audiosamplerate"   => "select",
-                    "acodec"            => "select",
-                    "devices"           => "checkbox",
-                ),
-            ),
-            "flexpaper" => array(
-                "definitions" => array(
-                    "low_F"     => array(),
-                    "medium_F"  => array(),
-                    "high_F"    => array(),
-                ),
-
-                "form" => array(
-                ),
-            ),
-        );
+        $config = $this->getConfiguration();
 
         return $this->render('admin/subdefs.html.twig', [
             'databox' => $databox,
@@ -214,5 +116,226 @@ class SubdefsController extends Controller
         return $this->app->redirectPath('admin_subdefs_subdef', [
             'sbas_id' => $databox->get_sbas_id(),
         ]);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getConfiguration()
+    {
+        $config = array(
+            "image" => array(
+                "definitions" => array(
+                    "JPG" => null,
+                    "160px JPG" => array("160", "75", "yes", "yes", "75", "jpeg", ["all"]),
+                    "320 px JPG (thumbnail Phraseanet)" => array("320", "75", "yes", "yes", "75", "jpeg", ["all"]),
+                    "640px JPG" => array("640", "75", "yes", "yes", "75", "jpeg", ["all"]),
+                    "1280px JPG (preview Phraseanet)" => array("1280", "75", "yes", "yes", "75", "jpeg", ["all"]),
+                    "2560px JPG" => array("2560", "75", "yes", "yes", "75", "jpeg", ["all"]),
+                    "PNG" => null,
+                    "160px PNG 8 bits" => array("160", "75", "yes", "yes", "75", "png", ["all"]),
+                    "320px PNG 8 bits" => array("320", "75", "yes", "yes", "75", "png", ["all"]),
+                    "640px PNG 8 bits" => array("640", "75", "yes", "yes", "75", "png", ["all"]),
+                    "1280px PNG 8 bits" => array("1280", "75", "yes", "yes", "75", "png", ["all"]),
+                    "2560px PNG 8 bits" => array("2560", "75", "yes", "yes", "75", "png", ["all"]),
+                    "TIFF" => null,
+                    "1280 TIFF" => array("1280", "75", "yes", "yes", "75", "tiff", ["all"]),
+                    "2560px TIFF" => array("2560", "75", "yes", "yes", "75", "tiff", ["all"]),
+                ),
+                "form" => array(
+                    "size" => "slide",
+                    "resolution" => "slide",
+                    "strip" => "radio",
+                    "flatten" => "radio",
+                    "quality" => "slide",
+                    "icodec" => "select",
+                    "devices" => "checkbox",
+                ),
+            ),
+            "video" => array(
+                "definitions" => array(
+                    "video codec H264" => null,
+                    "144P H264 128 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "256",
+                        "25",
+                        "128",
+                        "25",
+                        "libx264",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "240P H264 256 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "426",
+                        "25",
+                        "256",
+                        "25",
+                        "libx264",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "360P H264 576 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "480",
+                        "25",
+                        "576",
+                        "25",
+                        "libtheora",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "480P H264 750 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "854",
+                        "25",
+                        "750",
+                        "25",
+                        "libx264",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "720P H264 1492 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "1280",
+                        "25",
+                        "1492",
+                        "25",
+                        "libx264",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "1080P H264 2420 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "1920",
+                        "25",
+                        "2420",
+                        "25",
+                        "libx264",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "video codec libvpx" => null,
+                    "144P webm 128 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "256",
+                        "25",
+                        "128",
+                        "25",
+                        "libvpx",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "240P webm 256 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "426",
+                        "25",
+                        "256",
+                        "25",
+                        "libvpx",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "360P webm 576 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "480",
+                        "25",
+                        "576",
+                        "25",
+                        "libvpx",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "480P webm 750 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "854",
+                        "25",
+                        "750",
+                        "25",
+                        "libvpx",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "720P webm 1492 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "1280",
+                        "25",
+                        "1492",
+                        "25",
+                        "libvpx",
+                        "libfaac",
+                        ["all"]
+                    ),
+                    "1080P webm 2420 kbps ACC 128kbps" => array(
+                        "128",
+                        "44100",
+                        "1920",
+                        "25",
+                        "2420",
+                        "25",
+                        "libvpx",
+                        "libfaac",
+                        ["all"]
+                    ),
+                ),
+                "form" => array(
+                    "audiobitrate" => "slide",
+                    "audiosamplerate" => "select",
+                    "bitrate" => "slide",
+                    "GOPsize" => "slide",
+                    "size" => "slide",
+                    "fps" => "slide",
+                    "vcodec" => "select",
+                    "acodec" => "select",
+                    "devices" => "checkbox",
+                ),
+            ),
+            "gif" => array(
+                "definitions" => array(
+                    "256 px fast 200 ms" => array("256", "200", ["all"]),
+                    "256 px very fast 120 ms" => array("256", "120", ["all"]),
+                    "320 px fast 200 ms" => array("320", "200", ["all"]),
+                ),
+                "form" => array(
+                    "size" => "slide",
+                    "delay" => "slide",
+                    "devices" => "checkbox",
+                ),
+            ),
+            "audio" => array(
+                "definitions" => array(
+                    "Low AAC 96 kbit/s" => array("100", "8000", "libmp3lame", ["all"]),
+                    "Normal AAC 128 kbit/s" => array("180", "44100", "libmp3lame", ["all"]),
+                    "High AAC 320 kbit/s" => array("230", "50000", "libmp3lame", ["all"]),
+                ),
+                "form" => array(
+                    "audiobitrate" => "slide",
+                    "audiosamplerate" => "select",
+                    "acodec" => "select",
+                    "devices" => "checkbox",
+                ),
+            ),
+            "flexpaper" => array(
+                "definitions" => array(
+                    "low_F" => array(),
+                    "medium_F" => array(),
+                    "high_F" => array(),
+                ),
+                "form" => array(),
+            ),
+        );
+
+        return $config;
     }
 }

--- a/lib/Alchemy/Phrasea/Controller/Admin/SubdefsController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SubdefsController.php
@@ -11,8 +11,15 @@
 namespace Alchemy\Phrasea\Controller\Admin;
 
 use Alchemy\Phrasea\Controller\Controller;
+use Alchemy\Phrasea\Media\Subdef\Provider;
+use Alchemy\Phrasea\Media\Subdef\Subdef;
+use Alchemy\Phrasea\Media\Type\Type;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Alchemy\Phrasea\Media\Subdef\Image;
+use Alchemy\Phrasea\Media\Subdef\Video;
+use Alchemy\Phrasea\Media\Subdef\Audio;
+use Alchemy\Phrasea\Media\Subdef\Gif;
 
 class SubdefsController extends Controller
 {
@@ -23,11 +30,13 @@ class SubdefsController extends Controller
     function indexAction($sbas_id) {
         $databox = $this->findDataboxById((int) $sbas_id);
         $config = $this->getConfiguration();
+        $subviews_mapping = $this->getSubviewsMapping();
 
         return $this->render('admin/subdefs.html.twig', [
             'databox' => $databox,
             'subdefs' => $databox->get_subdef_structure(),
-            'config' => $config
+            'config' => $config,
+            'subviews_mapping' => $subviews_mapping
         ]);
     }
 
@@ -44,7 +53,7 @@ class SubdefsController extends Controller
 
         $databox = $this->findDataboxById((int) $sbas_id);
 
-        $add_subdef = ['class' => null, 'name'  => null, 'group' => null, 'presets' => null];
+        $add_subdef = ['class' => null, 'name'  => null, 'group' => null, 'mediaType' => null, 'presets' => null];
         foreach ($add_subdef as $k => $v) {
             if (!isset($toadd_subdef[$k]) || trim($toadd_subdef[$k]) === '') {
                 unset($add_subdef[$k]);
@@ -59,7 +68,7 @@ class SubdefsController extends Controller
             $name = $delete_subef[1];
             $subdefs = $databox->get_subdef_structure();
             $subdefs->delete_subdef($group, $name);
-        } elseif (count($add_subdef) === 4) {
+        } elseif (count($add_subdef) === 5) {
             $subdefs = $databox->get_subdef_structure();
 
             $group = $add_subdef['group'];
@@ -68,8 +77,81 @@ class SubdefsController extends Controller
             $name = $unicode->remove_nonazAZ09($add_subdef['name'], false);
             $class = $add_subdef['class'];
             $preset = $add_subdef['presets'];
+            $mediatype = $add_subdef['mediaType'];
 
-            $subdefs->add_subdef($group, $name, $class, $preset);
+            $subdefs->add_subdef($group, $name, $class, $mediatype, $preset);
+
+            if ($preset !== "Choose") {
+                $options = [];
+
+                $config = $this->getConfiguration();
+
+                //On applique directement les valeurs du preset à la sous def
+                switch($mediatype) {
+                    case Subdef::TYPE_IMAGE :
+                        $options["path"] = "";
+                        $options["meta"] = true;
+                        $options["mediatype"] = $mediatype;
+                        $options[Image::OPTION_SIZE] = $config["image"]["definitions"][$preset][Image::OPTION_SIZE];
+                        $options["dpi"] = $config["image"]["definitions"][$preset][Image::OPTION_RESOLUTION];
+                        $options[Image::OPTION_STRIP] = $config["image"]["definitions"][$preset][Image::OPTION_STRIP];
+                        $options[Image::OPTION_FLATTEN] = $config["image"]["definitions"][$preset][Image::OPTION_FLATTEN];
+                        $options[Image::OPTION_QUALITY] = $config["image"]["definitions"][$preset][Image::OPTION_QUALITY];
+                        $options[Image::OPTION_ICODEC] = $config["image"]["definitions"][$preset][Image::OPTION_ICODEC];
+                        foreach($config["image"]["definitions"][$preset][Image::OPTION_DEVICE] as $devices) {
+                            $options[Image::OPTION_DEVICE][] = $devices;
+                        }
+                        break;
+                    case Subdef::TYPE_VIDEO :
+                        $options["path"] = "";
+                        $options["meta"] = true;
+                        $options["mediatype"] = $mediatype;
+                        $options[Video::OPTION_AUDIOBITRATE] = $config["video"]["definitions"][$preset][Video::OPTION_AUDIOBITRATE];
+                        $options[Video::OPTION_AUDIOSAMPLERATE] = $config["video"]["definitions"][$preset][Video::OPTION_AUDIOSAMPLERATE];
+                        $options[Video::OPTION_BITRATE] = $config["video"]["definitions"][$preset][Video::OPTION_BITRATE];
+                        $options[Video::OPTION_GOPSIZE] = $config["video"]["definitions"][$preset][Video::OPTION_GOPSIZE];
+                        $options[Video::OPTION_SIZE] = $config["video"]["definitions"][$preset][Video::OPTION_SIZE];
+                        $options[Video::OPTION_FRAMERATE] = $config["video"]["definitions"][$preset][Video::OPTION_FRAMERATE];
+                        $options[Video::OPTION_VCODEC] = $config["video"]["definitions"][$preset][Video::OPTION_VCODEC];
+                        $options[Video::OPTION_ACODEC] = $config["video"]["definitions"][$preset][Video::OPTION_ACODEC];
+                        foreach($config["video"]["definitions"][$preset][Video::OPTION_DEVICE] as $devices) {
+                            $options[Video::OPTION_DEVICE][] = $devices;
+                        }
+                        break;
+                    case Subdef::TYPE_FLEXPAPER :
+                        $options["path"] = "";
+                        $options["meta"] = true;
+                        $options["mediatype"] = $mediatype;
+                        foreach($config["document"]["definitions"][$preset]["devices"] as $devices) {
+                            $options["devices"][] = $devices;
+                        }
+                        break;
+                    case Subdef::TYPE_ANIMATION :
+                        $options["path"] = "";
+                        $options["meta"] = true;
+                        $options["mediatype"] = $mediatype;
+                        $options[Gif::OPTION_SIZE] = $config["gif"]["definitions"][$preset][Gif::OPTION_SIZE];
+                        $options[Gif::OPTION_DELAY] = $config["gif"]["definitions"][$preset][Gif::OPTION_DELAY];
+                        foreach($config["gif"]["definitions"][$preset][Gif::OPTION_DEVICE] as $devices) {
+                            $options[Gif::OPTION_DEVICE][] = $devices;
+                        }
+                        break;
+                    case Subdef::TYPE_AUDIO :
+                        $options["path"] = "";
+                        $options["meta"] = true;
+                        $options["mediatype"] = $mediatype;
+                        $options[Audio::OPTION_AUDIOBITRATE] = $config["audio"]["definitions"][$preset][Audio::OPTION_AUDIOBITRATE];
+                        $options[Audio::OPTION_AUDIOSAMPLERATE] = $config["audio"]["definitions"][$preset][Audio::OPTION_AUDIOSAMPLERATE];
+                        $options[Audio::OPTION_ACODEC] = $config["audio"]["definitions"][$preset][Audio::OPTION_ACODEC];
+                        foreach($config["audio"]["definitions"][$preset][Audio::OPTION_DEVICE] as $devices) {
+                            $options[Audio::OPTION_DEVICE][] = $devices;
+                        }
+                        break;
+                }
+
+                $subdefs->set_subdef($group, $name, $class, $preset, false, $options, []);
+            }
+
         } else {
             $subdefs = $databox->get_subdef_structure();
 
@@ -96,7 +178,6 @@ class SubdefsController extends Controller
 
                     $options[$def] = $parm_loc;
                 }
-
                 $mediatype = $request->request->get($post_sub . '_mediatype');
                 $media = $request->request->get($post_sub . '_' . $mediatype, []);
 
@@ -122,216 +203,352 @@ class SubdefsController extends Controller
     /**
      * @return array
      */
+    protected function getSubviewsMapping()
+    {
+        $mapping = array(
+            Type::TYPE_IMAGE => array(Subdef::TYPE_IMAGE),
+            Type::TYPE_VIDEO => array(Subdef::TYPE_IMAGE, Subdef::TYPE_VIDEO, Subdef::TYPE_ANIMATION),
+            Type::TYPE_AUDIO => array(Subdef::TYPE_IMAGE, Subdef::TYPE_AUDIO),
+            Type::TYPE_DOCUMENT => array(Subdef::TYPE_IMAGE, Subdef::TYPE_FLEXPAPER),
+            Type::TYPE_FLASH => array(Subdef::TYPE_IMAGE)
+        );
+
+        return $mapping;
+    }
+
+    /**
+     * @return array
+     */
     protected function getConfiguration()
     {
         $config = array(
-            "image" => array(
+            Subdef::TYPE_IMAGE => array(
                 "definitions" => array(
                     "JPG" => null,
-                    "160px JPG" => array("160", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "320 px JPG (thumbnail Phraseanet)" => array("320", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "640px JPG" => array("640", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "1280px JPG (preview Phraseanet)" => array("1280", "75", "yes", "yes", "75", "jpeg", ["all"]),
-                    "2560px JPG" => array("2560", "75", "yes", "yes", "75", "jpeg", ["all"]),
+                    "160px JPG" => array(
+                        Image::OPTION_SIZE       => "160",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "jpeg",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "320 px JPG (thumbnail Phraseanet)" => array(
+                        Image::OPTION_SIZE       => "320",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "jpeg",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "640px JPG" => array(
+                        Image::OPTION_SIZE       => "640",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "jpeg",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "1280px JPG (preview Phraseanet)" => array(
+                        Image::OPTION_SIZE       => "1280",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "jpeg",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "2560px JPG" => array(
+                        Image::OPTION_SIZE       => "2560",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "jpeg",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
                     "PNG" => null,
-                    "160px PNG 8 bits" => array("160", "75", "yes", "yes", "75", "png", ["all"]),
-                    "320px PNG 8 bits" => array("320", "75", "yes", "yes", "75", "png", ["all"]),
-                    "640px PNG 8 bits" => array("640", "75", "yes", "yes", "75", "png", ["all"]),
-                    "1280px PNG 8 bits" => array("1280", "75", "yes", "yes", "75", "png", ["all"]),
-                    "2560px PNG 8 bits" => array("2560", "75", "yes", "yes", "75", "png", ["all"]),
+                    "160px PNG 8 bits" => array(
+                        Image::OPTION_SIZE       => "160",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "png",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "320px PNG 8 bits" => array(
+                        Image::OPTION_SIZE       => "320",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "png",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "640px PNG 8 bits" => array(
+                        Image::OPTION_SIZE       => "640",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "png",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "1280px PNG 8 bits" => array(
+                        Image::OPTION_SIZE       => "1280",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "png",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "2560px PNG 8 bits" => array(
+                        Image::OPTION_SIZE       => "2560",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "png",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
                     "TIFF" => null,
-                    "1280 TIFF" => array("1280", "75", "yes", "yes", "75", "tiff", ["all"]),
-                    "2560px TIFF" => array("2560", "75", "yes", "yes", "75", "tiff", ["all"]),
+                    "1280 TIFF" => array(
+                        Image::OPTION_SIZE       => "1280",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "tiff",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
+                    "2560px TIFF" => array(
+                        Image::OPTION_SIZE       => "2560",
+                        Image::OPTION_RESOLUTION => "75",
+                        Image::OPTION_STRIP      => "yes",
+                        Image::OPTION_FLATTEN    => "yes",
+                        Image::OPTION_QUALITY    => "75",
+                        Image::OPTION_ICODEC     => "tiff",
+                        Image::OPTION_DEVICE     => ["all"]
+                    ),
                 ),
                 "form" => array(
-                    "size" => "slide",
-                    "resolution" => "slide",
-                    "strip" => "radio",
-                    "flatten" => "radio",
-                    "quality" => "slide",
-                    "icodec" => "select",
-                    "devices" => "checkbox",
+                    Image::OPTION_SIZE       => "slide",
+                    Image::OPTION_RESOLUTION => "slide",
+                    Image::OPTION_STRIP      => "radio",
+                    Image::OPTION_FLATTEN    => "radio",
+                    Image::OPTION_QUALITY    => "slide",
+                    Image::OPTION_ICODEC     => "select",
+                    Image::OPTION_DEVICE     => "checkbox",
                 ),
             ),
-            "video" => array(
+            Subdef::TYPE_VIDEO => array(
                 "definitions" => array(
                     "video codec H264" => null,
                     "144P H264 128 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "256",
-                        "25",
-                        "128",
-                        "25",
-                        "libx264",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "256",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "128",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libx264",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "240P H264 256 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "426",
-                        "25",
-                        "256",
-                        "25",
-                        "libx264",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "426",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "256",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libx264",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "360P H264 576 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "480",
-                        "25",
-                        "576",
-                        "25",
-                        "libtheora",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "480",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "576",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libtheora",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "480P H264 750 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "854",
-                        "25",
-                        "750",
-                        "25",
-                        "libx264",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "854",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "750",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libx264",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "720P H264 1492 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "1280",
-                        "25",
-                        "1492",
-                        "25",
-                        "libx264",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "1280",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "1492",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libx264",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "1080P H264 2420 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "1920",
-                        "25",
-                        "2420",
-                        "25",
-                        "libx264",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "1920",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "2420",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libx264",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "video codec libvpx" => null,
                     "144P webm 128 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "256",
-                        "25",
-                        "128",
-                        "25",
-                        "libvpx",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "256",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "128",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libvpx",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "240P webm 256 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "426",
-                        "25",
-                        "256",
-                        "25",
-                        "libvpx",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "426",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "256",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libvpx",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "360P webm 576 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "480",
-                        "25",
-                        "576",
-                        "25",
-                        "libvpx",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "480",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "576",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libvpx",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "480P webm 750 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "854",
-                        "25",
-                        "750",
-                        "25",
-                        "libvpx",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "854",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "750",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libvpx",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "720P webm 1492 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "1280",
-                        "25",
-                        "1492",
-                        "25",
-                        "libvpx",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "1280",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "1492",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libvpx",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                     "1080P webm 2420 kbps ACC 128kbps" => array(
-                        "128",
-                        "44100",
-                        "1920",
-                        "25",
-                        "2420",
-                        "25",
-                        "libvpx",
-                        "libfaac",
-                        ["all"]
+                        Video::OPTION_AUDIOBITRATE    => "128",
+                        Video::OPTION_AUDIOSAMPLERATE => "44100",
+                        Video::OPTION_BITRATE         => "1920",
+                        Video::OPTION_GOPSIZE         => "25",
+                        Video::OPTION_SIZE            => "2420",
+                        Video::OPTION_FRAMERATE       => "25",
+                        Video::OPTION_VCODEC          => "libvpx",
+                        Video::OPTION_ACODEC          => "libfaac",
+                        Video::OPTION_DEVICE          => ["all"]
                     ),
                 ),
                 "form" => array(
-                    "audiobitrate" => "slide",
-                    "audiosamplerate" => "select",
-                    "bitrate" => "slide",
-                    "GOPsize" => "slide",
-                    "size" => "slide",
-                    "fps" => "slide",
-                    "vcodec" => "select",
-                    "acodec" => "select",
-                    "devices" => "checkbox",
+                    Video::OPTION_AUDIOBITRATE    => "slide",
+                    Video::OPTION_AUDIOSAMPLERATE => "select",
+                    Video::OPTION_BITRATE         => "slide",
+                    Video::OPTION_GOPSIZE         => "slide",
+                    Video::OPTION_SIZE            => "slide",
+                    Video::OPTION_FRAMERATE       => "slide",
+                    Video::OPTION_VCODEC          => "select",
+                    Video::OPTION_ACODEC          => "select",
+                    Video::OPTION_DEVICE          => "checkbox",
                 ),
             ),
-            "gif" => array(
+            Subdef::TYPE_ANIMATION => array(
                 "definitions" => array(
-                    "256 px fast 200 ms" => array("256", "200", ["all"]),
-                    "256 px very fast 120 ms" => array("256", "120", ["all"]),
-                    "320 px fast 200 ms" => array("320", "200", ["all"]),
+                    "256 px fast 200 ms" => array(
+                        Gif::OPTION_SIZE    => "256",
+                        Gif::OPTION_DELAY   => "200",
+                        Gif::OPTION_DEVICE  => ["all"]
+                    ),
+                    "256 px very fast 120 ms" => array(
+                        Gif::OPTION_SIZE    => "256",
+                        Gif::OPTION_DELAY   => "120",
+                        Gif::OPTION_DEVICE  => ["all"]
+                    ),
+                    "320 px fast 200 ms" => array(
+                        Gif::OPTION_SIZE    => "320",
+                        Gif::OPTION_DELAY   => "200",
+                        Gif::OPTION_DEVICE  => ["all"]
+                    ),
                 ),
                 "form" => array(
-                    "size" => "slide",
-                    "delay" => "slide",
-                    "devices" => "checkbox",
+                    Gif::OPTION_SIZE        => "slide",
+                    Gif::OPTION_DELAY       => "slide",
+                    Gif::OPTION_DEVICE      => "checkbox",
                 ),
             ),
-            "audio" => array(
+            Subdef::TYPE_AUDIO => array(
                 "definitions" => array(
-                    "Low AAC 96 kbit/s" => array("100", "8000", "libmp3lame", ["all"]),
-                    "Normal AAC 128 kbit/s" => array("180", "44100", "libmp3lame", ["all"]),
-                    "High AAC 320 kbit/s" => array("230", "50000", "libmp3lame", ["all"]),
+                    "Low AAC 96 kbit/s" => array(
+                        Audio::OPTION_AUDIOBITRATE      => "100",
+                        Audio::OPTION_AUDIOSAMPLERATE   => "8000",
+                        Audio::OPTION_ACODEC            => "libmp3lame",
+                        Audio::OPTION_DEVICE            => ["all"]
+                    ),
+                    "Normal AAC 128 kbit/s" => array(
+                        Audio::OPTION_AUDIOBITRATE      => "180",
+                        Audio::OPTION_AUDIOSAMPLERATE   => "44100",
+                        Audio::OPTION_ACODEC            => "libmp3lame",
+                        Audio::OPTION_DEVICE            => ["all"]
+                    ),
+                    "High AAC 320 kbit/s" => array(
+                        Audio::OPTION_AUDIOBITRATE      => "230",
+                        Audio::OPTION_AUDIOSAMPLERATE   => "50000",
+                        Audio::OPTION_ACODEC            => "libmp3lame",
+                        Audio::OPTION_DEVICE            => ["all"]
+                    ),
                 ),
                 "form" => array(
-                    "audiobitrate" => "slide",
-                    "audiosamplerate" => "select",
-                    "acodec" => "select",
-                    "devices" => "checkbox",
+                    Audio::OPTION_AUDIOBITRATE      => "slide",
+                    Audio::OPTION_AUDIOSAMPLERATE   => "select",
+                    Audio::OPTION_ACODEC            => "select",
+                    Audio::OPTION_DEVICE            => "checkbox",
                 ),
             ),
-            "flexpaper" => array(
+            Subdef::TYPE_FLEXPAPER => array(
                 "definitions" => array(
-                    "low_F" => array(),
-                    "medium_F" => array(),
-                    "high_F" => array(),
                 ),
                 "form" => array(),
             ),

--- a/lib/Alchemy/Phrasea/Controller/Admin/SubdefsController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SubdefsController.php
@@ -44,7 +44,7 @@ class SubdefsController extends Controller
 
         $databox = $this->findDataboxById((int) $sbas_id);
 
-        $add_subdef = ['class' => null, 'name'  => null, 'group' => null];
+        $add_subdef = ['class' => null, 'name'  => null, 'group' => null, 'presets' => null];
         foreach ($add_subdef as $k => $v) {
             if (!isset($toadd_subdef[$k]) || trim($toadd_subdef[$k]) === '') {
                 unset($add_subdef[$k]);
@@ -59,7 +59,7 @@ class SubdefsController extends Controller
             $name = $delete_subef[1];
             $subdefs = $databox->get_subdef_structure();
             $subdefs->delete_subdef($group, $name);
-        } elseif (count($add_subdef) === 3) {
+        } elseif (count($add_subdef) === 4) {
             $subdefs = $databox->get_subdef_structure();
 
             $group = $add_subdef['group'];
@@ -67,8 +67,9 @@ class SubdefsController extends Controller
             $unicode = $this->app['unicode'];
             $name = $unicode->remove_nonazAZ09($add_subdef['name'], false);
             $class = $add_subdef['class'];
+            $preset = $add_subdef['presets'];
 
-            $subdefs->add_subdef($group, $name, $class);
+            $subdefs->add_subdef($group, $name, $class, $preset);
         } else {
             $subdefs = $databox->get_subdef_structure();
 
@@ -80,6 +81,7 @@ class SubdefsController extends Controller
                 $group = $post_sub_ex[0];
                 $name = $post_sub_ex[1];
 
+                $preset = $request->request->get($post_sub . '_presets');
                 $class = $request->request->get($post_sub . '_class');
                 $downloadable = $request->request->get($post_sub . '_downloadable');
 
@@ -108,8 +110,7 @@ class SubdefsController extends Controller
                 }
 
                 $labels = $request->request->get($post_sub . '_label', []);
-
-                $subdefs->set_subdef($group, $name, $class, $downloadable, $options, $labels);
+                $subdefs->set_subdef($group, $name, $class, $preset, $downloadable, $options, $labels);
             }
         }
 

--- a/lib/Alchemy/Phrasea/Databox/Subdef/SubdefPreset.php
+++ b/lib/Alchemy/Phrasea/Databox/Subdef/SubdefPreset.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Alchemy\Phrasea\Databox\Subdef;
+
+class SubdefPreset
+{
+    /**
+     * @var string
+     */
+    private $mediaType;
+
+    /**
+     * @var string
+     */
+    private $label;
+
+    /**
+     * @var array
+     */
+    private $definitions;
+
+    /**
+     * @param string $mediaType
+     * @param array $definitions
+     */
+    public function __construct($mediaType, array $definitions)
+    {
+        foreach ($definitions as $definition) {
+            if (! $definition instanceof Subdef) {
+
+            }
+        }
+
+        $this->mediaType = (string) $mediaType;
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMediaType()
+    {
+        return $this->label;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefinitions()
+    {
+        return $this->definitions;
+    }
+}

--- a/lib/Alchemy/Phrasea/Databox/Subdef/SubdefPresetProvider.php
+++ b/lib/Alchemy/Phrasea/Databox/Subdef/SubdefPresetProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Alchemy\Phrasea\Databox\Subdef;
+
+class SubdefPresetProvider
+{
+
+    private $presets = [];
+
+    /**
+     * @param string $type Type of media for which to get presets
+     * @return SubdefPreset[]
+     */
+    public function getPresets($type)
+    {
+        if (! isset($this->presets[$type])) {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        return $this->presets[$type];
+    }
+}

--- a/lib/Alchemy/Phrasea/Media/Subdef/Subdef.php
+++ b/lib/Alchemy/Phrasea/Media/Subdef/Subdef.php
@@ -15,6 +15,8 @@ use MediaAlchemyst\Specification\SpecificationInterface;
 
 interface Subdef
 {
+    const OPTION_DEVICE = 'devices';
+
     const TYPE_IMAGE = 'image';
     const TYPE_ANIMATION = 'gif';
     const TYPE_VIDEO = 'video';

--- a/lib/classes/databox/subdef.php
+++ b/lib/classes/databox/subdef.php
@@ -32,6 +32,7 @@ class databox_subdef
     protected $devices = [];
     protected $name;
     protected $path;
+    protected $preset;
     protected $subdef_group;
     protected $labels = [];
 
@@ -80,6 +81,7 @@ class databox_subdef
         $this->name = strtolower($sd->attributes()->name);
         $this->downloadable = p4field::isyes($sd->attributes()->downloadable);
         $this->path = trim($sd->path) !== '' ? p4string::addEndSlash(trim($sd->path)) : '';
+        $this->preset = $sd->attributes()->presets;
 
         $this->requiresMetadataUpdate = p4field::isyes((string) $sd->meta);
 
@@ -121,6 +123,15 @@ class databox_subdef
     public function get_class()
     {
         return $this->class;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function get_preset()
+    {
+        return $this->preset;
     }
 
     /**

--- a/lib/classes/databox/subdefsStructure.php
+++ b/lib/classes/databox/subdefsStructure.php
@@ -184,10 +184,11 @@ class databox_subdefsStructure implements IteratorAggregate, Countable
      * @param  string $groupname
      * @param  string $name
      * @param  string $class
+     * @param  string $mediatype
      * @param  string $preset
      * @return databox_subdefsStructure
      */
-    public function add_subdef($groupname, $name, $class, $preset)
+    public function add_subdef($groupname, $name, $class, $mediatype, $preset)
     {
         $dom_struct = $this->databox->get_dom_structure();
 
@@ -195,6 +196,7 @@ class databox_subdefsStructure implements IteratorAggregate, Countable
         $subdef->setAttribute('class', $class);
         $subdef->setAttribute('name', mb_strtolower($name));
         $subdef->setAttribute('presets', $preset);
+        $subdef->setAttribute('mediaType', $mediatype);
 
         $dom_xp = $this->databox->get_xpath_structure();
         $query = '//record/subdefs/subdefgroup[@name="' . $groupname . '"]';

--- a/lib/classes/databox/subdefsStructure.php
+++ b/lib/classes/databox/subdefsStructure.php
@@ -184,15 +184,17 @@ class databox_subdefsStructure implements IteratorAggregate, Countable
      * @param  string $groupname
      * @param  string $name
      * @param  string $class
+     * @param  string $preset
      * @return databox_subdefsStructure
      */
-    public function add_subdef($groupname, $name, $class)
+    public function add_subdef($groupname, $name, $class, $preset)
     {
         $dom_struct = $this->databox->get_dom_structure();
 
         $subdef = $dom_struct->createElement('subdef');
         $subdef->setAttribute('class', $class);
         $subdef->setAttribute('name', mb_strtolower($name));
+        $subdef->setAttribute('presets', $preset);
 
         $dom_xp = $this->databox->get_xpath_structure();
         $query = '//record/subdefs/subdefgroup[@name="' . $groupname . '"]';
@@ -219,13 +221,14 @@ class databox_subdefsStructure implements IteratorAggregate, Countable
      * @param string $group
      * @param string $name
      * @param string $class
+     * @param string $preset
      * @param boolean $downloadable
      * @param array $options
      * @param array $labels
      * @return databox_subdefsStructure
      * @throws Exception
      */
-    public function set_subdef($group, $name, $class, $downloadable, $options, $labels)
+    public function set_subdef($group, $name, $class, $preset, $downloadable, $options, $labels)
     {
         $dom_struct = $this->databox->get_dom_structure();
 
@@ -233,6 +236,7 @@ class databox_subdefsStructure implements IteratorAggregate, Countable
         $subdef->setAttribute('class', $class);
         $subdef->setAttribute('name', mb_strtolower($name));
         $subdef->setAttribute('downloadable', ($downloadable ? 'true' : 'false'));
+        $subdef->setAttribute('presets', $preset);
 
         foreach ($labels as $code => $label) {
             $child = $dom_struct->createElement('label');

--- a/resources/www/admin/styles/main.scss
+++ b/resources/www/admin/styles/main.scss
@@ -402,7 +402,7 @@ input[id="elasticsearch_settings_highlight"] {
   left: -5px;
 }
 
-.form-horizontal .controls + div{
+.form-horizontal .controls + div {
   margin-left: 180px;
   font-style: italic;
 }
@@ -414,6 +414,15 @@ input[id="elasticsearch_settings_highlight"] {
 
 #users_page .user_deleter {
   margin-top: 5px;
+}
+
+.ui-dialog .ui-dialog-content {
+  position: relative;
+  border: 0;
+  padding: .5em 1em;
+  background: none;
+  margin-bottom: 7rem;
+  overflow: visible;
 }
 
 @media screen and (max-width: 1150px) {

--- a/templates/web/admin/subdefs.html.twig
+++ b/templates/web/admin/subdefs.html.twig
@@ -30,7 +30,7 @@
             $(box).toggle("500");
         });
 
-        $("input, select").on("change", activeSubmit);
+        $("input, select").one("change", activeSubmit);
     });
 
     function activeSubmit() {
@@ -67,8 +67,8 @@
         var config = JSON.parse('{{ config |json_encode|raw }}'),
                 i = 0,
                 defType = $('[name="'+section+'_'+name+'_mediatype"]').val(),
-                quality = $('[name="'+section+'_'+name+'_quality"]').val(),
-                optionValue = $('[name="'+section+'_'+name+'_quality"] option:selected').attr("value");
+                preset = $('[name="'+section+'_'+name+'_presets"]').val(),
+                optionValue = $('[name="'+section+'_'+name+'_presets"] option:selected').attr("value");
 
         if(typeof optionValue === 'undefined'){
 
@@ -78,16 +78,16 @@
 
         for (var input in config[defType].form) {
             if(config[defType].form[input] == "slide"){
-                fillSlide(section, name, defType, input, config[defType].definitions[quality][i]);
+                fillSlide(section, name, defType, input, config[defType].definitions[preset][i]);
             }
             if(config[defType].form[input] == "radio"){
-                fillRadio(section, name, defType, input, config[defType].definitions[quality][i]);
+                fillRadio(section, name, defType, input, config[defType].definitions[preset][i]);
             }
             if(config[defType].form[input] == "select"){
-                fillSelect(section, name, defType, input, config[defType].definitions[quality][i]);
+                fillSelect(section, name, defType, input, config[defType].definitions[preset][i]);
             }
             if(config[defType].form[input] == "checkbox"){
-                fillCheckbox(section, name, defType, input, config[defType].definitions[quality][i]);
+                fillCheckbox(section, name, defType, input, config[defType].definitions[preset][i]);
             }
             i++;
         }
@@ -96,7 +96,7 @@
     function select_mediatype(type, name, selector)
     {
         var config = JSON.parse('{{ config |json_encode|raw }}'),
-                inputPresets = '[name="'+type+'_'+name+'_quality"]',
+                inputPresets = '[name="'+type+'_'+name+'_presets"]',
                 defType = $(selector).val();
 
 
@@ -118,7 +118,7 @@
             .find('option')
             .remove()
             .end()
-            .append($("<option></option>").text('{{ 'Choisir' | trans }}'));
+            .append($("<option value='custom'></option>").text('{{ 'Custom' | trans }}'));
 
         if(typeof config[defType] === 'undefined'){
 
@@ -140,12 +140,43 @@
         }
     }
 
+    function media_type(selector){
+        var config = JSON.parse('{{ config |json_encode|raw }}'),
+                defType = $(selector).val();
+
+        $("#presets")
+                .find('option')
+                .remove()
+                .end()
+                .append($("<option></option>").text('{{ 'Choisir' | trans }}'));
+
+        if(typeof config[defType] === 'undefined'){
+
+            return;
+        }
+
+        for (var key in config[defType].definitions) {
+            if (config[defType].definitions[key] == null){
+                $("#presets").append($("<option></option>")
+                        .attr("disabled", "disabled")
+                        .text(key)
+                );
+            }else{
+                $("#presets").append($('<option></option>')
+                        .attr("value", key)
+                        .text(key)
+                );
+            }
+        }
+
+    }
+
     $(function() {
       // a workaround for a flaw in the demo system (http://dev.jqueryui.com/ticket/4375), ignore!
       $( "#dialog:ui-dialog" ).dialog( "destroy" );
 
-      var name = $( "#name" ), accessclass = $( "#accessclass" ),
-      allFields = $( [] ).add( name ).add(accessclass),
+      var name = $( "#name" ), accessclass = $( "#accessclass" ), presets = $( "#presets" ),
+      allFields = $( [] ).add( name ).add(accessclass).add(presets),
       tips = $( ".validateTips" );
 
       function updateTips( t ) {
@@ -205,8 +236,8 @@
 
       $( "#dialog-form" ).dialog({
         autoOpen: false,
-        height: 250,
-        width: 350,
+        height: 380,
+        width: 300,
         modal: true,
         buttons: {
           "Create a Subdef": function() {
@@ -224,6 +255,7 @@
               $('input[name="add_subdef[group]"]').val(get_current_group());
               $('input[name="add_subdef[name]"]').val(name.val());
               $('input[name="add_subdef[class]"]').val(accessclass.val());
+              $('input[name="add_subdef[presets]"]').val(presets.val());
               $( this ).dialog( "close" );
               $('form.subdefs').submit();
             }
@@ -299,6 +331,27 @@
                 <option value="preview" selected="selected">{{ 'preview' | trans }}</option>
                 <option value="thumbnail">{{ 'tout le monde' | trans }}</option>
             </select>
+            <label for="mediaType">{{ 'mediatype' | trans }}</label>
+            <select name="mediaType" onchange="media_type(this)">
+                <option>{{ 'Choisir' | trans }}</option>
+                <option value="image">{{ 'image' | trans }}</option>
+                <option value="video">{{ 'video' | trans }}</option>
+                <option value="gif">{{ 'gif' | trans }}</option>
+                <option value="audio">{{ 'audio' | trans }}</option>
+                <option value="flexpaper">{{ 'flexpaper' | trans }}</option>
+            </select>
+            <label for="presets">{{ 'Presets' | trans }}</label>
+            <select name="presets" id="presets">
+                <option>{{ 'Choisir' | trans }}</option>
+                {% set defType = subdef.getSubdefType.getType() %}
+                {% for key, pressets in config[defType].definitions %}
+                    {% if pressets == null %}
+                        <option disabled="disabled">{{ key }}</option>
+                    {% else %}
+                        <option value="{{ key }}">{{ key }}</option>
+                    {% endif %}
+                {% endfor %}
+            </select>
         </fieldset>
     </form>
 </div>
@@ -342,15 +395,6 @@
                         </tr>
                         <tr>
                             <td>
-                            Path
-                            </td>
-                            <td>
-                            <input class="path_testable test_writeable" type="text" value="{{subdef.get_path()}}" name="{{subdefgroup}}_{{subdefname}}_path"/>
-                            </td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <td>
                                 {{ 'mediatype' | trans }}
                             </td>
                             <td>
@@ -368,17 +412,26 @@
                                 {{ 'Presets' | trans }}
                             </td>
                             <td>
-                                <select onchange="populate_values('{{subdefgroup}}', '{{subdefname}}');" name="{{subdefgroup}}_{{subdefname}}_quality">
-                                    <option>{{ 'Choisir' | trans }}</option>
+                                <select onchange="populate_values('{{subdefgroup}}', '{{subdefname}}');" name="{{subdefgroup}}_{{subdefname}}_presets">
+                                    <option value="custom">{{ 'Custom' | trans }}</option>
                                     {% set defType = subdef.getSubdefType.getType() %}
                                     {% for key, pressets in config[defType].definitions %}
                                         {% if pressets == null %}
                                             <option disabled="disabled">{{ key }}</option>
                                         {% else %}
-                                            <option value="{{ key }}">{{ key }}</option>
+                                            <option value="{{ key }}" {% if subdef.get_preset() == key %}selected="selected"{% endif %}>{{ key }}</option>
                                         {% endif %}
                                     {% endfor %}
                                 </select>
+                            </td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td>
+                                Path
+                            </td>
+                            <td>
+                                <input class="path_testable test_writeable" type="text" value="{{subdef.get_path()}}" name="{{subdefgroup}}_{{subdefname}}_path"/>
                             </td>
                             <td></td>
                         </tr>
@@ -430,7 +483,9 @@
                                             {% if option.getStep() is not empty %}step : {{ option.getStep() }},{% endif %}
                                             slide: function( event, ui ) {
                                                 $( "#slidervalue{{subdefgroup}}{{subdefname}}{{ subdefType.getType() }}{{ option.getName() }}" ).val( ui.value );
-                                                activeSubmit();
+                                                jQuery('[name={{subdefgroup}}_{{subdefname}}_presets]').val("custom");
+                                                if(jQuery(".subviews-submit").attr("disabled"))
+                                                    activeSubmit();
                                             },
                                             create: function (event, ui) {
                                                 {# add no-ajax class to slider link to prevent page load in IE7 #}
@@ -473,6 +528,12 @@
                 </div>
                 {% endfor %}
             </div>
+            <script>
+                {% set defType = subdef.getSubdefType.getType() %}
+                jQuery('#box{{subdefgroup}}{{subdefname}}{{ defType }} input, #box{{subdefgroup}}{{subdefname}}{{ defType }} select').change(function(){
+                    jQuery('[name={{subdefgroup}}_{{subdefname}}_presets]').val("custom");
+                });
+            </script>
             {% endfor %}
         </div>
         {% endfor %}
@@ -481,6 +542,7 @@
     <input type="hidden" name="add_subdef[group]" value=""/>
     <input type="hidden" name="add_subdef[name]" value=""/>
     <input type="hidden" name="add_subdef[class]" value=""/>
+    <input type="hidden" name="add_subdef[presets]" value=""/>
 </form>
 
 <div style="display:none;">

--- a/templates/web/admin/subdefs.html.twig
+++ b/templates/web/admin/subdefs.html.twig
@@ -140,6 +140,24 @@
         }
     }
 
+    function subview_type(selector) {
+        var mapping = JSON.parse('{{ subviews_mapping |json_encode|raw }}'),
+                subviewType = $(selector).val();
+
+        $("#mediaType")
+                .find('option')
+                .remove()
+                .end()
+                .append($("<option></option>").text('{{ 'Choisir' | trans }}'));
+
+        for (var key in mapping[subviewType]) {
+            $("#mediaType").append($('<option></option>')
+                    .attr("value", mapping[subviewType][key])
+                    .text(mapping[subviewType][key])
+            );
+        }
+    }
+    
     function media_type(selector){
         var config = JSON.parse('{{ config |json_encode|raw }}'),
                 defType = $(selector).val();
@@ -168,15 +186,14 @@
                 );
             }
         }
-
     }
 
     $(function() {
       // a workaround for a flaw in the demo system (http://dev.jqueryui.com/ticket/4375), ignore!
       $( "#dialog:ui-dialog" ).dialog( "destroy" );
 
-      var name = $( "#name" ), accessclass = $( "#accessclass" ), presets = $( "#presets" ),
-      allFields = $( [] ).add( name ).add(accessclass).add(presets),
+      var name = $( "#name" ), accessclass = $( "#accessclass" ), subviewType =$( "#subviewType" ) , mediaType = $( "#mediaType" ), presets = $( "#presets" ),
+      allFields = $( [] ).add( name ).add(accessclass).add(subviewType).add(mediaType).add(presets),
       tips = $( ".validateTips" );
 
       function updateTips( t ) {
@@ -200,14 +217,9 @@
         }
       }
 
-      function get_current_group()
-      {
-        return $('.ui-tabs-nav .ui-state-active a').html();
-      }
+      function checkPresence( mediaType, o ) {
 
-      function checkPresence( o ) {
-
-        var el = $('input[name="subdefs[]"][value="'+get_current_group()+'_'+o.val()+'"]');
+        var el = $('input[name="subdefs[]"][value="'+mediaType+'_'+o.val()+'"]');
         if ( el.length !== 0 ) {
           o.addClass( "ui-state-error" );
           updateTips( "SubdefName should be unique per group" );
@@ -236,7 +248,7 @@
 
       $( "#dialog-form" ).dialog({
         autoOpen: false,
-        height: 380,
+        height: 420,
         width: 300,
         modal: true,
         buttons: {
@@ -247,13 +259,12 @@
 
             bValid = bValid && checkLength( name, "subdef name", 3, 16 );
             bValid = bValid && checkSpecialChar( name );
-            bValid = bValid && checkPresence( name );
-
-
+            bValid = bValid && checkPresence( subviewType.val(), name );
 
             if ( bValid ) {
-              $('input[name="add_subdef[group]"]').val(get_current_group());
+              $('input[name="add_subdef[group]"]').val(subviewType.val());
               $('input[name="add_subdef[name]"]').val(name.val());
+              $('input[name="add_subdef[mediaType]"]').val(mediaType.val());
               $('input[name="add_subdef[class]"]').val(accessclass.val());
               $('input[name="add_subdef[presets]"]').val(presets.val());
               $( this ).dialog( "close" );
@@ -331,14 +342,26 @@
                 <option value="preview" selected="selected">{{ 'preview' | trans }}</option>
                 <option value="thumbnail">{{ 'tout le monde' | trans }}</option>
             </select>
-            <label for="mediaType">{{ 'mediatype' | trans }}</label>
-            <select name="mediaType" onchange="media_type(this)">
+            <label for="subviewType">{{ 'subviewType' | trans }}</label>
+            <select name="subviewType" id="subviewType" onchange="subview_type(this)">
                 <option>{{ 'Choisir' | trans }}</option>
                 <option value="image">{{ 'image' | trans }}</option>
                 <option value="video">{{ 'video' | trans }}</option>
-                <option value="gif">{{ 'gif' | trans }}</option>
                 <option value="audio">{{ 'audio' | trans }}</option>
-                <option value="flexpaper">{{ 'flexpaper' | trans }}</option>
+                <option value="document">{{ 'document' | trans }}</option>
+                <option value="flash">{{ 'flash' | trans }}</option>
+            </select>
+            <label for="mediaType">{{ 'mediatype' | trans }}</label>
+            <select name="mediaType" id="mediaType" onchange="media_type(this)">
+                <option>{{ 'Choisir' | trans }}</option>
+                {% set mediaType = subdef.getSubdefType.getType() %}
+                {% for key, pressets in config[defType].definitions %}
+                    {% if pressets == null %}
+                        <option disabled="disabled">{{ key }}</option>
+                    {% else %}
+                        <option value="{{ key }}">{{ key }}</option>
+                    {% endif %}
+                {% endfor %}
             </select>
             <label for="presets">{{ 'Presets' | trans }}</label>
             <select name="presets" id="presets">
@@ -541,6 +564,7 @@
     <input type="hidden" name="delete_subdef" id="delete_subdef" value=""/>
     <input type="hidden" name="add_subdef[group]" value=""/>
     <input type="hidden" name="add_subdef[name]" value=""/>
+    <input type="hidden" name="add_subdef[mediaType]" value=""/>
     <input type="hidden" name="add_subdef[class]" value=""/>
     <input type="hidden" name="add_subdef[presets]" value=""/>
 </form>

--- a/tests/Alchemy/Tests/Phrasea/Controller/Admin/SubdefsTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Admin/SubdefsTest.php
@@ -58,7 +58,7 @@ class SubdefsTest extends \PhraseanetAuthenticatedWebTestCase
     {
         $subdefs =  $this->getApplication()->findDataboxById($this->databox_id)->get_subdef_structure();
         $name = $this->getSubdefName();
-        $subdefs->add_subdef("image", $name, "thumbnail");
+        $subdefs->add_subdef("image", $name, "thumbnail", "1280px JPG (preview Phraseanet)");
         self::$DI['client']->request("POST", "/admin/subdefs/" .  $this->databox_id . "/", ['delete_subdef' => 'image_' . $name]);
         $this->assertTrue(self::$DI['client']->getResponse()->isRedirect());
         try {
@@ -73,7 +73,7 @@ class SubdefsTest extends \PhraseanetAuthenticatedWebTestCase
     {
         $subdefs =  $this->getApplication()->findDataboxById($this->databox_id)->get_subdef_structure();
         $name = $this->getSubdefName();
-        $subdefs->add_subdef("image", $name, "thumbnail");
+        $subdefs->add_subdef("image", $name, "thumbnail", "1280px JPG (preview Phraseanet)");
         self::$DI['client']->request("POST", "/admin/subdefs/" .  $this->databox_id . "/"
             , ['subdefs' => [
                 'image_' . $name

--- a/tests/Alchemy/Tests/Phrasea/Controller/Admin/SubdefsTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Admin/SubdefsTest.php
@@ -58,7 +58,7 @@ class SubdefsTest extends \PhraseanetAuthenticatedWebTestCase
     {
         $subdefs =  $this->getApplication()->findDataboxById($this->databox_id)->get_subdef_structure();
         $name = $this->getSubdefName();
-        $subdefs->add_subdef("image", $name, "thumbnail", "1280px JPG (preview Phraseanet)");
+        $subdefs->add_subdef("image", $name, "thumbnail", "image", "1280px JPG (preview Phraseanet)");
         self::$DI['client']->request("POST", "/admin/subdefs/" .  $this->databox_id . "/", ['delete_subdef' => 'image_' . $name]);
         $this->assertTrue(self::$DI['client']->getResponse()->isRedirect());
         try {
@@ -73,7 +73,7 @@ class SubdefsTest extends \PhraseanetAuthenticatedWebTestCase
     {
         $subdefs =  $this->getApplication()->findDataboxById($this->databox_id)->get_subdef_structure();
         $name = $this->getSubdefName();
-        $subdefs->add_subdef("image", $name, "thumbnail", "1280px JPG (preview Phraseanet)");
+        $subdefs->add_subdef("image", $name, "thumbnail", "image", "1280px JPG (preview Phraseanet)");
         self::$DI['client']->request("POST", "/admin/subdefs/" .  $this->databox_id . "/"
             , ['subdefs' => [
                 'image_' . $name


### PR DESCRIPTION
## Changelog

### Adds
  - Add subdef pressets on subdef admin form.
  - Subdefs are hardcoded and defined on SubdefController. TODO: create API route to manage subdef subsets values. 
 - On subdef creation, presets values are deployed on subdef configuration. 

