### PR TITLE
PHRAS-1688_rollback-record-search-api_4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -75,6 +75,7 @@ use Alchemy\Phrasea\Search\SubdefView;
 use Alchemy\Phrasea\Search\TechnicalDataTransformer;
 use Alchemy\Phrasea\Search\TechnicalDataView;
 use Alchemy\Phrasea\Search\V1SearchCompositeResultTransformer;
+use Alchemy\Phrasea\Search\V1SearchRecordsResultTransformer;
 use Alchemy\Phrasea\Search\V1SearchResultTransformer;
 use Alchemy\Phrasea\SearchEngine\SearchEngineInterface;
 use Alchemy\Phrasea\SearchEngine\SearchEngineLogger;
@@ -1137,6 +1138,49 @@ class V1Controller extends Controller
         $result = $this->doSearch($request);
         $searchView = $this->buildSearchView(
             $result,
+            $includeResolver->resolve($fractal),
+            $this->resolveSubdefUrlTTL($request)
+        );
+
+        $ret = $fractal->createData(new Item($searchView, $searchTransformer))->toArray();
+
+        return Result::create($request, $ret)->createResponse();
+    }
+
+    /**
+     * Get a Response containing the results of a records search
+     *
+     * @deprecated in favor of search
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function searchRecordsAction(Request $request)
+    {
+        $subdefTransformer = new SubdefTransformer($this->app['acl'], $this->getAuthenticatedUser(), new PermalinkTransformer());
+        $technicalDataTransformer = new TechnicalDataTransformer();
+        $recordTransformer = new RecordTransformer($subdefTransformer, $technicalDataTransformer);
+        $searchTransformer = new V1SearchRecordsResultTransformer($recordTransformer);
+
+        $transformerResolver = new SearchResultTransformerResolver([
+            '' => $searchTransformer,
+            'results' => $recordTransformer,
+            'results.thumbnail' => $subdefTransformer,
+            'results.technical_informations' => $technicalDataTransformer,
+            'results.subdefs' => $subdefTransformer,
+            'results.metadata' => new CallbackTransformer(),
+            'results.status' => new CallbackTransformer(),
+            'results.caption' => new CallbackTransformer(),
+        ]);
+        $includeResolver = new IncludeResolver($transformerResolver);
+
+        $fractal = new \League\Fractal\Manager();
+        $fractal->setSerializer(new ArraySerializer());
+        $fractal->parseIncludes($this->resolveSearchRecordsIncludes($request));
+
+        $searchView = $this->buildSearchRecordsView(
+            $this->doSearch($request),
             $includeResolver->resolve($fractal),
             $this->resolveSubdefUrlTTL($request)
         );

--- a/lib/Alchemy/Phrasea/ControllerProvider/Api/V1.php
+++ b/lib/Alchemy/Phrasea/ControllerProvider/Api/V1.php
@@ -118,6 +118,8 @@ class V1 extends Api implements ControllerProviderInterface, ServiceProviderInte
 
         $controllers->match('/search/', 'controller.api.v1:searchAction');
 
+        $controllers->match('/records/search/', 'controller.api.v1:searchRecordsAction');
+
         $controllers->get('/records/{databox_id}/{record_id}/caption/', 'controller.api.v1:getRecordCaptionAction')
             ->before('controller.api.v1:ensureCanAccessToRecord')
             ->assert('databox_id', '\d+')

--- a/lib/Alchemy/Phrasea/Search/V1SearchRecordsResultTransformer.php
+++ b/lib/Alchemy/Phrasea/Search/V1SearchRecordsResultTransformer.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of Phraseanet
+ *
+ * (c) 2005-2016 Alchemy
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Alchemy\Phrasea\Search;
+
+class V1SearchRecordsResultTransformer extends V1SearchTransformer
+{
+    /**
+     * @var RecordTransformer
+     */
+    private $recordTransformer;
+
+    public function __construct(RecordTransformer $recordTransformer)
+    {
+        $this->recordTransformer = $recordTransformer;
+    }
+
+    public function includeResults(SearchResultView $resultView)
+    {
+        return $this->collection($resultView->getRecords(), $this->recordTransformer);
+    }
+}

--- a/tests/Alchemy/Tests/Phrasea/Model/Manipulator/ApiLogManipulatorTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Model/Manipulator/ApiLogManipulatorTest.php
@@ -72,6 +72,7 @@ class ApiLogManipulatorTest extends \PhraseanetTestCase
             ['/databoxes/1/termsOfUse/', ['resource' => 'databoxes', 'aspect' => 'termsOfUse', 'action' => null, 'general' => 'databoxes']],
             ['/quarantine/list/', ['resource' => 'quarantine', 'aspect' => null, 'action' => 'list', 'general' => 'quarantine']],
             ['/records/add/', ['resource' => 'records', 'aspect' => null, 'action' => 'add', 'general' => 'records']],
+            ['/records/search/', ['resource' => 'records', 'aspect' => null, 'action' => 'search', 'general' => 'records']],
             ['/records/1/1/caption/', ['resource' => 'records', 'aspect' => 'caption', 'action' => null, 'general' => 'records']],
             ['/records/1/1/metadatas/', ['resource' => 'records', 'aspect' => 'metadatas', 'action' => null, 'general' => 'records']],
             ['/records/1/1/status/', ['resource' => 'records', 'aspect' => 'status', 'action' => null, 'general' => 'records']],


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1688: revert deleted (obsolete) api route "records/search" because it is used by the Office plugin.