### PR TITLE
PHRAS-1817_java-provisioning_MASTER

### DIFF
--- a/resources/ansible/roles/elasticsearch/tasks/main.yml
+++ b/resources/ansible/roles/elasticsearch/tasks/main.yml
@@ -13,7 +13,7 @@
   changed_when: false
 
 - name: Install Dependencies
-  apt: pkg=oracle-java8-installer state=latest
+  apt: pkg=openjdk-7-jre state=latest
 
 - name: Remove temporary debian package
   shell: rm -f /tmp/elasticsearch-{{ elasticsearch.version }}.deb


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1817: change provisioning from oracle to openjdk


