### PR TITLE
PHRAS-1852 Ignore platform requirements on composer install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	make install_assets
 
 install_composer:
-	composer install
+	composer install --ignore-platform-reqs
 
 install_asset_dependencies:
 	yarn


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS 1852 | Add --ignore-platform-reqs: ignore php, hhvm, lib-* and ext-* requirements and force the installation even if the local machine does not fulfill these. See also the platform config option.

