### PR TITLE
Rollback PHRAS-1852 - Remove ignore-platform-reqs option on makefile composer setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	make install_assets
 
 install_composer:
-	composer install --ignore-platform-reqs
+	composer install
 
 install_asset_dependencies:
 	yarn


### PR DESCRIPTION
## Changelog

### Fixes
  - Remove ignore-platform-reqs option on makefile composer setup. Rollback.

