### PR TITLE
PHRAS-2427_advsearch-date-clear_4.0

### DIFF
--- a/resources/www/prod/js/jquery.main-prod.js
+++ b/resources/www/prod/js/jquery.main-prod.js
@@ -398,6 +398,7 @@ function reset_adv_search() {
                     "clauses":[ ]
                 },
                 {
+                    "_ux_zone":"DATE-FIELD",
                     "type":"DATE-FIELD",
                     "field":"",
                     "from":"",
@@ -1756,6 +1757,7 @@ $(document).ready(function () {
     });
 
     $('.add_new_term').on('click', function (event) {
+        event.preventDefault();
         AdvSearchAddNewTerm(1);
     });
 


### PR DESCRIPTION
## Changelog
### Fixes
  - PHRAS-2427: advsearch "date" zone is cleared ok
  - PHRAS-2427: advsearch "fields" zone, click "add" does not send the query anymore
