### PR TITLE
PHRAS-1834_missing-default-server-name_4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Command/Setup/Install.php
+++ b/lib/Alchemy/Phrasea/Command/Setup/Install.php
@@ -25,6 +25,8 @@ use Symfony\Component\VarDumper\VarDumper;
 
 class Install extends Command
 {
+    const DEFAULT_SERVER_NAME = "phraseanet";
+
     private $executableFinder;
     /** @var StructureTemplate StructureTemplate */
     private $structureTemplate;


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1834: default-server-name = "phraseanet"
