### PR TITLE
PHRAS-1359_remove_back_slash_n

### DIFF
--- a/lib/classes/cache/databox.php
+++ b/lib/classes/cache/databox.php
@@ -78,8 +78,7 @@ class cache_databox
                     $key = 'record_' . $sbas_id . '_' . $row['value'] . '_' . \record_adapter::CACHE_TECHNICAL_DATA;
                     $databox->delete_data_from_cache($key);
 
-                    $sql = 'DELETE FROM memcached
-              WHERE site_id = :site_id AND type="record" AND value = :value';
+                    $sql = 'DELETE FROM memcached WHERE site_id = :site_id AND type="record" AND value = :value';
 
                     $params = [
                         ':site_id' => $app['conf']->get('servername')
@@ -101,8 +100,7 @@ class cache_databox
                 case 'structure':
                     $app->getApplicationBox()->delete_data_from_cache(\appbox::CACHE_LIST_BASES);
 
-                    $sql = 'DELETE FROM memcached
-              WHERE site_id = :site_id AND type="structure" AND value = :value';
+                    $sql = 'DELETE FROM memcached WHERE site_id = :site_id AND type="structure" AND value = :value';
 
                     $params = [
                         ':site_id' => $app['conf']->get('servername')


### PR DESCRIPTION
removing \n into SQL requests causing memcached content deletion issues.

## Changelog
### Changed
  - Breaking change
  
### Fixes
  - PHRAS-1359: memcache mysql table content deletion fix
  - \n creates an issue while deleting memcached table content, causing issues into Phraseanet
