### PR TITLE
PHRAS-2371 strict thesaurus search when indexing

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus.php
@@ -63,7 +63,7 @@ class Thesaurus
         // TODO Use bulk queries for performance
         $concepts = array();
         foreach ($terms as $index => $term) {
-            $strict = ($term instanceof AST\TermNode);      // a "term" node is [strict group of words]
+            $strict |= ($term instanceof AST\TermNode);      // a "term" node is [strict group of words]
             $concepts[] = $this->findConcepts($term, $lang, $filters[$index], $strict);
         }
 


### PR DESCRIPTION
Now we are strict when do a thesaurus search and when indexing record.
The following of PHRAS-1831
We are also strict with context of thesaurus term.

## Changelog
### Changed
  - Now we are strict when do a thesaurus search and when indexing record.

  - A search with [orange] don't find record with thesaurus term "orange (city)" , "orange (fruit)" and 
    "Orange (color)".

  - A search with "Orange" (full text + thesaurus search ) find record with "orange (ville)" , "orange 
     (fruit)" and "orange (color)".

  - A search with "Orange City" find only record with "Orange (City)".

### Fixes
  - PHRAS-2371 strict thesaurus search when indexing
 
