### PR TITLE
PHRAS-1823 postport 4.0 switch to openjdk-7-jre

### DIFF
--- a/resources/ansible/roles/elasticsearch/tasks/main.yml
+++ b/resources/ansible/roles/elasticsearch/tasks/main.yml
@@ -15,7 +15,7 @@
   changed_when: false
 
 - name: Install Dependencies
-  apt: pkg=oracle-java8-installer state=latest
+  apt: pkg=openjdk-7-jre state=latest
 
 - name: Remove temporary debian package
   shell: rm -f /tmp/elasticsearch-{{ elasticsearch.version }}.deb


### PR DESCRIPTION
## Changelog

  
### Fixes
  - PHRAS-1823 for vagrant provisioning, switch to openjdk-7-jre repository, Oracle repo is not available  
 