### PR TITLE
Phras 1750 missing events from 3.8

### DIFF
--- a/lib/Alchemy/Phrasea/Application/ApiApplicationLoader.php
+++ b/lib/Alchemy/Phrasea/Application/ApiApplicationLoader.php
@@ -19,6 +19,8 @@ use Alchemy\Phrasea\ControllerProvider\Datafiles;
 use Alchemy\Phrasea\ControllerProvider\MediaAccessor;
 use Alchemy\Phrasea\ControllerProvider\Minifier;
 use Alchemy\Phrasea\ControllerProvider\Permalink;
+use Alchemy\Phrasea\Core\Event\ApiLoadEndEvent;
+use Alchemy\Phrasea\Core\Event\ApiLoadStartEvent;
 use Alchemy\Phrasea\Core\Event\ApiResultEvent;
 use Alchemy\Phrasea\Core\Event\Subscriber\ApiExceptionHandlerSubscriber;
 use Alchemy\Phrasea\Core\Event\Subscriber\ApiOauth2ErrorsSubscriber;
@@ -89,6 +91,8 @@ class ApiApplicationLoader extends BaseApplicationLoader
             }
         });
 
+        $app['dispatcher']->dispatch(PhraseaEvents::API_LOAD_START, new ApiLoadStartEvent());
+
         $app->get('/api/', function (Request $request, Application $app) {
             return Result::create($request, [
                 'name'          => $app['conf']->get(['registry', 'general', 'title']),
@@ -140,6 +144,7 @@ class ApiApplicationLoader extends BaseApplicationLoader
         $app->after(function (Request $request, Response $response) use ($app) {
             $app['dispatcher']->dispatch(PhraseaEvents::API_RESULT, new ApiResultEvent($request, $response));
         });
+        $app['dispatcher']->dispatch(PhraseaEvents::API_LOAD_END, new ApiLoadEndEvent());
     }
 
     protected function getDispatcherSubscribersFor(Application $app)

--- a/lib/Alchemy/Phrasea/Core/Event/ApiLoadEndEvent.php
+++ b/lib/Alchemy/Phrasea/Core/Event/ApiLoadEndEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Alchemy\Phrasea\Core\Event;
+
+use Alchemy\Phrasea\Core\PhraseaEvents;
+use Symfony\Component\EventDispatcher\Event as SfEvent;
+
+class ApiLoadEndEvent extends SfEvent
+{
+    public function getName()
+    {
+        return PhraseaEvents::API_LOAD_START;
+    }
+}

--- a/lib/Alchemy/Phrasea/Core/Event/ApiLoadEndEvent.php
+++ b/lib/Alchemy/Phrasea/Core/Event/ApiLoadEndEvent.php
@@ -9,6 +9,6 @@ class ApiLoadEndEvent extends SfEvent
 {
     public function getName()
     {
-        return PhraseaEvents::API_LOAD_START;
+        return PhraseaEvents::API_LOAD_END;
     }
 }

--- a/lib/Alchemy/Phrasea/Core/Event/ApiLoadStartEvent.php
+++ b/lib/Alchemy/Phrasea/Core/Event/ApiLoadStartEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Alchemy\Phrasea\Core\Event;
+
+use Alchemy\Phrasea\Core\PhraseaEvents;
+use Symfony\Component\EventDispatcher\Event as SfEvent;
+
+class ApiLoadStartEvent extends SfEvent
+{
+    public function getName()
+    {
+        return PhraseaEvents::API_LOAD_START;
+    }
+}


### PR DESCRIPTION
## Changelog
### Changed
  - Add missing events from 3.8
  
### Adds
  - PHRAS-1750: port missing 3.8 events to 4.1
  - Add API LOAD START and API LOAD END event

