### PR TITLE
PHRAS-1341_Admin_setup_user_smtp_autofill_to_off

### DIFF
--- a/lib/Alchemy/Phrasea/Form/Configuration/EmailFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/EmailFormType.php
@@ -42,6 +42,7 @@ class EmailFormType extends AbstractType
         ]);
         $builder->add('smtp-user', 'text', [
             'label'        => 'SMTP user',
+            'attr' => array('autocomplete' => 'off'),
         ]);
         $builder->add('hidden-password', 'password', [
             'label' => '',
@@ -51,6 +52,7 @@ class EmailFormType extends AbstractType
         ]);
         $builder->add('smtp-password', 'password', [
             'label'        => 'SMTP password',
+            'attr' => array('autocomplete' => 'new-password'),
         ]);
     }
 

--- a/templates/web/admin/setup.html.twig
+++ b/templates/web/admin/setup.html.twig
@@ -31,7 +31,7 @@
 
 
 
-{{ form_start(form, {'method': 'POST', 'action' : path('setup_display_globals'), 'attr': {'class' : 'form-horizontal'}}) }}
+{{ form_start(form, {'method': 'POST', 'action' : path('setup_display_globals'), 'attr': {'autocomplete' : 'off', 'class' : 'form-horizontal'}}) }}
 {{ form_errors(form) }}
 {% for daform in form %}
     <fieldset>


### PR DESCRIPTION
## Changelog
### Changed
  -  lib/Alchemy/Phrasea/Form/Configuration/EmailFormType.php
  -  templates/web/admin/setup.html.twig
  
### Fixes
  - PHRAS-1341_Admin_setup_user_smtp_autofill_to_off
  - Remove navigator autofill bug in SMTP user and SMTP password fields

