### PR TITLE
Remove DB_alt from mariadb task

### DIFF
--- a/resources/ansible/roles/mariadb/tasks/main.yml
+++ b/resources/ansible/roles/mariadb/tasks/main.yml
@@ -34,7 +34,6 @@
   with_items:
     - "{{ mariadb.appbox_db }}"
     - "{{ mariadb.databox_db }}"
-    - "{{ mariadb.alt_databox_db }}"
 
 - name: mariadb | Import dump
   mysql_db: name={{ mariadb.appbox_db }} state=import login_user=root login_password={{ mariadb.root_password }} target=/vagrant/{{ mariadb.dump }}


### PR DESCRIPTION
## Changelog

### Fixes
  - Remove DB_alt from mariadb task.
