### PR TITLE
PHRAS-1449_Populate-Order-Option_4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
@@ -146,6 +146,7 @@ class SearchEngineServiceProvider implements ServiceProviderInterface
         $app['elasticsearch.indexer.databox_fetcher_factory'] = $app->share(function ($app) {
             return new DataboxFetcherFactory(
                 $app['elasticsearch.record_helper'],
+                $app['elasticsearch.options'],
                 $app,
                 'search_engine.structure',
                 'thesaurus'

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
@@ -35,16 +35,21 @@ class DataboxFetcherFactory
      */
     private $recordHelper;
 
+    /** @var  ElasticsearchOptions */
+    private $options;
+
     /**
      * @param RecordHelper $recordHelper
+     * @param ElasticsearchOptions $options
      * @param \ArrayAccess $container
      * @param string $structureKey
      * @param string $thesaurusKey
      */
-    public function __construct(RecordHelper $recordHelper, \ArrayAccess $container, $structureKey, $thesaurusKey)
+    public function __construct(RecordHelper $recordHelper, ElasticsearchOptions $options, \ArrayAccess $container, $structureKey, $thesaurusKey)
     {
         $this->recordHelper = $recordHelper;
-        $this->container = $container;
+        $this->options      = $options;
+        $this->container    = $container;
         $this->structureKey = $structureKey;
         $this->thesaurusKey = $thesaurusKey;
     }
@@ -59,14 +64,19 @@ class DataboxFetcherFactory
         $connection = $databox->get_connection();
 
         $candidateTerms = new CandidateTerms($databox);
-        $fetcher = new Fetcher($databox, array(
-            new CoreHydrator($databox->get_sbas_id(), $databox->get_viewname(), $this->recordHelper),
-            new TitleHydrator($connection, $this->recordHelper),
-            new MetadataHydrator($connection, $this->getStructure(), $this->recordHelper),
-            new FlagHydrator($this->getStructure(), $databox),
-            new ThesaurusHydrator($this->getStructure(), $this->getThesaurus(), $candidateTerms),
-            new SubDefinitionHydrator($connection)
-        ), $fetcherDelegate);
+        $fetcher = new Fetcher(
+            $databox,
+            $this->options,
+            [
+                new CoreHydrator($databox->get_sbas_id(), $databox->get_viewname(), $this->recordHelper),
+                new TitleHydrator($connection, $this->recordHelper),
+                new MetadataHydrator($connection, $this->getStructure(), $this->recordHelper),
+                new FlagHydrator($this->getStructure(), $databox),
+                new ThesaurusHydrator($this->getStructure(), $this->getThesaurus(), $candidateTerms),
+                new SubDefinitionHydrator($connection)
+            ],
+            $fetcherDelegate
+        );
 
         $fetcher->setBatchSize(200);
         $fetcher->onDrain(function() use ($candidateTerms) {

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -27,6 +27,15 @@ class ElasticsearchOptions
     private $highlight;
     /** @var int */
     private $maxResultWindow;
+    /** @var string */
+    private $populateOrder;
+    /** @var string */
+    private $populateDirection;
+
+    const POPULATE_ORDER_RID  = "RECORD_ID";
+    const POPULATE_ORDER_MODDATE = "MODIFICATION_DATE";
+    const POPULATE_DIRECTION_ASC  = "ASC";
+    const POPULATE_DIRECTION_DESC = "DESC";
 
     /**
      * Factory method to hydrate an instance from serialized options
@@ -45,6 +54,8 @@ class ElasticsearchOptions
             'minScore' => 4,
             'highlight' => true,
             'max_result_window' => 500000,
+            'populate_order' => self::POPULATE_ORDER_RID,
+            'populate_direction' => self::POPULATE_DIRECTION_DESC,
         ], $options);
 
         $self = new self();
@@ -56,6 +67,8 @@ class ElasticsearchOptions
         $self->setMinScore($options['minScore']);
         $self->setHighlight($options['highlight']);
         $self->setMaxResultWindow($options['max_result_window']);
+        $self->setPopulateOrder($options['populate_order']);
+        $self->setPopulateDirection($options['populate_direction']);
 
         return $self;
     }
@@ -74,7 +87,63 @@ class ElasticsearchOptions
             'minScore' => $this->minScore,
             'highlight' => $this->highlight,
             'maxResultWindow' => $this->maxResultWindow,
+            'populate_order' => $this->populateOrder,
+            'populate_direction' => $this->populateDirection,
         ];
+    }
+
+    /**
+     * @param string $order
+     * @return bool returns false if order is invalid
+     */
+    public function setPopulateOrder($order)
+    {
+        $order = strtoupper($order);
+        if(in_array($order, [self::POPULATE_ORDER_RID, self::POPULATE_ORDER_MODDATE])) {
+            $this->populateOrder = $order;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $direction
+     * @return bool returns false if direction is invalid
+     */
+    public function setPopulateDirection($direction)
+    {
+        $direction = strtoupper($direction);
+        if(in_array($direction, [self::POPULATE_DIRECTION_DESC, self::POPULATE_DIRECTION_ASC])) {
+            $this->populateDirection = $direction;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPopulateOrderAsSQL()
+    {
+        static $orderAsColumn = [
+            self::POPULATE_ORDER_RID     => "`record_id`",
+            self::POPULATE_ORDER_MODDATE => "`moddate`",
+        ];
+        // populateOrder IS one of the keys (ensured by setPopulateOrder)
+        return $orderAsColumn[$this->populateOrder];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPopulateDirectionAsSQL()
+    {
+        // already a SQL word
+        return $this->populateDirection;
     }
 
     /**


### PR DESCRIPTION
## Changelog

### Adds
  - PHRAS-1449: allow to specify a populate order/direction for "searchengine.index" cmd, see --help
todo : unit test of new methods
