### PR TITLE
Revert "PHRAS-1691_test-testPostGlobals_4.0"

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Admin/SetupController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SetupController.php
@@ -52,7 +52,9 @@ class SetupController extends Controller
 
             if ($form->isValid()) {
                 $registryData = $this->registryFormManipulator->getRegistryData($form, $this->configuration);
-
+                if (count($registryData['custom-links']) > 0) {
+                    $registryData["custom-links"] = json_decode($registryData["custom-links"], true);
+                }
                 $this->configuration->set('registry', $registryData);
             }
 


### PR DESCRIPTION
Reverts alchemy-fr/Phraseanet#2343
bad fix : test is ok, but the customlinks are not written anymore in conf.

note : customlinks are sent as one json string by the form, then json-decoded to be written as array in  conf.
But during tests the conf is read, modified then written back : customlinks is already an array, so json-decode crashes.

todo : do NOT use the trick to json-encode data from the form, send it as real text fields.
The SetupController should never apply a specific work on any field (here "custom-links")