### PR TITLE
PHRAS-2149 Circleci bum elasticsearch and node version as same 4.1 version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
   php:
     version: 5.5.31
   node:
-    version: 6.11.4
+    version: stable
   services:
     - memcached
     - redis
@@ -17,7 +17,7 @@ machine:
 
 dependencies:
   cache_directories:
-    - elasticsearch-1.6.0 # relative to the build directory
+    - elasticsearch-2.3.3 # relative to the build directory
     - node_modules
     - ~/.composer
   pre:
@@ -32,8 +32,8 @@ dependencies:
     - composer install --no-progress --no-interaction --optimize-autoloader
   post:
     - make install_asset_dependencies
-    - if [[ ! -e elasticsearch-1.6.0 ]]; then wget --no-check-certificate https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz && tar -xvf elasticsearch-1.6.0.tar.gz && elasticsearch-1.6.0/bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0; fi
-    - elasticsearch-1.6.0/bin/elasticsearch: {background: true}
+    - if [[ ! -e elasticsearch-2.3.3 ]]; then wget --no-check-certificate https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-2.3.3.tar.gz && tar -xvf elasticsearch-2.3.3.tar.gz && elasticsearch-2.3.3/bin/plugin install elasticsearch/elasticsearch-analysis-icu/2.6.0; fi
+    - elasticsearch-2.3.3/bin/elasticsearch: {background: true}
 
 
 database:


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2149: Circleci bum elasticsearch and node version as same 4.1 version




