### PR TITLE
PHRAS-2322_return_aggregates_as_new_json_structure-BIS-4.0

### DIFF
--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -201,7 +201,6 @@
             <div id="headBlock" class="PNB">
                 <div class="searchFormWrapper">
                     <form id="searchForm" method="POST" action="{{ path('prod_query') }}" name="phrasea_query" class="phrasea_query">
-                        <input id="SENT_query" name="qry" type="hidden" value="{{app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page_query')}}">
                         <input type="hidden" name="pag" id="formAnswerPage" value="">
                         <input type="hidden" name="sel" value="">
 
@@ -352,12 +351,12 @@
                                                     </label>
                                                     
                                                     <label for="multiple-terms" class="radio inline custom_checkbox_label">
-                                                        <input type="radio" class="multiple_terms" name="terms_type" checked="checked" id="multiple-terms"/>
+                                                        <input type="radio" class="multiple_terms" name="must_match" value="ALL" checked="checked" id="multiple-terms"/>
                                                         <span class="custom_radio"></span>
                                                         {{ 'All these conditions' | trans }}
                                                     </label>
                                                     <label for="single-terms" class="radio inline custom_checkbox_label">
-                                                        <input type="radio" class="single_terms" name="terms_type" id="single-terms"/>
+                                                        <input type="radio" class="single_terms" name="must_match" value="ONE" id="single-terms"/>
                                                         <span class="custom_radio"></span>
                                                         {{ 'One of these conditions' | trans }}
                                                     </label>


### PR DESCRIPTION
## Changelog
### Changed
  - only the input text of query is saved/restored as "last query", everything else is lost (adv search settings, aggregates etc...)
  todo : save / restore everything

### Adds
  - PHRAS-2322: 
    - build jsonquery from adv-search and facets
    - build equivalent fulltext query from jsonquery (backward compatible)
    - save/restore only the input text for now (todo: save jsonquery, restore ux)

included some code from Filip so previous pr will be closed.

