### PR TITLE
PHRAS-1831_wrong-results-th-query_4.0

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Query.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Query.php
@@ -27,8 +27,9 @@ class Query
     {
         $query = $this->root->buildQuery($context);
         if ($query === null) {
-            $query = [];
-            $query['bool']['must'] = [];
+            //$query = ['bool'=> ['must' => []]];
+            // a null query shoud return no results !
+            $query = ['constant_score'=> ['filter' => new \stdClass]];
         }
 
         return $query;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus.php
@@ -63,6 +63,7 @@ class Thesaurus
         // TODO Use bulk queries for performance
         $concepts = array();
         foreach ($terms as $index => $term) {
+            $strict = ($term instanceof AST\TermNode);      // a "term" node is [strict group of words]
             $concepts[] = $this->findConcepts($term, $lang, $filters[$index], $strict);
         }
 

--- a/lib/classes/databox.php
+++ b/lib/classes/databox.php
@@ -1256,7 +1256,7 @@ class databox extends base implements ThumbnailedElement
             if ($domct !== false) {
                 $nodesToDel = [];
                 for($n = $domct->documentElement->firstChild; $n; $n = $n->nextSibling) {
-                    if(!($n->getAttribute('delbranch'))){
+                    if($n->nodeType == XML_ELEMENT_NODE && !($n->getAttribute('delbranch'))){
                         $nodesToDel[] = $n;
                     }
                 }


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1831: enforce strict search with [bracketted] query
  - fix small issue with "clear candidates" function 

### Change
  - th query on non-existing term (eg. " [vfshfvyervaze] ") now return 0 results instead of "all"