### PR TITLE
PHRAS-1828 Download link validity

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Configuration/RegistryFormManipulator.php
+++ b/lib/Alchemy/Phrasea/Core/Configuration/RegistryFormManipulator.php
@@ -86,7 +86,7 @@ class RegistryFormManipulator
                 'force-push-authentication' => false,
                 'enable-feed-notification' => true,
                 'export-stamp-choice' => false,
-                'download-link-validity' => 0,
+                'download-link-validity' => 24,
             ],
             'ftp' => [
                 'ftp-enabled' => false,

--- a/lib/Alchemy/Phrasea/Form/Configuration/ActionsFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/ActionsFormType.php
@@ -57,6 +57,9 @@ class ActionsFormType extends AbstractType
         $builder->add('enable-feed-notification', 'checkbox', [
             'label'        => 'Enable possibility to notify users when publishing a new feed entry',
         ]);
+        $builder->add('download-link-validity', 'integer', [
+            'label'        => 'Validity period of the download links',
+        ]);
     }
 
     public function getName()

--- a/lib/Alchemy/Phrasea/Model/Manipulator/TokenManipulator.php
+++ b/lib/Alchemy/Phrasea/Model/Manipulator/TokenManipulator.php
@@ -138,9 +138,8 @@ class TokenManipulator implements ManipulatorInterface
     public function createDownloadToken(User $user, $data)
     {
         $downloadLinkValidity = (int) $this->conf->get(['registry', 'actions', 'download-link-validity']);
-        $time = ($downloadLinkValidity)? "+{$downloadLinkValidity} hours":'+3 hours';
 
-        return $this->create($user, self::TYPE_DOWNLOAD, new \DateTime($time), $data);
+        return $this->create($user, self::TYPE_DOWNLOAD, new \DateTime("+{$downloadLinkValidity} hours"), $data);
     }
 
     /**
@@ -151,9 +150,8 @@ class TokenManipulator implements ManipulatorInterface
     public function createEmailExportToken($data)
     {
         $downloadLinkValidity = (int) $this->conf->get(['registry', 'actions', 'download-link-validity']);
-        $time = ($downloadLinkValidity)? "+{$downloadLinkValidity} hours":'+1 day';
-        
-        return $this->create(null, self::TYPE_EMAIL, new \DateTime($time), $data);
+
+        return $this->create(null, self::TYPE_EMAIL, new \DateTime("+{$downloadLinkValidity} hours"), $data);
     }
 
     /**


### PR DESCRIPTION
## Changelog

### Adds
  - PHRAS-1828: Download link validity
  - Set default value of download link validity to 24 (hours)
  - Make download link validity editable from Admin > Setup


