### PR TITLE
PHRAS-1498 chart not loading IE

### DIFF
--- a/templates/web/common/index_bootstrap.html.twig
+++ b/templates/web/common/index_bootstrap.html.twig
@@ -23,7 +23,7 @@
         <script type="text/javascript" src="/assets/vendors/jquery-ui/jquery-ui{% if not app.debug %}.min{% endif %}.js"></script>
         <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
         <script type="text/javascript">
-            google.charts.load('current', {packages: ['corechart', 'bar']});
+            google.charts.load('42', {packages: ['corechart']});
             $.widget.bridge('uitooltip', $.ui.tooltip);
         </script>
         <script type="text/javascript" src="/assets/vendors/bootstrap/js/bootstrap{% if not app.debug %}.min{% endif %}.js"></script>

--- a/templates/web/prod/preview/popularity.html.twig
+++ b/templates/web/prod/preview/popularity.html.twig
@@ -13,12 +13,12 @@
   <script type="text/javascript">
     $(document).ready(function() {
 
-        var referrersValues = [];
-        var statistics = {{ record.getStatistics(30)|json_encode()|raw }};
+        var referrersValues = [], statistics = null;
+        statistics = {{ record.getStatistics(30)|json_encode()|raw }};
         if(statistics != null) {
             var arrayViews = [], arrayDownloads = [], arrayReferrers = [];
 
-            var statisticsArrayByDay = Object.values(statistics.by_day);
+            var statisticsArrayByDay = _(statistics.by_day).toArray();
             statisticsArrayByDay.map(function(objByDay) {
                 //[new Date(2017, 0, 1), 5],
                 arrayViews.push([new Date(objByDay.label), objByDay.views]);
@@ -27,7 +27,7 @@
 
             //add header for piechart
             arrayReferrers.push(['Links', 'Visualisation']);
-            var statisticsReferrers = Object.values(statistics.referrers);
+            var statisticsReferrers = _(statistics.referrers).toArray();
 
             //sort array in descending order - referrers count
             statisticsReferrers = _.sortBy(statisticsReferrers, "count").reverse();


### PR DESCRIPTION
## Changelog
### Fixes
  - PHRAS-1498: fix issue with chart not loading on IE
  - downgrade google chart API to fix flickering on hover

