### PR TITLE
Update ansible mariadb variable naming

### DIFF
--- a/resources/ansible/vars/all.yml
+++ b/resources/ansible/vars/all.yml
@@ -41,7 +41,7 @@ nginx:
 mariadb:
     install: '1'
     root_password: toor
-    database: ab_master
+    appbox_db: ab_master
     databox_db: db_master
     alt_db: db_alt
     user: phraseanet


### PR DESCRIPTION
## Changelog

### Fixes
  - Update ansible mariadb variable naming. Provisionning called appbox_db database given
