### PR TITLE
PHRAS-2410 security failure in pear.php.net

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ jobs:
     - run: git clone https://github.com/alanxz/rabbitmq-c
     - run: cd rabbitmq-c && git checkout 2ca1774489328cde71195f5fa95e17cf3a80cb8a
     - run: cd rabbitmq-c && git submodule init && git submodule update && autoreconf -i && ./configure && make && sudo make install
-    - run: pecl channel-update pear.php.net
+    # 20192401 disabled because pear.php.net is down cause of security failure
+    #- run: pecl channel-update pear.php.net
     - run: yes '' | pecl install amqp-1.9.3
     - run: yes '' | pecl install imagick
     - run: sudo apt-get install libzmq-dev


### PR DESCRIPTION
Disabled pear.php.net,  is down cause of security failure

## Changelog
### Changed
  - disabled because pear.php.net is down cause of security failure

  
