### PR TITLE
Phras 2381 save restore advsearch 4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
@@ -85,6 +85,8 @@ class QueryController extends Controller
                         return null;
                     };
 
+                    $userManipulator->setUserSetting($user, 'start_page_jsonquery', (string)$request->request->get('jsQuery'));
+
                     $jsQuery = @json_decode((string)$request->request->get('jsQuery'), true);
                     if(($ft = $findFulltext($jsQuery['query'])) !== null) {
                         $userManipulator->setUserSetting($user, 'start_page_query', $ft);

--- a/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
@@ -85,7 +85,7 @@ class QueryController extends Controller
                         return null;
                     };
 
-                    $userManipulator->setUserSetting($user, 'start_page_jsonquery', (string)$request->request->get('jsQuery'));
+                    $userManipulator->setUserSetting($user, 'last_jsonquery', (string)$request->request->get('jsQuery'));
 
                     $jsQuery = @json_decode((string)$request->request->get('jsQuery'), true);
                     if(($ft = $findFulltext($jsQuery['query'])) !== null) {

--- a/resources/www/prod/js/jquery.main-prod.js
+++ b/resources/www/prod/js/jquery.main-prod.js
@@ -1644,26 +1644,12 @@ $(document).ready(function () {
     $(document).on('click', '.term_deleter', function (event) {
         event.preventDefault();
         var $this = $(this);
-        var rowOption = $this.siblings('.term_select_field');
-        
-        $('.term_select_multiple option').each(function (index, el) {
-            var $el = $(el);
-            if(rowOption.val() == $el.val()) {
-                $el.prop('selected', false);
-            }
-        });
-        checkFilters(true);
         $this.closest('.term_select_wrapper').remove();
+        checkFilters(true);
     });
 
     $('.add_new_term').on('click', function (event) {
-        event.preventDefault();
-        if ($('select.term_select_field').length === 0) {
-            $('.term_select').prepend('<div class="term_select_wrapper">' + multi_term_select_html + '</div>');
-        }
-        else if ($('select.term_select_field').last().val() !== '') {
-            $('.term_select_wrapper').last().after('<div class="term_select_wrapper">' + multi_term_select_html + '</div>');
-        }
+        AdvSearchAddNewTerm(1);
     });
 
     $('.adv_search_button').on('click', function () {

--- a/resources/www/prod/js/jquery.main-prod.js
+++ b/resources/www/prod/js/jquery.main-prod.js
@@ -937,6 +937,131 @@ function getFacetsTree() {
     return $facetsTree.fancytree('getTree');
 }
 
+function findClauseBy_ux_zone(clause, ux_zone)
+{
+    if(typeof clause._ux_zone != 'undefined' && clause._ux_zone == ux_zone) {
+        return clause;
+    }
+    if(clause.type == "CLAUSES") {
+        for(var i=0; i<clause.clauses.length; i++) {
+            var r = findClauseBy_ux_zone(clause.clauses[i], ux_zone);
+            if(r != null) {
+                return r;
+            }
+        }
+    }
+    return null;
+}
+
+function restoreJsonQuery() {
+    var jsq = {
+        "sort": {
+            "field": "LastEditDate",
+            "order": "asc"
+        },
+        "perpage": 100,
+        "page": 1,
+        "use_truncation": false,
+        "phrasea_recordtype": "RECORD",
+        "phrasea_mediatype": "",
+        "bases": [
+            393
+        ],
+        "statuses": [
+            {
+                "databox": "2",
+                "status": [
+                    {
+                        "index": "4",
+                        "value": false
+                    }
+                ]
+            }
+        ],
+        "query": {
+            "_ux_zone": "PROD",
+            "type": "CLAUSES",
+            "must_match": "ALL",
+            "enabled": true,
+            "clauses": [
+                {
+                    "_ux_zone": "FULLTEXT",
+                    "type": "FULLTEXT",
+                    "value": "nikon",
+                    "enabled": true
+                },
+                {
+                    "_ux_zone": "FIELDS",
+                    "type": "CLAUSES",
+                    "must_match": "ONE",
+                    "enabled": true,
+                    "clauses": [
+                        {
+                            "type": "TEXT-FIELD",
+                            "field": "field.CameraDevice",
+                            "operator": ":",
+                            "value": "d300",
+                            "enabled": true
+                        },
+                        {
+                            "type": "TEXT-FIELD",
+                            "field": "field.Format",
+                            "operator": "=",
+                            "value": "image/jpeg",
+                            "enabled": true
+                        }
+                    ]
+                },
+                {
+                    "type": "DATE-FIELD",
+                    "field": "",
+                    "from": "",
+                    "to": "",
+                    "enabled": false
+                },
+                {
+                    "_ux_zone": "AGGREGATES",
+                    "type": "CLAUSES",
+                    "must_match": "ALL",
+                    "enabled": true,
+                    "clauses": [
+                        {
+                            "type": "NUMBER-AGGREGATE",
+                            "field": "meta.ShutterSpeed",
+                            "value": 0.0080000003799796,
+                            "negated": false,
+                            "enabled": true
+                        },
+                        {
+                            "type": "NUMBER-AGGREGATE",
+                            "field": "meta.Aperture",
+                            "value": 14,
+                            "negated": false,
+                            "enabled": true
+                        }
+                    ]
+                }
+            ]
+        }
+    };
+
+    // console.log(jsq);
+
+    // check one radio will uncheck siblings
+    $('#searchForm INPUT[name=search_type][value="' + ((jsq.phrasea_recordtype == 'RECORD') ? '0' : '1') + '"]').prop('checked', true);
+
+    $('#searchForm SELECT[name=record_type] OPTION[value="' + jsq.phrasea_mediatype.toLowerCase() + '"]').prop('checked', true);
+
+    $('#ADVSRCH_USE_TRUNCATION').prop('checked', jsq.use_truncation);
+
+    $('#ADVSRCH_SORT_ZONE SELECT[name=sort] OPTION[value="' + jsq.sort.field + '"]').prop('selected', true);
+    $('#ADVSRCH_SORT_ZONE SELECT[name=ord] OPTION[value="' + jsq.sort.order + '"]').prop('selected', true);
+
+    var clause = findClauseBy_ux_zone(jsq.query, "FIELDS");
+    $('#ADVSRCH_FIELDS_ZONE INPUT[name=must_match][value="' + clause.must_match + '"]').attr('checked', true);
+
+
+}
 
 function serializeJSON(data, selectedFacetValues, facets) {
     var json = {},

--- a/resources/www/prod/js/jquery.main-prod.js
+++ b/resources/www/prod/js/jquery.main-prod.js
@@ -366,21 +366,49 @@ function clearAnswers() {
 }
 
 function reset_adv_search() {
-    var container = $("#ADVSRCH_OPTIONS_ZONE");
-    var fieldsSort = $('#ADVSRCH_SORT_ZONE select[name=sort]', container);
-    var fieldsSortOrd = $('#ADVSRCH_SORT_ZONE select[name=ord]', container);
-    var dateFilterSelect = $('#ADVSRCH_DATE_ZONE select', container);
+    var jsq = {
+        "sort":{
+            "field":"created_on",
+            "order":"desc"
+        },
+        "use_truncation":false,
+        "phrasea_recordtype":"RECORD",
+        "phrasea_mediatype":"",
+        "bases":[ ],
+        "statuses":[ ],
+        "query":{
+            "_ux_zone":"PROD",
+            "type":"CLAUSES",
+            "must_match":"ALL",
+            "enabled":true,
+            "clauses":[
+                {
+                    "_ux_zone":"FIELDS",
+                    "type":"CLAUSES",
+                    "must_match":"ALL",
+                    "enabled":false,
+                    "clauses":[ ]
+                },
+                {
+                    "type":"DATE-FIELD",
+                    "field":"",
+                    "from":"",
+                    "to":"",
+                    "enabled":false
+                },
+                {
+                    "_ux_zone":"AGGREGATES",
+                    "type":"CLAUSES",
+                    "must_match":"ALL",
+                    "enabled":false,
+                    "clauses":[ ]
+                }
+            ]
+        },
+        "_selectedFacets":{ }
+    };
 
-    $("option.default-selection", fieldsSort).prop("selected", true);
-    $("option.default-selection", fieldsSortOrd).prop("selected", true);
-
-    $('#ADVSRCH_FIELDS_ZONE option').prop("selected", false);
-    $('#ADVSRCH_OPTIONS_ZONE input:checkbox.field_switch').prop("checked", false);
-
-    $("option:eq(0)", dateFilterSelect).prop("selected", true);
-    $('#ADVSRCH_OPTIONS_ZONE .datepicker').val('');
-    $('form.adv_search_bind input:text').val('');
-    checkBases(true);
+    restoreJsonQuery(jsq, false);
 }
 
 
@@ -591,8 +619,27 @@ function initAnswerForm() {
         });
         return false;
     });
-    if (searchForm.hasClass('triggerAfterInit')) {
-        searchForm.removeClass('triggerAfterInit').trigger('submit');
+
+    // if defined, play the first query
+    //
+    try {
+        var jsq = $("#FIRST_QUERY_CONTAINER");
+        if(jsq.length > 0) {
+            // there is a query to play
+            if(jsq.data('format') === "json") {
+                // json
+                jsq = JSON.parse(jsq.text());
+                restoreJsonQuery(jsq, true);
+            }
+            else {
+                // text : do it the old way : restore only fulltext and submit
+                searchForm.trigger('submit');
+            }
+        }
+    }
+    catch (e) {
+        // malformed jsonquery ?
+        // no-op
     }
 }
 
@@ -864,12 +911,6 @@ function getFacetsTree() {
                             s_label.setAttribute("class", "facetFilter-label");
                             s_label.setAttribute("title", label);
 
-                            /*
-                            var labelString = label.toString();
-                            _.each($.parseHTML(labelString), function (elem) {
-                                s_label.appendChild(elem);
-                            });
-                            */
                             // label is a string ; todo : count may be obsolete when ux is restored ? for now don't print
                             s_label.appendChild(document.createTextNode(label)); // + ' (' + facetValue.value.count + ')');
 
@@ -961,220 +1002,96 @@ function findClauseBy_ux_zone(clause, ux_zone) {
     return null;
 }
 
-function restoreJsonQuery() {
-    var jsq = {
-        "sort":{
-            "field":"created_on",
-            "order":"desc"
-        },
-        "perpage":100,
-        "page":1,
-        "use_truncation":false,
-        "phrasea_recordtype":"RECORD",
-        "phrasea_mediatype":"",
-        "bases":[
-            394,
-            395,
-            396,
-            397,
-            398,
-            399,
-            1,
-            341,
-            369,
-            371,
-            372,
-            373,
-            375,
-            376,
-            377,
-            378,
-            379,
-            380,
-            381,
-            382,
-            383,
-            384,
-            385,
-            386,
-            387,
-            388,
-            389,
-            390,
-            391,
-            392,
-            393
-        ],
-        "statuses":[
-
-        ],
-        "query":{
-            "_ux_zone":"PROD",
-            "type":"CLAUSES",
-            "must_match":"ALL",
-            "enabled":true,
-            "clauses":[
-                {
-                    "_ux_zone":"FULLTEXT",
-                    "type":"FULLTEXT",
-                    "value":"",
-                    "enabled":false
-                },
-                {
-                    "_ux_zone":"FIELDS",
-                    "type":"CLAUSES",
-                    "must_match":"ALL",
-                    "enabled":false,
-                    "clauses":[
-
-                    ]
-                },
-                {
-                    "type":"DATE-FIELD",
-                    "field":"",
-                    "from":"",
-                    "to":"",
-                    "enabled":false
-                },
-                {
-                    "_ux_zone":"AGGREGATES",
-                    "type":"CLAUSES",
-                    "must_match":"ALL",
-                    "enabled":true,
-                    "clauses":[
-                        {
-                            "type":"STRING-AGGREGATE",
-                            "field":"field.MotsCles",
-                            "value":"ciel",
-                            "negated":false,
-                            "enabled":true
-                        },
-                        {
-                            "type":"STRING-AGGREGATE",
-                            "field":"field.MotsCles",
-                            "value":"Immeubles",
-                            "negated":true,
-                            "enabled":true
-                        },
-                        {
-                            "type":"NUMBER-AGGREGATE",
-                            "field":"meta.Aperture",
-                            "value":8,
-                            "negated":false,
-                            "enabled":true
-                        }
-                    ]
-                }
-            ]
-        },
-        "_selectedFacets":{
-            "field.MotsCles":{
-                "name":"MotsCles",
-                "field":"field.MotsCles",
-                "label":"Mots Clés",
-                "type":"STRING-AGGREGATE",
-                "values":[
-                    {
-                        "value":{
-                            "query":"field.MotsCles:ciel",
-                            "field":"field.MotsCles",
-                            "raw_value":"ciel",
-                            "value":"ciel",
-                            "label":"ciel",
-                            "type":"STRING-AGGREGATE",
-                            "count":108
-                        },
-                        "enabled":true,
-                        "negated":false
-                    },
-                    {
-                        "value":{
-                            "query":"field.MotsCles:Immeubles",
-                            "field":"field.MotsCles",
-                            "raw_value":"Immeubles",
-                            "value":"Immeubles",
-                            "label":"Immeubles",
-                            "type":"STRING-AGGREGATE",
-                            "count":78
-                        },
-                        "enabled":true,
-                        "negated":true
-                    }
-                ]
-            },
-            "meta.Aperture":{
-                "name":"aperture_aggregate",
-                "field":"meta.Aperture",
-                "label":"Ouverture",
-                "type":"NUMBER-AGGREGATE",
-                "values":[
-                    {
-                        "value":{
-                            "query":"meta.Aperture=8",
-                            "field":"meta.Aperture",
-                            "raw_value":8,
-                            "value":8,
-                            "label":"8",
-                            "type":"NUMBER-AGGREGATE",
-                            "count":8
-                        },
-                        "enabled":true,
-                        "negated":false
-                    }
-                ]
-            }
-        }
-    };
-
+/**
+ * restore the advansearch ux from a json-query
+ * elements are restored thank's to custom properties ("_xxx") included in json.
+ * nb : for now, _ux_ facets can't be restored _before_sending_the_query_,
+ *      but since "selectedFacets" (js) IS restored, sending the query WILL restore facets.
+ *
+ * @param jsq
+ * @param submit
+ */
+function restoreJsonQuery(jsq, submit) {
     var clause;
 
     // restore the "fulltext" input-text
     clause = findClauseBy_ux_zone(jsq.query, "FULLTEXT");
-    $('#EDIT_query').val(clause.value);
+    if(clause) {
+        $('#EDIT_query').val(clause.value);
+    }
 
     // restore the "records/stories" radios
-    $('#searchForm INPUT[name=search_type][value="' + ((jsq.phrasea_recordtype == 'RECORD') ? '0' : '1') + '"]').prop('checked', true);  // check one radio will uncheck siblings
+    if(!_.isUndefined(jsq.phrasea_recordtype)) {
+        $('#searchForm INPUT[name=search_type][value="' + ((jsq.phrasea_recordtype == 'STORY') ? '1' : '0') + '"]').prop('checked', true);  // check one radio will uncheck siblings
+    }
 
     // restore the "record type" menu (image, video, audio, ...)
-    $('#searchForm SELECT[name=record_type] OPTION[value="' + jsq.phrasea_mediatype.toLowerCase() + '"]').prop('selected', true);
+    if(!_.isUndefined(jsq.phrasea_mediatype)) {
+        $('#searchForm SELECT[name=record_type] OPTION[value="' + jsq.phrasea_mediatype.toLowerCase() + '"]').prop('selected', true);
+    }
 
     // restore the "use truncation" checkbox
-    $('#ADVSRCH_USE_TRUNCATION').prop('checked', jsq.use_truncation);
+    if(!_.isUndefined(jsq.phrasea_mediatype)) {
+        $('#ADVSRCH_USE_TRUNCATION').prop('checked', jsq.phrasea_mediatype);
+    }
 
     // restore the "sort results" menus
-    $('#ADVSRCH_SORT_ZONE SELECT[name=sort] OPTION[value="' + jsq.sort.field + '"]').prop('selected', true);
-    $('#ADVSRCH_SORT_ZONE SELECT[name=ord] OPTION[value="' + jsq.sort.order + '"]').prop('selected', true);
+    if(!_.isUndefined(jsq.sort)) {
+        if(!_.isUndefined(jsq.sort.field)) {
+            $('#ADVSRCH_SORT_ZONE SELECT[name=sort] OPTION[value="' + jsq.sort.field + '"]').prop('selected', true);
+        }
+        if(!_.isUndefined(jsq.sort.order)) {
+            $('#ADVSRCH_SORT_ZONE SELECT[name=ord] OPTION[value="' + jsq.sort.order + '"]').prop('selected', true);
+        }
+    }
 
     // restore the "bases" checkboxes
-    $('#ADVSRCH_SBAS_ZONE INPUT.checkbas').attr('checked', false);
-    for(var i=0; i<jsq.bases.length; i++) {
-        $('#ADVSRCH_SBAS_ZONE INPUT.checkbas[value="' + jsq.bases[i] + '"]').attr('checked', true);
+    if(!_.isUndefined(jsq.bases)) {
+        $('#ADVSRCH_SBAS_ZONE INPUT.checkbas').attr('checked', false);
+        if (jsq.bases.length > 0) {
+            for (var i = 0; i < jsq.bases.length; i++) {
+                $('#ADVSRCH_SBAS_ZONE INPUT.checkbas[value="' + jsq.bases[i] + '"]').attr('checked', true);
+            }
+        } else {
+            // special case : EMPTY array ==> since it's a nonsense, check ALL bases
+            $('#ADVSRCH_SBAS_ZONE INPUT.checkbas').attr('checked', true);
+        }
     }
 
     // restore the multiples "fields" (field-menu + op-menu + value-input)
     clause = findClauseBy_ux_zone(jsq.query, "FIELDS");
-    $('#ADVSRCH_FIELDS_ZONE INPUT[name=must_match][value="' + clause.must_match + '"]').attr('checked', true);
-    $('#ADVSRCH_FIELDS_ZONE DIV.term_select_wrapper').remove();
-    for(var i=0; i<clause.clauses.length; i++) {
-        var wrapper = AdvSearchAddNewTerm(1);    // div.term_select_wrapper
-        // todo : restore content
-        var f = $(".term_select_field", wrapper);
-        var o = $(".term_select_op", wrapper);
-        var v = $(".term_select_value", wrapper);
+    if(clause) {
+        $('#ADVSRCH_FIELDS_ZONE INPUT[name=must_match][value="' + clause.must_match + '"]').attr('checked', true);
+        $('#ADVSRCH_FIELDS_ZONE DIV.term_select_wrapper').remove();
+        for (var i = 0; i < clause.clauses.length; i++) {
+            var wrapper = AdvSearchAddNewTerm();    // div.term_select_wrapper
+            var f = $(".term_select_field", wrapper);
+            var o = $(".term_select_op", wrapper);
+            var v = $(".term_select_value", wrapper);
 
-        f.data('fieldtype', clause.clauses[i].type);
-        $('option[value="' + clause.clauses[i].field + '"]', f).prop('selected', true);
-        $('option[value="' + clause.clauses[i].operator + '"]', o).prop('selected', true);
-        v.val(clause.clauses[i].value);
+            f.data('fieldtype', clause.clauses[i].type);
+            $('option[value="' + clause.clauses[i].field + '"]', f).prop('selected', true);
+            $('option[value="' + clause.clauses[i].operator + '"]', o).prop('selected', true);
+            v.val(clause.clauses[i].value);
+        }
+        if(i === 0) {
+            // if no field, add an empty one to ux
+            AdvSearchAddNewTerm();
+        }
     }
 
     // restore the selected facets (whole saved as custom property)
-    selectedFacets = jsq._selectedFacets;
+    if(!_.isUndefined(jsq._selectedFacets)) {
+        selectedFacets = jsq._selectedFacets;
+    }
 
-    // the ux is restored, finish the job (display "danger")
+    // the ux is restored, finish the job (hide unavailable fields/status etc, display "danger" where needed)
     checkFilters(false);
+    // loadFacets([]);  // useless, facets will be restored after the query is sent
 
-    $('#searchForm').submit();
+    if(submit) {
+        $('#searchForm').submit();
+    }
 }
 
 function serializeJSON(data, selectedFacets, facets) {
@@ -1233,9 +1150,9 @@ function serializeJSON(data, selectedFacets, facets) {
         var f = $(".term_select_field option:selected", wrapper);
         var o = $(".term_select_op", wrapper);
         var v = $(".term_select_value", wrapper);
-
+        var type = f.data('fieldtype');
         fields.push({
-            'type'    : f.data('fieldtype').toUpperCase(),
+            'type'    : _.isString(type) ? type.toUpperCase() : "",
             'field'   : f.val(),
             'operator': o.val(),
             'value'   : v.val(),
@@ -1246,9 +1163,9 @@ function serializeJSON(data, selectedFacets, facets) {
     _.each(selectedFacets, function(facets) {
         _.each(facets.values, function(facetValue) {
             aggregates.push({
-                'type':    facetValue.value.type,
-                'field':   facetValue.value.field,
-                'value':   facetValue.value.raw_value,
+                'type'   : facetValue.value.type,
+                'field'  : facetValue.value.field,
+                'value'  : facetValue.value.raw_value,
                 'negated': facetValue.negated,
                 'enabled': facetValue.enabled
             });
@@ -1355,7 +1272,7 @@ function buildQ(clause) {
                 // no "yes" clauses
                 if(t_neg.length > 0) {
                     // only "neg" clauses
-                    return "(" + _ALL_Clause_ + " EXCEPT (" + t_neg.join(clause.must_match=="ALL" ? " OR " : " AND ") + "))";
+                    return "(" + _ALL_Clause_ + " EXCEPT (" + t_neg.join(clause.must_match == "ALL" ? " OR " : " AND ") + "))";
                 }
                 else {
                     // no clauses at all
@@ -1656,20 +1573,23 @@ function HueToRgb(m1, m2, hue) {
     return 255 * v;
 }
 
-function AdvSearchAddNewTerm(n) {
-    if(n === undefined) {
-        n = 1;
-    }
+/**
+ * add "field" zone on advsearch
+ *
+ * @returns {jQuery|HTMLElement}
+ * @constructor
+ */
+function AdvSearchAddNewTerm() {
     var block_template = $('#ADVSRCH_FIELDS_ZONE DIV.term_select_wrapper_template');
     var last_block = $('#ADVSRCH_FIELDS_ZONE DIV.term_select_wrapper:last');
     if(last_block.length === 0) {
         last_block = block_template;
     }
-    for(var i=0; i<n; i++) {
-        last_block = block_template.clone(true).insertAfter(last_block);    // true: clone event handlers
-        last_block.removeClass('term_select_wrapper_template').addClass('term_select_wrapper').show();
-        last_block.css("background-color", "");
-    }
+    last_block = block_template.clone(true).insertAfter(last_block);    // true: clone event handlers
+    last_block.removeClass('term_select_wrapper_template').addClass('term_select_wrapper').show();
+    last_block.css("background-color", "");
+
+    return last_block;
 }
 
 

--- a/resources/www/prod/js/jquery.main-prod.js
+++ b/resources/www/prod/js/jquery.main-prod.js
@@ -1634,37 +1634,8 @@ $(document).ready(function () {
         }
     });
 
-    var previousVal;
-    $(document).on('focus', 'select.term_select_field', function () {
-        previousVal = $(this).val();
-    })
-    .on('change', 'select.term_select_field', function () {
+    $(document).on('change', 'select.term_select_field', function () {
         var $this = $(this);
-
-        // if option is selected
-        if($this.val()) {
-            $this.siblings().prop('disabled', false);
-
-            $('.term_select_multiple option').each(function (index, el) {
-                var $el = $(el);
-                if($this.val() === $el.val()) {
-                    $el.prop('selected', true);
-                }
-                else if (previousVal === $el.val()) {
-                    $el.prop('selected', false);
-                }
-            });
-        }
-        else {
-            $this.siblings().prop('disabled', 'disabled');
-
-            $('.term_select_multiple option').each(function (index, el) {
-                var $el = $(el);
-                if(previousVal === $el.val()) {
-                    $el.prop('selected', false);
-                }
-            });
-        }
         $this.blur();
         checkFilters(true);
     });

--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -211,6 +211,7 @@
                                     <img src="/assets/common/images/icons/settings.png" title="{{ 'Advanced Search' | trans }}"/>
                                 </a>
                                 <button type="submit" class="btn btn-inverse" style="font-size:14px">{{ 'boutton::rechercher' | trans }}</button>
+                                <button type="button" id="TESTJS">TestJS</button>
                             </div>
                             <div class="control-group pull-left">
                             {% if GV_multiAndReport %}

--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -363,27 +363,27 @@
                                                     </label>
 
                                                     <div class="term_select">
-                                                        <div class="term_select_wrapper">
+                                                        <div class="term_select_wrapper_template" style="display: none;">
                                                             <select class="term_select_field" style="vertical-align:middle; width:30%;">
                                                                 <option value="">{{ 'Select a field' | trans }}</option>
                                                                 {% for field_id, field in search_datas['fields'] %}
-                                                                    {% if field['type'] != 'date' %}
-                                                                        <option class="dbx db_{{field['sbas']|join(' db_')}}" value="{{field_id}}">{{field['fieldname']}}</option>
-                                                                    {% endif %}
+                                                                    {# % if field['type'] != 'date' % #}
+                                                                        <option class="dbx db_{{field['sbas']|join(' db_')}}" data-fieldtype="{{ field['type'] }}-FIELD" value="field.{{field_id}}">{{field['fieldname']}}</option>
+                                                                    {# % endif % #}
                                                                 {% endfor %}
                                                             </select>
-                                                            <select disabled style="vertical-align:middle; width: 23%;">
-                                                                <option value="contains">{{ 'Contains' | trans }}</option>
-                                                                <option value="equals">{{ 'Equals' | trans }}</option>
+                                                            <select class="term_select_op" disabled style="vertical-align:middle; width: 23%;">
+                                                                <option value=":">{{ 'Contains' | trans }}</option>
+                                                                <option value="=">{{ 'Equals' | trans }}</option>
                                                             </select>
-                                                            <input disabled style="vertical-align:middle; width: 32%;" placeholder="{{ 'Ex : Paris, bleu, montagne' | trans }}">
+                                                            <input class="term_select_value" disabled style="vertical-align:middle; width: 32%;" placeholder="{{ 'Ex : Paris, bleu, montagne' | trans }}">
                                                             <input class="term_deleter" style="margin-bottom: 4px;">
                                                         </div>
 
                                                         <button class="add_new_term"><span>&plus;</span> Add</button>
                                                     </div>
 
-                                                    <div style="display:none;">
+                                                    <div style="">
                                                         <select class="term_select_multiple" size="8" multiple name="fields[]" style="vertical-align:middle; width:99%;">
                                                             <option value="phraseanet--all--fields">{{ 'rechercher dans tous les champs' | trans }}</option>
                                                             {% for field_id, field in search_datas['fields'] %}
@@ -393,6 +393,7 @@
                                                             {% endfor %}
                                                         </select>
                                                     </div>
+
                                                 </div>
 
                                                 <div id="ADVSRCH_DATE_ZONE">

--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -200,6 +200,12 @@
         <div class="PNB" id="rightFrame" style="left:auto; width:{{ w2 ~ '%' }}">
             <div id="headBlock" class="PNB">
                 <div class="searchFormWrapper">
+                    {% if app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page') == 'QUERY' %}
+                        <div id="FIRST_QUERY_CONTAINER" style="display: none" data-format="text">{{app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page_jsonquery') | raw}}</div>
+                    {% elseif app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page') == 'LAST_QUERY' %}
+                        <div id="FIRST_QUERY_CONTAINER" style="display: none" data-format="json">{{app['settings'].getUserSetting(app.getAuthenticatedUser(), 'last_jsonquery') | raw}}</div>
+                    {% endif %}
+
                     <form id="searchForm" method="POST" action="{{ path('prod_query') }}" name="phrasea_query" class="phrasea_query">
                         <input type="hidden" name="pag" id="formAnswerPage" value="">
                         <input type="hidden" name="sel" value="">
@@ -211,7 +217,6 @@
                                     <img src="/assets/common/images/icons/settings.png" title="{{ 'Advanced Search' | trans }}"/>
                                 </a>
                                 <button type="submit" class="btn btn-inverse" style="font-size:14px">{{ 'boutton::rechercher' | trans }}</button>
-                                <button type="button" id="TESTJS">TestJS</button>
                             </div>
                             <div class="control-group pull-left">
                             {% if GV_multiAndReport %}
@@ -507,11 +512,7 @@
                 <div id="answers" class=" PNB10">
                     <script>
                         $(document).ready(function(){
-                            {% if app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page') == 'QUERY' %}
-                                $('form[name="phrasea_query"]').addClass('triggerAfterInit');
-                            {% elseif app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page') == 'LAST_QUERY' %}
-                                $('form[name="phrasea_query"]').addClass('triggerAfterInit');
-                            {% elseif app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page') == 'PUBLI' %}
+                            {% if app['settings'].getUserSetting(app.getAuthenticatedUser(), 'start_page') == 'PUBLI' %}
                                 getHome('PUBLI');
                             {% endif %}
                         });

--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -382,18 +382,6 @@
 
                                                         <button class="add_new_term"><span>&plus;</span> Add</button>
                                                     </div>
-
-                                                    <div style="">
-                                                        <select class="term_select_multiple" size="8" multiple name="fields[]" style="vertical-align:middle; width:99%;">
-                                                            <option value="phraseanet--all--fields">{{ 'rechercher dans tous les champs' | trans }}</option>
-                                                            {% for field_id, field in search_datas['fields'] %}
-                                                                {% if field['type'] != 'date' %}
-                                                                    <option class="dbx db_{{field['sbas']|join(' db_')}}" value="{{field_id}}">{{field['fieldname']}}</option>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        </select>
-                                                    </div>
-
                                                 </div>
 
                                                 <div id="ADVSRCH_DATE_ZONE">


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2403: mixing blue/red facets generates the good query

### Adds
  - PHRAS-2381: if user setting is "last query", the whole last search (including adv search settings & facets) is played.
    advsearch ux change : when a db is un-selected, not available fields (in "fields" menu) are grayed (not hidden as before).

### todo
  - adv-search should contain at least on "field" zone.
  - "field" zones does not show "danger" indication.
