### PR TITLE
PHRAS-2317_wrong-collid-logdoc_4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Version.php
+++ b/lib/Alchemy/Phrasea/Core/Version.php
@@ -16,7 +16,7 @@ class Version
     /**
      * @var string
      */
-    private $number = '4.0.6a';
+    private $number = '4.0.6b';
 
     /**
      * @var string

--- a/lib/classes/patch/406b.php
+++ b/lib/classes/patch/406b.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of Phraseanet
+ *
+ * (c) 2005-2016 Alchemy
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use Alchemy\Phrasea\Application;
+
+
+class patch_406b implements patchInterface
+{
+    /** @var string */
+    private $release = '4.0.6b';
+
+    /** @var array */
+    private $concern = [base::DATA_BOX];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get_release()
+    {
+        return $this->release;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDoctrineMigrations()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function require_all_upgrades()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function concern()
+    {
+        return $this->concern;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(base $databox, Application $app)
+    {
+        $sql = "UPDATE `log_docs` SET `coll_id`=`final` WHERE `action`='collection'";
+        $databox->get_connection()->prepare($sql)->execute();
+
+        return true;
+    }
+}

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -529,11 +529,12 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
         }
 
         $coll_id_from = $this->getCollectionId();
+        $coll_id_to = $collection->get_coll_id();
 
         $sql = "UPDATE record SET moddate = NOW(), coll_id = :coll_id WHERE record_id =:record_id";
 
         $params = [
-            ':coll_id'   => $collection->get_coll_id(),
+            ':coll_id'   => $coll_id_to,
             ':record_id' => $this->getRecordId(),
         ];
 
@@ -542,11 +543,12 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
         $stmt->closeCursor();
 
         $this->base_id = $collection->get_base_id();
+        $this->collection_id = $coll_id_to;
+
+        $this->delete_data_from_cache();
 
         $this->app['phraseanet.logger']($this->getDatabox())
             ->log($this, Session_Logger::EVENT_MOVE, $collection->get_coll_id(), '', $coll_id_from);
-
-        $this->delete_data_from_cache();
 
         $this->dispatch(RecordEvents::COLLECTION_CHANGED, new CollectionChangedEvent($this));
 


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2317: wrong coll_id (destination collection) on table log_docs for "collection" actions (change collection)
    Added a patch (4.0.6b) to fix old bad values.


