### PR TITLE
PHRAS-2031 Port to 4.1 - Add XmpMM:DocumentID source

### DIFF
--- a/lib/Alchemy/Phrasea/Border/File.php
+++ b/lib/Alchemy/Phrasea/Border/File.php
@@ -49,6 +49,7 @@ class File
     protected $originalName;
     protected $md5;
     protected $attributes;
+    public static $xmpTag = ['XMP-xmpMM:DocumentID'];
 
     /**
      * Constructor
@@ -102,6 +103,7 @@ class File
             'IPTC:UniqueDocumentID',
             'ExifIFD:ImageUniqueID',
             'Canon:ImageUniqueID',
+            'XMP-xmpMM:DocumentID',
         ];
 
         if (!$this->uuid) {
@@ -112,6 +114,9 @@ class File
             foreach ($availableUUIDs as $meta) {
                 if ($metadatas->containsKey($meta)) {
                     $candidate = $metadatas->get($meta)->getValue()->asString();
+                    if(in_array($meta, self::$xmpTag)){
+                        $candidate = self::sanitizeXmpUuid($candidate);
+                    }
                     if (Uuid::isValid($candidate)) {
                         $uuid = $candidate;
                         break;
@@ -286,5 +291,14 @@ class File
         }
 
         return new File($app, $media, $collection, $originalName);
+    }
+
+    /**
+     * Sanitize XMP UUID
+     * @param $uuid
+     * @return mixed
+     */
+    public static function sanitizeXmpUuid($uuid){
+        return str_replace('xmp.did:', '', $uuid);
     }
 }

--- a/lib/Alchemy/Phrasea/Metadata/PhraseanetMetadataSetter.php
+++ b/lib/Alchemy/Phrasea/Metadata/PhraseanetMetadataSetter.php
@@ -11,6 +11,7 @@
 
 namespace Alchemy\Phrasea\Metadata;
 
+use Alchemy\Phrasea\Border\File;
 use Alchemy\Phrasea\Databox\DataboxRepository;
 use Alchemy\Phrasea\Metadata\Tag\NoSource;
 use PHPExiftool\Driver\Metadata\Metadata;
@@ -119,8 +120,11 @@ class PhraseanetMetadataSetter
                 if (!isset($metadataPerField[$fieldName])) {
                     $metadataPerField[$fieldName] = [];
                 }
-
-                $metadataPerField[$fieldName] = array_merge($metadataPerField[$fieldName], $metadata->getValue()->asArray());
+                if(in_array($tagName, File::$xmpTag)){
+                    $metadataPerField[$fieldName] = array_merge($metadataPerField[$fieldName], (array) File::sanitizeXmpUuid($metadata->getValue()->asString()));
+                }else{
+                    $metadataPerField[$fieldName] = array_merge($metadataPerField[$fieldName], $metadata->getValue()->asArray());
+                }
             }
         }
 


### PR DESCRIPTION
## Changelog
 
### Adds
  - PHRAS-2031: Port to 4.1 - Add XmpMM:DocumentID source
  - Add XmpMM:DocumentID source for value of 'UUID' of table 'record' of Databox


