### PR TITLE
PHRAS-2368 Change cmd elasticsearch create index

### DIFF
--- a/resources/ansible/roles/app/tasks/main.yml
+++ b/resources/ansible/roles/app/tasks/main.yml
@@ -60,7 +60,7 @@
     chdir: /vagrant/
 
 - name: Create ElasticSearch indexes
-  shell: php bin/console s:i:c
+  shell: php bin/console searchengine:index -c
   args:
     chdir: /vagrant/
 


### PR DESCRIPTION
Cmd bin/console s:c:p is deprecated

## Changelog
### Changed
  - Cmd bin/console s:c:p is deprecated change in favor of new cmd
      bin/console searchengine:index -c