### PR TITLE
PHRAS-2464_downgrade_Phraseanet-production-client_to_0_33_84

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "normalize-css": "^2.1.0",
     "npm": "^6.0.0",
     "npm-modernizr": "^2.8.3",
-    "phraseanet-production-client": "^0.33.0",
+    "phraseanet-production-client": "0.33.84",
     "requirejs": "^2.3.5",
     "tinymce": "^4.0.28",
     "underscore": "^1.8.3",


### PR DESCRIPTION

  
### Fixes
  - PHRAS-2464: last 4.1 version with search OK downgrade Phraseanet-production-client to 0.33.84




