### PR TITLE
PHRAS-2258 Quarantine - special characteres in filename of uploaded file, block actions, (add, substitute, delete).

### DIFF
--- a/lib/Alchemy/Phrasea/Filesystem/LazaretPathBooker.php
+++ b/lib/Alchemy/Phrasea/Filesystem/LazaretPathBooker.php
@@ -54,6 +54,9 @@ class LazaretPathBooker
      */
     public function bookFile($filename, $suffix = '')
     {
+        // stripped all non-alpha-numeric in filename
+        $filename = preg_replace("/[^a-zA-Z0-9-_.]/", '', $filename);
+
         $output = $this->tmpPath .'/lzrt_' . substr($filename, 0, 3) . '_' . $suffix . '.' . pathinfo($filename, PATHINFO_EXTENSION);
         $infos = pathinfo($output);
         $n = 0;


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2258: filter special characterin filename when created lazaretfile


