### PR TITLE
PHRAS-1752 update facebook sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
         "doctrine/migrations": "^1.0.0",
         "doctrine/orm": "^2.4.0",
         "elasticsearch/elasticsearch": "~2.0",
-        "facebook/php-sdk": "~3.2",
         "firebase/php-jwt": "^3.0.0",
         "gedmo/doctrine-extensions": "~2.3.0",
         "goodby/csv": "^1.3.0",
@@ -104,7 +103,8 @@
         "vierbergenlars/php-semver": "~2.1",
         "webmozart/json": "^1.1",
         "willdurand/negotiation": "^2.0.0-alpha1",
-        "zend/gdata": "~1.12.1"
+        "zend/gdata": "~1.12.1",
+        "facebook/graph-sdk": "^5.6"
     },
     "require-dev":  {
         "phpunit/phpunit": "~4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1b80b320db80c213b75a253e24284eb5",
-    "content-hash": "90a0142ec5f08902b9127d9f554574d8",
+    "content-hash": "e4da1d6d5bb6b7c15c07f58872839df1",
     "packages": [
         {
             "name": "alchemy-fr/tcpdf-clone",
@@ -71,7 +70,7 @@
                 "source": "https://github.com/alchemy-fr/tcpdf-clone/tree/6.0.039",
                 "issues": "https://github.com/alchemy-fr/tcpdf-clone/issues"
             },
-            "time": "2013-10-13 16:11:17"
+            "time": "2013-10-13T16:11:17+00:00"
         },
         {
             "name": "alchemy/binary-driver",
@@ -128,7 +127,7 @@
                 "binary",
                 "driver"
             ],
-            "time": "2016-03-02 13:49:15"
+            "time": "2016-03-02T13:49:15+00:00"
         },
         {
             "name": "alchemy/embed-bundle",
@@ -182,7 +181,7 @@
                 "source": "https://github.com/alchemy-fr/embed-bundle/tree/0.3.6",
                 "issues": "https://github.com/alchemy-fr/embed-bundle/issues"
             },
-            "time": "2017-05-17 19:25:26"
+            "time": "2017-05-17T19:25:26+00:00"
         },
         {
             "name": "alchemy/geonames-api-consumer",
@@ -220,7 +219,7 @@
             "keywords": [
                 "geonames"
             ],
-            "time": "2014-02-05 15:29:39"
+            "time": "2014-02-05T15:29:39+00:00"
         },
         {
             "name": "alchemy/ghostscript",
@@ -272,7 +271,7 @@
                 "ghostscript",
                 "pdf"
             ],
-            "time": "2013-06-25 09:12:58"
+            "time": "2013-06-25T09:12:58+00:00"
         },
         {
             "name": "alchemy/google-plus-api-client",
@@ -310,7 +309,7 @@
             ],
             "description": "PHP Client for Google APIs",
             "homepage": "https://code.google.com/p/google-api-php-client/",
-            "time": "2016-07-06 13:47:16"
+            "time": "2016-07-06T13:47:16+00:00"
         },
         {
             "name": "alchemy/mediavorus",
@@ -373,7 +372,7 @@
             "keywords": [
                 "metadata"
             ],
-            "time": "2016-05-02 15:08:36"
+            "time": "2016-05-02T15:08:36+00:00"
         },
         {
             "name": "alchemy/oauth2php",
@@ -396,7 +395,7 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2013-07-01 09:46:59"
+            "time": "2013-07-01T09:46:59+00:00"
         },
         {
             "name": "alchemy/phlickr",
@@ -419,7 +418,7 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2014-12-15 14:27:57"
+            "time": "2014-12-15T14:27:57+00:00"
         },
         {
             "name": "alchemy/phpexiftool",
@@ -492,7 +491,7 @@
                 "exiftool",
                 "metadata"
             ],
-            "time": "2017-05-18 19:04:04"
+            "time": "2017-05-18T19:04:04+00:00"
         },
         {
             "name": "alchemy/rest-bundle",
@@ -544,7 +543,7 @@
                 }
             ],
             "description": "Simple REST utility bundle",
-            "time": "2016-05-16 09:37:34"
+            "time": "2016-05-16T09:37:34+00:00"
         },
         {
             "name": "alchemy/symfony-cors",
@@ -591,7 +590,7 @@
                 }
             ],
             "description": "A library that adds CORS services to Silex/Symfony Applications",
-            "time": "2015-12-17 15:34:43"
+            "time": "2015-12-17T15:34:43+00:00"
         },
         {
             "name": "alchemy/task-manager",
@@ -654,7 +653,7 @@
                 "parallel",
                 "process"
             ],
-            "time": "2016-11-30 13:34:30"
+            "time": "2016-11-30T13:34:30+00:00"
         },
         {
             "name": "alchemy/zippy",
@@ -716,7 +715,7 @@
                 "tar",
                 "zip"
             ],
-            "time": "2016-02-15 22:46:40"
+            "time": "2016-02-15T22:46:40+00:00"
         },
         {
             "name": "aws/aws-sdk-php",
@@ -779,7 +778,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-07-25 18:03:20"
+            "time": "2016-07-25T18:03:20+00:00"
         },
         {
             "name": "beberlei/assert",
@@ -834,7 +833,7 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2016-12-05 11:33:17"
+            "time": "2016-12-05T11:33:17+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -874,7 +873,7 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2015-09-28 16:26:35"
+            "time": "2015-09-28T16:26:35+00:00"
         },
         {
             "name": "cocur/slugify",
@@ -938,7 +937,7 @@
                 "slug",
                 "slugify"
             ],
-            "time": "2016-08-09 20:10:17"
+            "time": "2016-08-09T20:10:17+00:00"
         },
         {
             "name": "dailymotion/sdk",
@@ -971,7 +970,7 @@
                 "dailymotion",
                 "sdk"
             ],
-            "time": "2015-11-20 11:18:32"
+            "time": "2015-11-20T11:18:32+00:00"
         },
         {
             "name": "data-uri/data-uri",
@@ -1016,7 +1015,7 @@
                 "data-uri",
                 "uri"
             ],
-            "time": "2014-08-22 15:01:57"
+            "time": "2014-08-22T15:01:57+00:00"
         },
         {
             "name": "dflydev/doctrine-orm-service-provider",
@@ -1078,7 +1077,7 @@
                 "pimple",
                 "silex"
             ],
-            "time": "2015-09-07 12:16:54"
+            "time": "2015-09-07T12:16:54+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -1146,7 +1145,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -1216,7 +1215,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29 11:16:17"
+            "time": "2016-10-29T11:16:17+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -1282,7 +1281,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -1355,7 +1354,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2016-11-30 16:50:46"
+            "time": "2016-11-30T16:50:46+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -1426,7 +1425,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2016-09-09 19:13:33"
+            "time": "2016-09-09T19:13:33+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1493,7 +1492,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1547,7 +1546,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1601,7 +1600,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "doctrine/migrations",
@@ -1675,7 +1674,7 @@
                 "database",
                 "migrations"
             ],
-            "time": "2016-12-25 22:54:00"
+            "time": "2016-12-25T22:54:00+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -1751,7 +1750,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18 15:42:34"
+            "time": "2016-12-18T15:42:34+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",
@@ -1805,7 +1804,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2016-11-30 17:15:05"
+            "time": "2016-11-30T17:15:05+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -1845,54 +1844,65 @@
             "keywords": [
                 "event-dispatcher"
             ],
-            "time": "2012-05-30 15:01:08"
+            "time": "2012-05-30T15:01:08+00:00"
         },
         {
-            "name": "facebook/php-sdk",
-            "version": "v3.2.3",
+            "name": "facebook/graph-sdk",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/facebookarchive/facebook-php-sdk.git",
-                "reference": "6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb"
+                "url": "https://github.com/facebook/php-graph-sdk.git",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebookarchive/facebook-php-sdk/zipball/6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb",
-                "reference": "6714042fa2f5979d4c64c7d11fb4bcab16bdf6cb",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "php": ">=5.2.0"
+                "php": "^5.4|^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*"
+                "guzzlehttp/guzzle": "~5.0",
+                "mockery/mockery": "~0.8",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client",
+                "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
             "autoload": {
-                "classmap": [
-                    "src"
+                "psr-4": {
+                    "Facebook\\": "src/Facebook/"
+                },
+                "files": [
+                    "src/Facebook/polyfills.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache2"
+                "Facebook Platform"
             ],
             "authors": [
                 {
                     "name": "Facebook",
-                    "homepage": "https://github.com/facebook/facebook-php-sdk/contributors"
+                    "homepage": "https://github.com/facebook/php-graph-sdk/contributors"
                 }
             ],
-            "description": "Facebook PHP SDK",
-            "homepage": "https://github.com/facebook/facebook-php-sdk",
+            "description": "Facebook SDK for PHP",
+            "homepage": "https://github.com/facebook/php-graph-sdk",
             "keywords": [
                 "facebook",
                 "sdk"
             ],
-            "abandoned": "facebook/graph-sdk",
-            "time": "2013-11-19 23:11:14"
+            "time": "2017-08-16T17:28:07+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -1935,7 +1945,7 @@
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
-            "time": "2015-07-22 18:31:08"
+            "time": "2015-07-22T18:31:08+00:00"
         },
         {
             "name": "gedmo/doctrine-extensions",
@@ -2013,7 +2023,7 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2015-02-24 21:41:37"
+            "time": "2015-02-24T21:41:37+00:00"
         },
         {
             "name": "goodby/csv",
@@ -2070,7 +2080,7 @@
                 "export",
                 "import"
             ],
-            "time": "2015-06-29 10:28:19"
+            "time": "2015-06-29T10:28:19+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -2166,7 +2176,7 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18 18:23:50"
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",
@@ -2217,7 +2227,7 @@
                 }
             ],
             "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2015-05-20 03:37:09"
+            "time": "2015-05-20T03:37:09+00:00"
         },
         {
             "name": "guzzlehttp/streams",
@@ -2267,7 +2277,7 @@
                 "Guzzle",
                 "stream"
             ],
-            "time": "2014-10-12 19:18:40"
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "hoa/compiler",
@@ -2347,7 +2357,7 @@
                 "trace",
                 "uniform"
             ],
-            "time": "2015-10-29 21:35:12"
+            "time": "2015-10-29T21:35:12+00:00"
         },
         {
             "name": "hoa/console",
@@ -2419,7 +2429,7 @@
                 "tput",
                 "window"
             ],
-            "time": "2015-07-27 07:52:10"
+            "time": "2015-07-27T07:52:10+00:00"
         },
         {
             "name": "hoa/core",
@@ -2487,7 +2497,7 @@
                 "protocol"
             ],
             "abandoned": "hoa/consistency",
-            "time": "2015-11-09 06:51:06"
+            "time": "2015-11-09T06:51:06+00:00"
         },
         {
             "name": "hoa/dispatcher",
@@ -2547,7 +2557,7 @@
                 "kit",
                 "library"
             ],
-            "time": "2015-11-09 06:52:08"
+            "time": "2015-11-09T06:52:08+00:00"
         },
         {
             "name": "hoa/file",
@@ -2607,7 +2617,7 @@
                 "link",
                 "temporary"
             ],
-            "time": "2015-11-09 06:55:20"
+            "time": "2015-11-09T06:55:20+00:00"
         },
         {
             "name": "hoa/iterator",
@@ -2660,7 +2670,7 @@
                 "iterator",
                 "library"
             ],
-            "time": "2015-10-29 21:37:16"
+            "time": "2015-10-29T21:37:16+00:00"
         },
         {
             "name": "hoa/math",
@@ -2722,7 +2732,7 @@
                 "sampler",
                 "set"
             ],
-            "time": "2015-10-26 15:22:52"
+            "time": "2015-10-26T15:22:52+00:00"
         },
         {
             "name": "hoa/regex",
@@ -2776,7 +2786,7 @@
                 "library",
                 "regex"
             ],
-            "time": "2015-08-13 06:48:47"
+            "time": "2015-08-13T06:48:47+00:00"
         },
         {
             "name": "hoa/router",
@@ -2828,7 +2838,7 @@
                 "library",
                 "router"
             ],
-            "time": "2015-10-21 14:12:51"
+            "time": "2015-10-21T14:12:51+00:00"
         },
         {
             "name": "hoa/stream",
@@ -2886,7 +2896,7 @@
                 "stream",
                 "wrapper"
             ],
-            "time": "2015-10-26 12:21:43"
+            "time": "2015-10-26T12:21:43+00:00"
         },
         {
             "name": "hoa/ustring",
@@ -2945,7 +2955,7 @@
                 "string",
                 "unicode"
             ],
-            "time": "2015-11-09 06:44:33"
+            "time": "2015-11-09T06:44:33+00:00"
         },
         {
             "name": "hoa/visitor",
@@ -3000,7 +3010,7 @@
                 "visit",
                 "visitor"
             ],
-            "time": "2015-08-17 06:30:58"
+            "time": "2015-08-17T06:30:58+00:00"
         },
         {
             "name": "igorw/get-in",
@@ -3045,7 +3055,7 @@
                 "assoc-array",
                 "hash-map"
             ],
-            "time": "2014-12-15 23:03:51"
+            "time": "2014-12-15T23:03:51+00:00"
         },
         {
             "name": "imagine/imagine",
@@ -3104,7 +3114,7 @@
             "support": {
                 "source": "https://github.com/alchemy-fr/Imagine/tree/alchemy-0.6.2"
             },
-            "time": "2015-01-13 18:12:26"
+            "time": "2015-01-13T18:12:26+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -3146,7 +3156,7 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20 16:49:30"
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "ircmaxell/random-lib",
@@ -3201,7 +3211,7 @@
                 "random-numbers",
                 "random-strings"
             ],
-            "time": "2016-09-07 15:52:06"
+            "time": "2016-09-07T15:52:06+00:00"
         },
         {
             "name": "ircmaxell/security-lib",
@@ -3247,7 +3257,7 @@
             ],
             "description": "A Base Security Library",
             "homepage": "https://github.com/ircmaxell/SecurityLib",
-            "time": "2015-03-20 14:31:23"
+            "time": "2015-03-20T14:31:23+00:00"
         },
         {
             "name": "jms/metadata",
@@ -3298,7 +3308,7 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2016-12-05 10:18:33"
+            "time": "2016-12-05T10:18:33+00:00"
         },
         {
             "name": "jms/parser-lib",
@@ -3333,7 +3343,7 @@
                 "Apache2"
             ],
             "description": "A library for easily creating recursive-descent parsers.",
-            "time": "2012-11-18 18:08:43"
+            "time": "2012-11-18T18:08:43+00:00"
         },
         {
             "name": "jms/serializer",
@@ -3403,7 +3413,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2014-03-18 08:39:00"
+            "time": "2014-03-18T08:39:00+00:00"
         },
         {
             "name": "jms/translation-bundle",
@@ -3479,7 +3489,7 @@
             "support": {
                 "source": "https://github.com/alchemy-fr/JMSTranslationBundle/tree/rebase-2015-10-20"
             },
-            "time": "2015-11-04 15:09:44"
+            "time": "2015-11-04T15:09:44+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -3545,7 +3555,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2016-05-10 20:38:51"
+            "time": "2016-05-10T20:38:51+00:00"
         },
         {
             "name": "league/flysystem",
@@ -3628,7 +3638,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-10-19 20:38:46"
+            "time": "2016-10-19T20:38:46+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v2",
@@ -3675,7 +3685,7 @@
                 }
             ],
             "description": "Flysystem adapter for AWS S3 SDK v2",
-            "time": "2015-10-15 15:55:48"
+            "time": "2015-10-15T15:55:48+00:00"
         },
         {
             "name": "league/fractal",
@@ -3736,7 +3746,7 @@
                 "league",
                 "rest"
             ],
-            "time": "2016-12-02 14:55:48"
+            "time": "2016-12-02T14:55:48+00:00"
         },
         {
             "name": "media-alchemyst/media-alchemyst",
@@ -3810,7 +3820,7 @@
                 "video",
                 "video processing"
             ],
-            "time": "2016-03-16 13:11:52"
+            "time": "2016-03-16T13:11:52+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3888,7 +3898,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-11-26 00:15:39"
+            "time": "2016-11-26T00:15:39+00:00"
         },
         {
             "name": "mrclay/minify",
@@ -3928,7 +3938,7 @@
             ],
             "description": "Minify is a PHP5 app that helps you follow several rules for client-side performance. It combines multiple CSS or Javascript files, removes unnecessary whitespace and comments, and serves them with gzip encoding and optimal client-side cache headers",
             "homepage": "http://code.google.com/p/minify/",
-            "time": "2013-07-23 19:58:28"
+            "time": "2013-07-23T19:58:28+00:00"
         },
         {
             "name": "neutron/process-manager",
@@ -3967,7 +3977,7 @@
                     "homepage": "http://www.lickmychip.com/"
                 }
             ],
-            "time": "2014-02-13 20:27:33"
+            "time": "2014-02-13T20:27:33+00:00"
         },
         {
             "name": "neutron/recaptcha",
@@ -4011,7 +4021,7 @@
                 }
             ],
             "description": "ReCaptcha Client",
-            "time": "2013-02-14 13:42:00"
+            "time": "2013-02-14T13:42:00+00:00"
         },
         {
             "name": "neutron/signal-handler",
@@ -4054,7 +4064,7 @@
             "keywords": [
                 "signal"
             ],
-            "time": "2014-01-15 17:24:13"
+            "time": "2014-01-15T17:24:13+00:00"
         },
         {
             "name": "neutron/silex-filesystem-provider",
@@ -4098,7 +4108,7 @@
                 "silex",
                 "temporary-filesystem"
             ],
-            "time": "2012-11-08 21:07:08"
+            "time": "2012-11-08T21:07:08+00:00"
         },
         {
             "name": "neutron/silex-imagine-provider",
@@ -4145,7 +4155,7 @@
                 "imagine",
                 "silex"
             ],
-            "time": "2013-05-03 18:48:51"
+            "time": "2013-05-03T18:48:51+00:00"
         },
         {
             "name": "neutron/temporary-filesystem",
@@ -4185,7 +4195,7 @@
                 }
             ],
             "description": "Symfony filesystem extension to handle temporary files",
-            "time": "2016-03-05 10:22:50"
+            "time": "2016-03-05T10:22:50+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4230,7 +4240,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-09-19 14:15:08"
+            "time": "2015-09-19T14:15:08+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -4293,7 +4303,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2015-08-09 04:28:19"
+            "time": "2015-08-09T04:28:19+00:00"
         },
         {
             "name": "pagerfanta/pagerfanta",
@@ -4360,7 +4370,7 @@
                 "paginator",
                 "paging"
             ],
-            "time": "2016-11-28 09:17:04"
+            "time": "2016-11-28T09:17:04+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -4408,7 +4418,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-11-07 23:38:38"
+            "time": "2016-11-07T23:38:38+00:00"
         },
         {
             "name": "php-ffmpeg/php-ffmpeg",
@@ -4477,7 +4487,7 @@
                 "video",
                 "video processing"
             ],
-            "time": "2014-08-26 08:46:56"
+            "time": "2014-08-26T08:46:56+00:00"
         },
         {
             "name": "php-mp4box/php-mp4box",
@@ -4528,7 +4538,7 @@
                 "gpac",
                 "mp4box"
             ],
-            "time": "2013-06-25 10:13:06"
+            "time": "2013-06-25T10:13:06+00:00"
         },
         {
             "name": "php-unoconv/php-unoconv",
@@ -4578,7 +4588,7 @@
             "keywords": [
                 "unoconv"
             ],
-            "time": "2013-06-25 10:09:59"
+            "time": "2013-06-25T10:09:59+00:00"
         },
         {
             "name": "php-xpdf/php-xpdf",
@@ -4630,7 +4640,7 @@
                 "pdf",
                 "xpdf"
             ],
-            "time": "2016-07-04 07:30:16"
+            "time": "2016-07-04T07:30:16+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -4678,7 +4688,7 @@
                 "sequence",
                 "set"
             ],
-            "time": "2015-05-17 12:39:23"
+            "time": "2015-05-17T12:39:23+00:00"
         },
         {
             "name": "phpexiftool/exiftool",
@@ -4711,7 +4721,7 @@
                 "exiftool",
                 "metadatas"
             ],
-            "time": "2016-01-25 11:10:14"
+            "time": "2016-01-25T11:10:14+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -4761,7 +4771,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25 16:39:46"
+            "time": "2015-07-25T16:39:46+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -4807,7 +4817,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2013-11-22 08:30:29"
+            "time": "2013-11-22T08:30:29+00:00"
         },
         {
             "name": "psr/log",
@@ -4854,7 +4864,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -4936,7 +4946,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-11-22 19:21:44"
+            "time": "2016-11-22T19:21:44+00:00"
         },
         {
             "name": "react/promise",
@@ -4979,7 +4989,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2016-12-22 14:09:01"
+            "time": "2016-12-22T14:09:01+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -5114,7 +5124,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2017-05-13 14:02:28"
+            "time": "2017-05-13T14:02:28+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -5160,7 +5170,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2016-11-14 17:59:58"
+            "time": "2016-11-14T17:59:58+00:00"
         },
         {
             "name": "silex/silex",
@@ -5237,7 +5247,7 @@
             "keywords": [
                 "microframework"
             ],
-            "time": "2016-01-06 14:59:35"
+            "time": "2016-01-06T14:59:35+00:00"
         },
         {
             "name": "silex/web-profiler",
@@ -5282,7 +5292,7 @@
             ],
             "description": "A WebProfiler for Silex",
             "homepage": "http://silex.sensiolabs.org/",
-            "time": "2016-01-10 11:39:13"
+            "time": "2016-01-10T11:39:13+00:00"
         },
         {
             "name": "simple-bus/doctrine-orm-bridge",
@@ -5336,7 +5346,7 @@
                 "doctrine",
                 "event bus"
             ],
-            "time": "2015-04-29 12:27:27"
+            "time": "2015-04-29T12:27:27+00:00"
         },
         {
             "name": "simple-bus/jms-serializer-bridge",
@@ -5385,7 +5395,7 @@
                 "message",
                 "serialization"
             ],
-            "time": "2015-07-29 07:48:42"
+            "time": "2015-07-29T07:48:42+00:00"
         },
         {
             "name": "simple-bus/message-bus",
@@ -5435,7 +5445,7 @@
                 "message",
                 "message bus"
             ],
-            "time": "2016-02-12 08:35:53"
+            "time": "2016-02-12T08:35:53+00:00"
         },
         {
             "name": "simple-bus/serialization",
@@ -5483,7 +5493,7 @@
                 "messages",
                 "serialization"
             ],
-            "time": "2015-05-08 13:34:17"
+            "time": "2015-05-08T13:34:17+00:00"
         },
         {
             "name": "sorien/silex-dbal-profiler",
@@ -5531,7 +5541,7 @@
                 "profiler",
                 "silex"
             ],
-            "time": "2016-10-26 11:08:02"
+            "time": "2016-10-26T11:08:02+00:00"
         },
         {
             "name": "sorien/silex-pimple-dumper",
@@ -5573,7 +5583,7 @@
                 "plugin",
                 "silex"
             ],
-            "time": "2015-11-11 07:16:28"
+            "time": "2015-11-11T07:16:28+00:00"
         },
         {
             "name": "swftools/swftools",
@@ -5627,7 +5637,7 @@
                 "flash",
                 "swf"
             ],
-            "time": "2017-11-07 14:36:48"
+            "time": "2017-11-07T14:36:48+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -5681,7 +5691,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2016-12-29 10:02:40"
+            "time": "2016-12-29T10:02:40+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -5734,7 +5744,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -5792,7 +5802,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -5851,7 +5861,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php54",
@@ -5909,7 +5919,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php55",
@@ -5965,7 +5975,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -6021,7 +6031,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -6080,7 +6090,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-util",
@@ -6132,7 +6142,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/security-acl",
@@ -6193,7 +6203,7 @@
             ],
             "description": "Symfony Security Component - ACL (Access Control List)",
             "homepage": "https://symfony.com",
-            "time": "2015-12-28 09:39:46"
+            "time": "2015-12-28T09:39:46+00:00"
         },
         {
             "name": "symfony/symfony",
@@ -6328,7 +6338,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2016-12-13 12:16:34"
+            "time": "2016-12-13T12:16:34+00:00"
         },
         {
             "name": "themattharris/tmhoauth",
@@ -6370,7 +6380,7 @@
                 "oauth",
                 "twitter"
             ],
-            "time": "2014-08-06 22:29:35"
+            "time": "2014-08-06T22:29:35+00:00"
         },
         {
             "name": "twig/extensions",
@@ -6422,7 +6432,7 @@
                 "i18n",
                 "text"
             ],
-            "time": "2016-10-25 17:34:14"
+            "time": "2016-10-25T17:34:14+00:00"
         },
         {
             "name": "twig/twig",
@@ -6483,7 +6493,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-12-23 11:06:22"
+            "time": "2016-12-23T11:06:22+00:00"
         },
         {
             "name": "vierbergenlars/php-semver",
@@ -6531,7 +6541,7 @@
                 "semver",
                 "versioning"
             ],
-            "time": "2013-09-20 10:41:27"
+            "time": "2013-09-20T10:41:27+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -6581,7 +6591,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "webmozart/json",
@@ -6630,7 +6640,7 @@
                 }
             ],
             "description": "A robust JSON decoder/encoder with support for schema validation.",
-            "time": "2016-01-14 12:11:46"
+            "time": "2016-01-14T12:11:46+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -6676,7 +6686,7 @@
                 }
             ],
             "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
-            "time": "2015-12-17 08:42:14"
+            "time": "2015-12-17T08:42:14+00:00"
         },
         {
             "name": "willdurand/negotiation",
@@ -6728,7 +6738,7 @@
                 "header",
                 "negotiation"
             ],
-            "time": "2016-10-14 09:17:47"
+            "time": "2016-10-14T09:17:47+00:00"
         },
         {
             "name": "zend/gdata",
@@ -6769,7 +6779,7 @@
                 "gdata",
                 "zend"
             ],
-            "time": "2013-01-30 15:31:21"
+            "time": "2013-01-30T15:31:21+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -6821,7 +6831,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-04-20 17:26:42"
+            "time": "2016-04-20T17:26:42+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -6875,7 +6885,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-02-18T20:53:00+00:00"
         }
     ],
     "packages-dev": [
@@ -6923,7 +6933,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2016-07-18 14:02:57"
+            "time": "2016-07-18T14:02:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -6977,7 +6987,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -7022,7 +7032,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -7069,7 +7079,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -7132,7 +7142,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7194,7 +7204,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -7241,7 +7251,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -7282,7 +7292,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -7326,7 +7336,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -7375,7 +7385,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -7447,7 +7457,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-09 02:45:31"
+            "time": "2016-12-09T02:45:31+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -7503,7 +7513,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -7567,7 +7577,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2016-11-19T09:18:40+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -7619,7 +7629,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -7669,7 +7679,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -7736,7 +7746,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -7787,7 +7797,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -7840,7 +7850,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -7875,7 +7885,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         }
     ],
     "aliases": [

--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -136,6 +136,7 @@ authentication:
             options:
                 app-id: ''
                 secret: ''
+                default-graph-version: 'v2.10'
         twitter:
             enabled: false
             options:

--- a/lib/Alchemy/Phrasea/Authentication/Provider/Facebook.php
+++ b/lib/Alchemy/Phrasea/Authentication/Provider/Facebook.php
@@ -111,6 +111,11 @@ class Facebook extends AbstractProvider
             exit;
         }
 
+        if (!$response)
+        {
+            throw new NotAuthenticatedException('Not authenticated');
+        }
+
         return $response->getGraphUser();
     }
 
@@ -128,7 +133,7 @@ class Facebook extends AbstractProvider
         $identity->set(Identity::PROPERTY_EMAIL, $user['email']);
         $identity->set(Identity::PROPERTY_FIRSTNAME, $user['first_name']);
         $identity->set(Identity::PROPERTY_LASTNAME, $user['last_name']);
-        $identity->set(Identity::PROPERTY_USERNAME, $user['name']);
+        $identity->set(Identity::PROPERTY_USERNAME, $user['first_name']);
 
         return $identity;
     }

--- a/lib/Alchemy/Phrasea/Authentication/Provider/Facebook.php
+++ b/lib/Alchemy/Phrasea/Authentication/Provider/Facebook.php
@@ -21,13 +21,14 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class Facebook extends AbstractProvider
 {
-    /** @var \Facebook */
+    /** @var \Facebook\Facebook */
     private $facebook;
 
-    public function __construct(\Facebook $facebook, UrlGenerator $generator)
+    public function __construct(\Facebook\Facebook $facebook, UrlGenerator $generator, SessionInterface $session)
     {
         $this->facebook = $facebook;
         $this->generator = $generator;
+        $this->session = $session;
     }
 
     /**
@@ -51,14 +52,16 @@ class Facebook extends AbstractProvider
      */
     public function authenticate()
     {
-        return new RedirectResponse($this->facebook->getLoginUrl([
-            'scope'        => 'email',
-            'redirect_uri' => $this->generator->generate(
-                'login_authentication_provider_callback',
-                ['providerId' => $this->getId()],
-                UrlGenerator::ABSOLUTE_URL
+        return new RedirectResponse(
+            $this->facebook->getRedirectLoginHelper()->getLoginUrl(
+                $this->generator->generate(
+                    'login_authentication_provider_callback',
+                    ['providerId' => $this->getId()],
+                    UrlGenerator::ABSOLUTE_URL
+                ),
+                ['email']
             )
-        ]));
+        );
     }
 
     /**
@@ -66,15 +69,15 @@ class Facebook extends AbstractProvider
      */
     public function logout()
     {
-        $this->facebook->destroySession();
+        $this->session->remove('fb_access_token');
     }
 
     /**
-     * @param \Facebook $facebook
+     * @param \Facebook\Facebook $facebook
      *
      * @return Facebook
      */
-    public function setFacebook(\Facebook $facebook)
+    public function setFacebook(\Facebook\Facebook $facebook)
     {
         $this->facebook = $facebook;
 
@@ -82,7 +85,7 @@ class Facebook extends AbstractProvider
     }
 
     /**
-     * @return \Facebook
+     * @return \Facebook\Facebook
      */
     public function getFacebook()
     {
@@ -90,27 +93,42 @@ class Facebook extends AbstractProvider
     }
 
     /**
+     * @param $dataToRetrieve
+     * @return \Facebook\GraphNodes\GraphUser
+     */
+    protected function getGraphUser($dataToRetrieve)
+    {
+        try {
+            $response = $this->facebook->get(
+                "/me?fields=" . implode(',', $dataToRetrieve),
+                $this->session->get('fb_access_token')
+            );
+        } catch(\Facebook\Exceptions\FacebookResponseException $e) {
+            throw new NotAuthenticatedException('Graph returned an error: ' . $e->getMessage());
+            exit;
+        } catch(\Facebook\Exceptions\FacebookSDKException $e) {
+            throw new NotAuthenticatedException('Facebook SDK returned an error: ' . $e->getMessage());
+            exit;
+        }
+
+        return $response->getGraphUser();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getIdentity()
     {
-        try {
-            $data = $this->facebook->api('/me');
-            $identity = new Identity();
+        $user = $this->getGraphUser(['id', 'name', 'email', 'picture', 'last_name', 'first_name']);
+        
+        $identity = new Identity();
 
-            $identity->set(Identity::PROPERTY_ID, $data['id']);
-            $identity->set(Identity::PROPERTY_IMAGEURL, sprintf(
-                'https://graph.facebook.com/%s/picture?return_ssl_resources=1',
-                $data['username']
-            ));
-            $identity->set(Identity::PROPERTY_EMAIL, $data['email']);
-            $identity->set(Identity::PROPERTY_FIRSTNAME, $data['first_name']);
-            $identity->set(Identity::PROPERTY_LASTNAME, $data['last_name']);
-            $identity->set(Identity::PROPERTY_USERNAME, $data['username']);
-
-        } catch (\FacebookApiException $e) {
-            throw new NotAuthenticatedException('Unable to get profile informations', $e->getCode(), $e);
-        }
+        $identity->set(Identity::PROPERTY_ID, $user['id']);
+        $identity->set(Identity::PROPERTY_IMAGEURL, $user['picture']);
+        $identity->set(Identity::PROPERTY_EMAIL, $user['email']);
+        $identity->set(Identity::PROPERTY_FIRSTNAME, $user['first_name']);
+        $identity->set(Identity::PROPERTY_LASTNAME, $user['last_name']);
+        $identity->set(Identity::PROPERTY_USERNAME, $user['name']);
 
         return $identity;
     }
@@ -120,9 +138,44 @@ class Facebook extends AbstractProvider
      */
     public function onCallback(Request $request)
     {
-        if (!$this->facebook->getUser()) {
-            throw new NotAuthenticatedException('Facebook authentication failed');
+        $helper = $this->facebook->getRedirectLoginHelper();
+
+        try {
+            $accessToken = $helper->getAccessToken();
+        } catch(\Facebook\Exceptions\FacebookResponseException $e) {
+            throw new NotAuthenticatedException('Graph returned an error: ' . $e->getMessage());
+            exit;
+        } catch(\Facebook\Exceptions\FacebookSDKException $e) {
+            throw new NotAuthenticatedException('Facebook SDK returned an error: ' . $e->getMessage());
+            exit;
         }
+
+        if (! isset($accessToken)) {
+            if ($helper->getError()) {
+                $error  = "Error: " . $helper->getError() . "\n";
+                $error .= "Error Code: " . $helper->getErrorCode() . "\n";
+                $error .= "Error Reason: " . $helper->getErrorReason() . "\n";
+                $error .= "Error Description: " . $helper->getErrorDescription() . "\n";
+
+                throw new NotAuthenticatedException($error);
+
+            } else {
+                throw new NotAuthenticatedException('Facebook authentication failed');
+            }
+            exit;
+        }
+
+        $oAuth2Client = $this->facebook->getOAuth2Client();
+
+        if (! $accessToken->isLongLived()) {
+            try {
+                $accessToken = $oAuth2Client->getLongLivedAccessToken($accessToken);
+            } catch (\Facebook\Exceptions\FacebookSDKException $e) {
+                throw new NotAuthenticatedException('Error getting long-lived access token: ' . $e->getMessage() );
+                exit;
+            }
+        }
+        $this->session->set('fb_access_token', (string) $accessToken);
     }
 
     /**
@@ -130,11 +183,9 @@ class Facebook extends AbstractProvider
      */
     public function getToken()
     {
-        if (0 >= $this->facebook->getUser()) {
-            throw new NotAuthenticatedException('Provider has not authenticated');
-        }
+        $user = $this->getGraphUser(['id']);
 
-        return new Token($this, $this->facebook->getUser());
+        return new Token($this, $user['id']);
     }
 
     /**
@@ -194,11 +245,12 @@ class Facebook extends AbstractProvider
      */
     public static function create(UrlGenerator $generator, SessionInterface $session, array $options)
     {
-        $config['appId'] = $options['app-id'];
-        $config['secret'] = $options['secret'];
+        $config['app_id'] = $options['app-id'];
+        $config['app_secret'] = $options['secret'];
+        $config['default_graph_version'] = $options['default-graph-version'];
 
-        $facebook = new \Facebook($config);
+        $facebook = new \Facebook\Facebook($config);
 
-        return new static($facebook, $generator);
+        return new static($facebook, $generator, $session);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/Authentication/Provider/FacebookTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Authentication/Provider/FacebookTest.php
@@ -5,6 +5,7 @@ namespace Alchemy\Tests\Phrasea\Authentication\Provider;
 use Alchemy\Phrasea\Authentication\Provider\Facebook;
 use Alchemy\Phrasea\Authentication\Provider\ProviderInterface;
 use Alchemy\Phrasea\Authentication\Provider\Token\Identity;
+use Facebook\Authentication\AccessToken;
 
 /**
  * @group functional
@@ -12,6 +13,8 @@ use Alchemy\Phrasea\Authentication\Provider\Token\Identity;
  */
 class FacebookTest extends ProviderTestCase
 {
+    const TOKEN = 'aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789';
+
     public function testGetSetSession()
     {
         $this->markTestSkipped('testGetSetSession disabled for facebook');
@@ -35,10 +38,6 @@ class FacebookTest extends ProviderTestCase
     public function provideDataForFailingCallback()
     {
         $provider = $this->getProvider();
-        $provider->getFacebook()->expects($this->any())
-            ->method('getUser')
-            ->will($this->returnValue(null));
-
         return [
             [$provider, $this->getRequestMock()]
         ];
@@ -52,10 +51,8 @@ class FacebookTest extends ProviderTestCase
     public function provideDataForSuccessCallback()
     {
         $provider = $this->getProvider();
-        $provider->getFacebook()->expects($this->any())
-            ->method('getUser')
-            ->will($this->returnValue('123456'));
-
+        $facebookMock = $this->getFacebookMock(true);
+        $provider->setFacebook($facebookMock);
         return [
             [$provider, $this->getRequestMock()]
         ];
@@ -63,41 +60,20 @@ class FacebookTest extends ProviderTestCase
 
     protected function getProvider()
     {
-        return new Facebook($this->getFacebookMock(), $this->getUrlGeneratorMock());
+        return new Facebook($this->getFacebookMock(), $this->getUrlGeneratorMock(), $this->getMockSession());
     }
 
     protected function authenticateProvider(ProviderInterface $provider)
     {
-        $provider->getFacebook()->expects($this->any())
-            ->method('getUser')
-            ->will($this->returnValue('123456'));
+        $facebookMock = $this->getFacebookMock(true);
+        $provider->setFacebook($facebookMock);
+        $provider->getSession()->set('fb_access_token', self::TOKEN);
     }
 
     protected function getProviderForSuccessIdentity()
     {
         $provider = $this->getProvider();
         $this->authenticateProvider($provider);
-
-        $facebook = $this->getMockBuilder('Facebook')
-            ->disableOriginalConstructor()
-            ->setMethods(['getLoginUrl', 'api', 'getUser'])
-            ->getMock();
-
-        $facebook->expects($this->any())
-            ->method('getLoginUrl')
-            ->will($this->returnValue('http://www.facebook.com/'));
-
-        $facebook->expects($this->once())
-            ->method('api')
-            ->will($this->returnValue([
-               'id'         => self::ID,
-               'username'   => self::FIRSTNAME,
-               'first_name' => self::FIRSTNAME,
-               'last_name'  => self::LASTNAME,
-               'email'      => self::EMAIL,
-            ]));
-
-        $provider->setFacebook($facebook);
 
         return $provider;
     }
@@ -123,6 +99,7 @@ class FacebookTest extends ProviderTestCase
         return [
             'app-id' => 'zizi',
             'secret' => 's3cr3t',
+            'default-graph-version' => 'v2.10'
         ];
     }
 
@@ -131,27 +108,100 @@ class FacebookTest extends ProviderTestCase
         return $this->getProvider();
     }
 
-    private function getFacebookMock()
+    private function getFacebookMock($ValidAccessToken = false)
     {
-        $facebook = $this->getMockBuilder('Facebook')
+        $facebook = $this->getMockBuilder('Facebook\Facebook')
             ->disableOriginalConstructor()
-            ->setMethods(['getLoginUrl', 'api', 'getUser'])
+            ->setMethods(['getRedirectLoginHelper', 'get', 'getOAuth2Client'])
             ->getMock();
 
-        $facebook->expects($this->any())
-            ->method('getLoginUrl')
-            ->will($this->returnValue('http://www.facebook.com/'));
+        $helper = $this->getFacebookRedirectLoginHelperMock($ValidAccessToken);
 
         $facebook->expects($this->any())
-            ->method('api')
-            ->will($this->returnCallback(function () use ($facebook) {
-                if (!$facebook->getUser()) {
-                    throw new \FacebookApiException([
-                        'error_msg' => 'Not authenticated'
-                    ]);
-                }
-            }));
+            ->method('getRedirectLoginHelper')
+            ->will($this->returnValue($helper));
+
+        $OAuth2Client = $this->getOAuth2ClientMock();
+
+        $facebook->expects($this->any())
+            ->method('getOAuth2Client')
+            ->will($this->returnValue($OAuth2Client));
+
+        if ($ValidAccessToken)
+        {
+            $FacebookResponse = $this->getFacebookResponseMock();
+
+            $facebook->expects($this->any())
+                ->method('get')
+                ->will($this->returnValue($FacebookResponse));
+        }
 
         return $facebook;
     }
+
+    private function getAccessTokenMock($valid = true)
+    {
+        $expiresAt = (time() + 3600);
+        return ($valid)? new AccessToken(self::TOKEN, $expiresAt) : null;
+    }
+
+    private function getFacebookRedirectLoginHelperMock($ValidAccessToken = true)
+    {
+        $accessToken = $this->getAccessTokenMock($ValidAccessToken);
+
+        $helper = $this->getMockBuilder('Facebook\Helpers\FacebookRedirectLoginHelper')
+            ->disableOriginalConstructor()
+            ->setMethods(['getLoginUrl', 'getAccessToken', 'getError'])
+            ->getMock();
+
+        $helper->expects($this->any())
+            ->method('getLoginUrl')
+            ->will($this->returnValue('http://www.facebook.com/'));
+
+        $helper->expects($this->any())
+            ->method('getAccessToken')
+            ->will($this->returnValue($accessToken));
+
+        $helper->expects($this->any())
+            ->method('getError')
+            ->will($this->returnValue(null));
+
+        return $helper;
+    }
+
+    private function getOAuth2ClientMock()
+    {
+        $OAuth2Client = $this->getMockBuilder('Facebook\Authentication\OAuth2Client')
+            ->disableOriginalConstructor()
+            ->setMethods(['getLongLivedAccessToken'])
+            ->getMock();
+
+        $OAuth2Client->expects($this->any())
+            ->method('getLongLivedAccessToken')
+            ->will($this->returnValue(self::TOKEN));
+
+        return $OAuth2Client;
+    }
+
+    private function getFacebookResponseMock()
+    {
+        $FacebookResponse = $this->getMockBuilder('Facebook\FacebookResponse')
+            ->disableOriginalConstructor()
+            ->setMethods(['getGraphUser'])
+            ->getMock();
+
+        $FacebookResponse->expects($this->any())
+            ->method('getGraphUser')
+            ->will($this->returnValue([
+                'id'    => self::ID,
+                'name'   => self::FIRSTNAME,
+                'first_name' => self::FIRSTNAME,
+                'last_name'  => self::LASTNAME,
+                'email'      => self::EMAIL,
+                'picture'   => self::IMAGEURL
+            ]));
+
+        return $FacebookResponse;
+    }
+
 }


### PR DESCRIPTION
 ### Fixes
  - PHRAS-1752: Update facebook SDK
  - Update code logic for connexion on phraseanet from facebook

### Adds
  - Add facebook/graph-sdk 5.6 in composer.json

### Removes
  - Remove facebook/php-sdk 3.2 in composer.json

