### PR TITLE
Phpversion is now passed in args to vagrant up function

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,6 +88,7 @@ Vagrant.configure("2") do |config|
             ansible.extra_vars = {
                 hostname: $hostname,
                 host_addresses: $hostIps,
+                phpversion: ENV['phpversion'],
                 postfix: {
                     postfix_domain: $hostname + ".vb"
                 }
@@ -104,7 +105,7 @@ Vagrant.configure("2") do |config|
             }
         end
     else
-        config.vm.provision :shell, path: "resources/ansible/windows.sh", args: ["default"]
+        config.vm.provision :shell, path: "resources/ansible/windows.sh", args: ["default", ENV['phpversion']]
        # config.vm.provision :shell, run: "always", path: "resources/ansible/windows-always.sh", args: ["default"]
     end
 

--- a/resources/ansible/roles/nginx/templates/default.j2
+++ b/resources/ansible/roles/nginx/templates/default.j2
@@ -25,7 +25,7 @@ server {
     location ~ ^/(index|index_dev|api|api_dev)\.php(/|$) {
         root {{ nginx.docroot }}/www;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php5.6-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php{{ phpversion }}-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH /usr/local/bin:/usr/bin:/bin;
@@ -63,7 +63,7 @@ server {
     location ~ ^/(index|index_dev|api)\.php(/|$) {
         root {{ nginx.docroot }}/www;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php5.6-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php{{ phpversion }}-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH /usr/local/bin:/usr/bin:/bin;

--- a/resources/ansible/roles/php/handlers/main.yml
+++ b/resources/ansible/roles/php/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: restart php5.6-fpm
-  service: name=php5.6-fpm enabled=yes state=restarted
+- name: restart php{{ phpversion }}-fpm
+  service: name=php{{ phpversion }}-fpm enabled=yes state=restarted

--- a/resources/ansible/roles/php/tasks/configure.yml
+++ b/resources/ansible/roles/php/tasks/configure.yml
@@ -1,11 +1,11 @@
 ---
-- stat: path=/etc/php/5.6/apache2/php.ini
+- stat: path=/etc/php/{{ phpversion }}/apache2/php.ini
   register: modphp
 
-- stat: path=/etc/php/5.6/fpm/php.ini
+- stat: path=/etc/php/{{ phpversion }}/fpm/php.ini
   register: phpfpm
 
-- stat: path=/etc/php/5.6/cli/php.ini
+- stat: path=/etc/php/{{ phpversion }}/cli/php.ini
   register: phpcli
 
 - include: php-fpm.yml

--- a/resources/ansible/roles/php/tasks/main.yml
+++ b/resources/ansible/roles/php/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 # Watch repositories task to retrieve repository add
-- name: Install php5.6
+- name: Install php{{ phpversion }}
   sudo: yes
-  apt: pkg=php5.6 state=latest
+  apt: pkg=php{{ phpversion }} state=latest
 
-- name: Install php5.6-fpm
+- name: Install php{{ phpversion }}-fpm
   sudo: yes
-  apt: pkg=php5.6-fpm state=latest
+  apt: pkg=php{{ phpversion }}-fpm state=latest
 
 - name: Install PHP Packages
   sudo: yes
@@ -15,4 +15,4 @@
   when: php.packages is defined
 
 - include: configure.yml
-# - include: pecl.yml
+- include: pecl.yml

--- a/resources/ansible/roles/php/tasks/mod-php.yml
+++ b/resources/ansible/roles/php/tasks/mod-php.yml
@@ -1,30 +1,30 @@
 ---
 - name: ensure timezone is set in apache2 php.ini
-  lineinfile: dest=/etc/php/5.6/apache2/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/apache2/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 
 - name: enabling opcache
-  lineinfile: dest=/etc/php/5.6/apache2/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/apache2/php.ini
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'
 
 - name: Disable PHP cache limiter
-  lineinfile: dest=/etc/php/5.6/apache2/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/apache2/php.ini
               regexp=';?\s*session.cache_limiter\s*=\s*'
               line='session.cache_limiter = ""'
 
 - name: set post_max_size
-  lineinfile: dest=/etc/php/5.6/apache2/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/apache2/php.ini
               regexp=';?post_max_size\s*=\s*'
               line='post_max_size = 2G'
 
 - name: set upload_max_filesize
-  lineinfile: dest=/etc/php/5.6/apache2/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/apache2/php.ini
               regexp=';?upload_max_filesize\s*=\s*'
               line='upload_max_filesize = 2G'
 
 - name: set max_input_vars
-  lineinfile: dest=/etc/php/5.6/apache2/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/apache2/php.ini
               regexp=';?max_input_vars\s*=\s*'
               line='max_input_vars = 12000'

--- a/resources/ansible/roles/php/tasks/pecl.yml
+++ b/resources/ansible/roles/php/tasks/pecl.yml
@@ -1,5 +1,5 @@
 - name: Install
-  apt: pkg="php5.6-dev" state=present
+  apt: pkg="php{{ phpversion }}-dev" state=present
   when: php.pecl_packages is defined
 
 - name: Update pecl chennel
@@ -16,7 +16,7 @@
 - name: Create extension .ini file
   template: >
     src="extension.tpl"
-    dest="/etc/php/5.6/mods-available/{{ item.name }}.ini"
+    dest="/etc/php/{{ phpversion }}/mods-available/{{ item.name }}.ini"
     owner="root"
     group="root"
     mode=0644

--- a/resources/ansible/roles/php/tasks/php-cli.yml
+++ b/resources/ansible/roles/php/tasks/php-cli.yml
@@ -1,30 +1,30 @@
 ---
 - name: ensure timezone is set in cli php.ini
-  lineinfile: dest=/etc/php/5.6/cli/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/cli/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 
 - name: enabling opcache cli
-  lineinfile: dest=/etc/php/5.6/cli/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/cli/php.ini
               regexp=';?opcache.enable_cli=\d'
               line='opcache.enable_cli=1'
 
 - name: Disable PHP cache limiter
-  lineinfile: dest=/etc/php/5.6/cli/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/cli/php.ini
               regexp=';?\s*session.cache_limiter\s*=\s*'
               line='session.cache_limiter = ""'
 
 - name: set post_max_size
-  lineinfile: dest=/etc/php/5.6/cli/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/cli/php.ini
               regexp=';?post_max_size\s*=\s*'
               line='post_max_size = 2G'
 
 - name: set upload_max_filesize
-  lineinfile: dest=/etc/php/5.6/cli/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/cli/php.ini
               regexp=';?upload_max_filesize\s*=\s*'
               line='upload_max_filesize = 2G'
 
 - name: set max_input_vars
-  lineinfile: dest=/etc/php/5.6/cli/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/cli/php.ini
               regexp=';?max_input_vars\s*=\s*'
               line='max_input_vars = 12000'

--- a/resources/ansible/roles/php/tasks/php-fpm.yml
+++ b/resources/ansible/roles/php/tasks/php-fpm.yml
@@ -1,48 +1,48 @@
 ---
 - name: Set permissions on socket - owner
-  lineinfile: "dest=/etc/php/5.6/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
-  notify: restart php5.6-fpm
+  lineinfile: "dest=/etc/php/{{ phpversion }}/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
+  notify: restart php{{ phpversion }}-fpm
 
 - name: Set permissions on socket - group
-  lineinfile: "dest=/etc/php/5.6/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
-  notify: restart php5.6-fpm
+  lineinfile: "dest=/etc/php/{{ phpversion }}/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
+  notify: restart php{{ phpversion }}-fpm
 
 - name: Set permissions on socket - mode
-  lineinfile: "dest=/etc/php/5.6/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
-  notify: restart php5.6-fpm
+  lineinfile: "dest=/etc/php/{{ phpversion }}/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
+  notify: restart php{{ phpversion }}-fpm
 
 - name: ensure timezone is set in fpm php.ini
-  lineinfile: dest=/etc/php/5.6/fpm/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/fpm/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
-  notify: restart php5.6-fpm
+  notify: restart php{{ phpversion }}-fpm
 
 - name: enabling opcache
-  lineinfile: dest=/etc/php/5.6/fpm/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/fpm/php.ini
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'
-  notify: restart php5.6-fpm
+  notify: restart php{{ phpversion }}-fpm
 
 - name: Disable PHP cache limiter
-  lineinfile: dest=/etc/php/5.6/fpm/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/fpm/php.ini
               regexp=';?\s*session.cache_limiter\s*=\s*'
               line='session.cache_limiter = ""'
-  notify: restart php5.6-fpm
+  notify: restart php{{ phpversion }}-fpm
 
 - name: set post_max_size
-  lineinfile: dest=/etc/php/5.6/fpm/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/fpm/php.ini
               regexp=';?post_max_size\s*=\s*'
               line='post_max_size = 2G'
-  notify: restart php5.6-fpm
+  notify: restart php{{ phpversion }}-fpm
 
 - name: set upload_max_filesize
-  lineinfile: dest=/etc/php/5.6/fpm/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/fpm/php.ini
               regexp=';?upload_max_filesize\s*=\s*'
               line='upload_max_filesize = 2G'
-  notify: restart php5.6-fpm
+  notify: restart php{{ phpversion }}-fpm
 
 - name: set max_input_vars
-  lineinfile: dest=/etc/php/5.6/fpm/php.ini
+  lineinfile: dest=/etc/php/{{ phpversion }}/fpm/php.ini
               regexp=';?max_input_vars\s*=\s*'
               line='max_input_vars = 12000'
-  notify: restart php5.6-fpm
+  notify: restart php{{ phpversion }}-fpm

--- a/resources/ansible/roles/xdebug/tasks/main.yml
+++ b/resources/ansible/roles/xdebug/tasks/main.yml
@@ -5,5 +5,5 @@
 - name: Copy xdebug INI into mods-available folder.
   template: >
     src=xdebug.ini.j2
-    dest=/etc/php/5.6/mods-available/xdebug.ini
+    dest=/etc/php/{{ phpversion }}/mods-available/xdebug.ini
     owner=root group=root mode=644

--- a/resources/ansible/vars/all.yml
+++ b/resources/ansible/vars/all.yml
@@ -62,32 +62,33 @@ elasticsearch:
 php:
     install: '1'
     ppa: php
+    version: '{{ phpversion }}'
     packages:
-        - 'php5.6-cli'
-        - 'php5.6-fpm'
-        - 'php5.6-intl'
-        - 'php5.6-mcrypt'
-        - 'php5.6-enchant'
-        - 'php5.6-gd'
-        - 'php5.6-memcache'
-        - 'php5.6-xml'
-        - 'php5.6-xmlrpc'
-        - 'php5.6-memcached'
-        - 'php5.6-mbstring'
-        - 'php5.6-curl'
-        - 'php5.6-mysql'
-        - 'php5.6-imagick'
-        - 'php5.6-zip'
-        - 'php5.6-sqlite3'
-        - 'php5.6-bcmath'
+        - 'php{{ phpversion }}-cli'
+        - 'php{{ phpversion }}-fpm'
+        - 'php{{ phpversion }}-intl'
+        - 'php{{ phpversion }}-mcrypt'
+        - 'php{{ phpversion }}-enchant'
+        - 'php{{ phpversion }}-gd'
+        - 'php{{ phpversion }}-memcache'
+        - 'php{{ phpversion }}-xml'
+        - 'php{{ phpversion }}-xmlrpc'
+        - 'php{{ phpversion }}-memcached'
+        - 'php{{ phpversion }}-mbstring'
+        - 'php{{ phpversion }}-curl'
+        - 'php{{ phpversion }}-mysql'
+        - 'php{{ phpversion }}-imagick'
+        - 'php{{ phpversion }}-zip'
+        - 'php{{ phpversion }}-sqlite3'
+        - 'php{{ phpversion }}-bcmath'
         - 'php-pear'
-        - 'php5.6-dev'
+        - 'php{{ phpversion }}-dev'
     pecl_packages:
-        - {name: zmq, package: zmq-beta}
-        - {name: amqp, package: amqp-1.9.3}
+        - {name: zmq, package: zmq-beta}
+        - {name: amqp, package: amqp-1.9.3}
 node:
     install: '1'
-    version: '9.4.0' 
+    version: '9.4.0'
 xdebug:
     install: '1'
     idekey: 'PHPSTORM'

--- a/resources/ansible/windows.sh
+++ b/resources/ansible/windows.sh
@@ -28,4 +28,4 @@ sudo apt-get install -y ansible
 cp /vagrant/resources/ansible/inventories/dev /etc/ansible/hosts -f
 chmod 666 /etc/ansible/hosts
 cat /vagrant/resources/ansible/files/authorized_keys >> /home/vagrant/.ssh/authorized_keys
-sudo ansible-playbook /vagrant/resources/ansible/playbook.yml -e hostname=$1 --connection=local
+sudo ansible-playbook /vagrant/resources/ansible/playbook.yml -e hostname=$1 phpversion=$2 --connection=local


### PR DESCRIPTION
## Changelog

### Adds
  - Phpversion is now passed in args to vagrant up function.
  - Now, run *phpversion='5.6' vagrant up* to run provisionning.
