### PR TITLE
PHRAS-2446: Databases templates - 'flexpaper' to 'PDF' forChange setting of subdefs

### DIFF
--- a/lib/conf.d/data_templates/DublinCore.xml
+++ b/lib/conf.d/data_templates/DublinCore.xml
@@ -148,7 +148,7 @@
             </subdef>
             <subdef class="preview" name="preview" downloadable="false">
                 <path>{{datapathnoweb}}{{basename}}/subdefs</path>
-                <mediatype>flexpaper</mediatype>
+                <mediatype>pdf</mediatype>
                 <writeDatas>no</writeDatas>
                 <devices>screen</devices>
                 <label lang="fr">Prévisualisation</label>

--- a/lib/conf.d/data_templates/en-simple.xml
+++ b/lib/conf.d/data_templates/en-simple.xml
@@ -148,7 +148,7 @@
             </subdef>
             <subdef class="preview" name="preview" downloadable="false">
                 <path>{{datapathnoweb}}{{basename}}/subdefs</path>
-                <mediatype>flexpaper</mediatype>
+                <mediatype>pdf</mediatype>
                 <writeDatas>no</writeDatas>
                 <devices>screen</devices>
                 <label lang="fr">Prévisualisation</label>

--- a/lib/conf.d/data_templates/fr-simple.xml
+++ b/lib/conf.d/data_templates/fr-simple.xml
@@ -148,7 +148,7 @@
             </subdef>
             <subdef class="preview" name="preview" downloadable="false">
                 <path>{{datapathnoweb}}{{basename}}/subdefs</path>
-                <mediatype>flexpaper</mediatype>
+                <mediatype>pdf</mediatype>
                 <writeDatas>no</writeDatas>
                 <devices>screen</devices>
                 <label lang="fr">Prévisualisation</label>


### PR DESCRIPTION
## Changelog
### Changed
  - PHRAS-2446: use pdf instead flexpaper for document's preview
  - Change in database template

