### PR TITLE
PHRAS-1793_temp-index-phraseanetjy_4.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,9 @@ def config_net(config)
         config.vm.provider "virtualbox" do |vb|
           vb.customize ["modifyvm", :id, "--hostonlyadapter2", "vboxnet0"]
         end
+
+        config.vm.network :public_network, bridge:"en0: Ethernet"
+
         config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
             if vm.id
                 `VBoxManage guestproperty get #{vm.id} "/VirtualBox/GuestInfo/Net/1/V4/IP"`.split()[1]
@@ -49,11 +52,18 @@ $hostname = File.basename($root).downcase
 if which('ip')
     # $hostIps = `ip addr show | grep inet | grep -v inet6 | cut -d' ' -f6 | cut -d'/' -f1`.split("\n");
     $hostIps = `ip addr show | sed -nE 's/[[:space:]]*inet ([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})(.*)$/\\1/p'`.split("\n");
+    # puts "via ip : "
 else
     $hostIps = `ifconfig | sed -nE 's/[[:space:]]*inet ([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})(.*)$/\\1/p'`.split("\n");
+    # puts "via ifconfig : "
 end
+$hostIps.each do |item|
+    # puts item
+end
+# puts "ici"
 
 Vagrant.configure("2") do |config|
+    # puts "là"
 
     # Configure hostmanager
     config.hostmanager.enabled = true
@@ -109,4 +119,5 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.synced_folder "./", "/vagrant", type: "nfs"
+    # puts "fin"
 end

--- a/lib/Alchemy/Phrasea/Command/SearchEngine/IndexManipulateCommand.php
+++ b/lib/Alchemy/Phrasea/Command/SearchEngine/IndexManipulateCommand.php
@@ -130,8 +130,13 @@ class IndexManipulateCommand extends Command
                 return 1;
             }
             else {
-                $indexer->createIndex();
-                $output->writeln(sprintf('<info>Search index "%s" was created</info>', $idx));
+                $r = $indexer->createIndex();
+                $output->writeln(sprintf('<info>Search index "%s@%s:%s" -> "%s" was created</info>'
+                    , $r['alias']
+                    , $options->getHost()
+                    , $options->getPort()
+                    , $r['index']
+                ));
             }
         }
 
@@ -140,19 +145,33 @@ class IndexManipulateCommand extends Command
         if($populate) {
             if(!$indexExists) {
                 $indexer->createIndex();
-                $output->writeln(sprintf('<info>Search index "%s" was created</info>', $idx));
+                $r = $indexer->createIndex();
+                $output->writeln(sprintf('<info>Search index "%s@%s:%s" -> "%s" was created</info>'
+                    , $r['alias']
+                    , $options->getHost()
+                    , $options->getPort()
+                    , $r['index']
+                ));
             }
 
             $oldAliasName = $indexer->getIndex()->getName();
             $newAliasName = $newIndexName = null;
             if($temporary) {
                 // change the name to create a new index
-                $now = sprintf("%s.%06d", Date('YmdHis'), 1000000*explode(' ', microtime())[0]) ;
-                $indexer->getIndex()->getOptions()->setIndexName("temp_". $now);
+                $now = explode(' ', microtime());
+                $now = sprintf("%X%X", $now[1], 1000000*$now[0]);
+                $indexer->getIndex()->getOptions()->setIndexName($oldAliasName . "_T" . $now);
 
-                $r = $indexer->createIndex("phraseanetjy");
+                $r = $indexer->createIndex($oldAliasName);
                 $newIndexName = $r['index'];
                 $newAliasName = $r['alias'];
+
+                $output->writeln(sprintf('<info>Temporary index "%s@%s:%s" -> "%s" was created</info>'
+                    , $r['alias']
+                    , $options->getHost()
+                    , $options->getPort()
+                    , $r['index']
+                ));
             }
 
             foreach ($this->container->getDataboxes() as $databox) {
@@ -168,10 +187,20 @@ class IndexManipulateCommand extends Command
             }
 
             if($temporary) {
+                $output->writeln(sprintf('<info>Renaming temporary to "%s" -> "%s"</info>'
+                    , $newAliasName
+                    , $newIndexName
+                ));
+
                 $indexer->getIndex()->getOptions()->setIndexName($oldAliasName);
 
-                $indexer->replaceIndex($newIndexName, $newAliasName);
+                $r = $indexer->replaceIndex($newIndexName, $newAliasName);
+                foreach($r as $action) {
+                    $output->writeln(sprintf('<info>%s</info>', $action['msg']));
+                }
             }
         }
+
+        return 0;
     }
 }

--- a/www/scripts/apps/admin/require.config.js
+++ b/www/scripts/apps/admin/require.config.js
@@ -11,20 +11,20 @@
 require.config({
     baseUrl: "/scripts",
     paths: {
-        jquery: "../assets/vendors/jquery/jquery.min",
-        "jquery.geonames": "../assets/vendors/jquery.geonames/jquery.geonames",
-        "jquery.ui": "../assets/vendors/jquery-ui/jquery-ui.min",
-        underscore: "../assets/vendors/underscore/underscore.min",
-        backbone: "../assets/vendors/backbone/backbone.min",
-        "jquery.ui.widget": "../assets/vendors/jquery-file-upload/jquery.ui.widget.min",
-        "jquery.cookie": "../assets/vendors/jquery.cookie/jquery.cookie.min",
-        "jquery.treeview": "../assets/vendors/jquery-treeview/jquery.treeview",
+        jquery: "/assets/vendors/jquery/jquery.min",
+        "jquery.geonames": "/assets/vendors/jquery.geonames/jquery.geonames",
+        "jquery.ui": "/assets/vendors/jquery-ui/jquery-ui.min",
+        underscore: "/assets/vendors/underscore/underscore.min",
+        backbone: "/assets/vendors/backbone/backbone.min",
+        "jquery.ui.widget": "/assets/vendors/jquery-file-upload/jquery.ui.widget.min",
+        "jquery.cookie": "/assets/vendors/jquery.cookie/jquery.cookie.min",
+        "jquery.treeview": "/assets/vendors/jquery-treeview/jquery.treeview",
         //"jquery.tooltip": "../include/jquery.tooltip",
-        "blueimp.loadimage" : "../assets/vendors/blueimp-load-image/load-image",
-        "jfu.iframe-transport": "../assets/vendors/jquery-file-upload/jquery.iframe-transport",
-        "jfu.fileupload": "../assets/vendors/jquery-file-upload/jquery.fileupload",
-        i18n: "../assets/vendors/i18next/i18next.min",
-        bootstrap: "../assets/vendors/bootstrap/js/bootstrap.min",
+        "blueimp.loadimage" : "/assets/vendors/blueimp-load-image/load-image",
+        "jfu.iframe-transport": "/assets/vendors/jquery-file-upload/jquery.iframe-transport",
+        "jfu.fileupload": "/assets/vendors/jquery-file-upload/jquery.fileupload",
+        i18n: "/assets/vendors/i18next/i18next.min",
+        bootstrap: "/assets/vendors/bootstrap/js/bootstrap.min"
     },
     shim: {
         "jquery.treeview": {


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1793: when indexing, the temporary alias is not named "phraseanetjy" anymore.
The alias name is "\<index\>\_T\<key\>" where \<key\> is a hex string, helping to distinguish from the index name "\<index\>_\<timestamp\>.\<microseconds\>"

  