### PR TITLE
PHRAS-1404_Admin_search_engine_setting_send_GET_settings

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
@@ -56,29 +56,6 @@ class SearchEngineController extends Controller
         $indexer = $this->app['elasticsearch.indexer'];
         if (!$indexer->indexExists()) {
             $indexer->createIndex();
-
-            $options = $this->app['elasticsearch.options'];
-            $curl = curl_init();
-
-            curl_setopt_array($curl, [
-                CURLOPT_URL => "http://localhost:9200/" . $options->getIndexName() . "/_settings",
-                CURLOPT_CUSTOMREQUEST => "PUT",
-                CURLOPT_POSTFIELDS => "{ \"index\" : { \"max_result_window\" : 500000 } }",
-            ]);
-
-            $response = curl_exec($curl);
-            $err = curl_error($curl);
-
-            curl_close($curl);
-
-            if ($err)
-            {
-                echo "cURL Error #:" . $err;
-            }
-            else
-            {
-                echo $response;
-            }
         }
         return $this->app->redirectPath('admin_searchengine_form');
     }
@@ -113,36 +90,26 @@ class SearchEngineController extends Controller
 
     public function dumpResultIndexElasticsearchAction()
     {
-        $options = $this->app['elasticsearch.options'];
-        $indexName = $options->getIndexName();
-        $curl = curl_init();
-
-        curl_setopt_array($curl, [
-            CURLOPT_URL => "http://localhost:9200/" . $indexName . "/_settings/index.number_*",
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_CUSTOMREQUEST => "GET",
-        ]);
-
-        $response = curl_exec($curl);
-        $err = curl_error($curl);
-
-        curl_close($curl);
-
-        if ($err)
+        $indexer = $this->app['elasticsearch.indexer'];
+        if (!$indexer->indexExists())
         {
             return $this->app->json([
                 'success' => false,
-                'message' => implode("\n", $err),
+                'message' => ("Error"),
             ]);
         }
         else
         {
-            $resultat = json_decode($response);
-
+            $index = $this->app['elasticsearch.index'];
+            $resultat = $index->getOptions();
+            $response = [
+                'number_of_shards' => $resultat->getShards(),
+                'number_of_replicas' => $resultat->getReplicas(),
+            ];
 
             return $this->app->json([
                 'success' => true,
-                'response' => $resultat->$indexName->settings->index
+                'response' => $response
             ]);
         }
     }

--- a/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
@@ -110,4 +110,40 @@ class SearchEngineController extends Controller
             'action' => $this->app->url('admin_searchengine_form'),
         ]);
     }
+
+    public function dumpResultIndexElasticsearchAction()
+    {
+        $options = $this->app['elasticsearch.options'];
+        $indexName = $options->getIndexName();
+        $curl = curl_init();
+
+        curl_setopt_array($curl, [
+            CURLOPT_URL => "http://localhost:9200/" . $indexName . "/_settings/index.number_*",
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => "GET",
+        ]);
+
+        $response = curl_exec($curl);
+        $err = curl_error($curl);
+
+        curl_close($curl);
+
+        if ($err)
+        {
+            return $this->app->json([
+                'success' => false,
+                'message' => implode("\n", $err),
+            ]);
+        }
+        else
+        {
+            $resultat = json_decode($response);
+
+
+            return $this->app->json([
+                'success' => true,
+                'response' => $resultat->$indexName->settings->index
+            ]);
+        }
+    }
 }

--- a/lib/Alchemy/Phrasea/ControllerProvider/Admin/SearchEngine.php
+++ b/lib/Alchemy/Phrasea/ControllerProvider/Admin/SearchEngine.php
@@ -43,6 +43,9 @@ class SearchEngine implements ControllerProviderInterface, ServiceProviderInterf
         $controllers->post('/create_index', 'controller.admin.search-engine:createIndexAction')
             ->bind("admin_searchengine_create_index");
 
+        $controllers->post('/dump_result_index_elasticsearch', 'controller.admin.search-engine:dumpResultIndexElasticsearchAction')
+            ->bind('admin_searchengine_dump_result_index_elasticsearch');
+
         $controllers->match('/', 'controller.admin.search-engine:formConfigurationPanelAction')
             ->method('GET|POST')
             ->bind('admin_searchengine_form');

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
@@ -55,6 +55,12 @@ class ElasticsearchSettingsFormType extends AbstractType
                 'required' => false
             ])
             ->add('save', 'submit')
+            ->add('dumpResultIndexElasticsearch', 'button', [
+                'label' => 'Dump result index elasticsearch',
+                'attr' => [
+                    'onClick' => 'ajaxDumpResultIndexElasticsearch()'
+                ]
+            ])
         ;
     }
 

--- a/templates/web/admin/search-engine/elastic-search.html.twig
+++ b/templates/web/admin/search-engine/elastic-search.html.twig
@@ -18,5 +18,29 @@
     var elasticSearchIndexExists = false;
     {% endif %}
     searchEngineConfigurationFormInit(elasticSearchIndexExists);
+
+    function ajaxDumpResultIndexElasticsearch() {
+        $.ajax({
+            url: "{{ path('admin_searchengine_dump_result_index_elasticsearch') }}"
+            , type: "POST"
+            , success: function (data) {
+                if (data.success) {
+                    var response = data.response;
+                    $('input[name="elasticsearch_settings[shards]"]').val(response['number_of_shards']);
+                    $('input[name="elasticsearch_settings[replicas]"]').val(response['number_of_replicas']);
+                } else {
+                    if (window.console) {
+                        console.log(data.message);
+                    }
+                    alert("{{ 'An error occured' | trans | e('js') }}" + data.message);
+                }
+            }
+            , error: function (jqXHR, textStatus, errorThrown) {
+                alert("Erreur XML:\n\n" + jqXHR.responseText);
+            }
+        });
+
+        return false;
+    }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Changelog
### Changed
  - lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
- lib/Alchemy/Phrasea/ControllerProvider/Admin/SearchEngine.php
- lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
- templates/web/admin/search-engine/elastic-search.html.twig
  
### Fixes
  -PHRAS-1404_Admin_search_engine_setting_send_GET_settings
  - the button dump the elasticsearch index result to complete the form

