### PR TITLE
PHRAS-2482_advsearch-date-fields_4.0

### DIFF
--- a/templates/web/prod/index.html.twig
+++ b/templates/web/prod/index.html.twig
@@ -373,7 +373,7 @@
                                                                 <option value="">{{ 'Select a field' | trans }}</option>
                                                                 {% for field_id, field in search_datas['fields'] %}
                                                                     {# % if field['type'] != 'date' % #}
-                                                                        <option class="dbx db_{{field['sbas']|join(' db_')}}" data-fieldtype="{{ field['type'] }}-FIELD" value="field.{{field_id}}">{{field['fieldname']}}</option>
+                                                                    <option class="dbx db_{{field['sbas']|join(' db_')}}" data-fieldtype="STRING-FIELD" value="field.{{field_id}}">{{field['fieldname']}}</option>
                                                                     {# % endif % #}
                                                                 {% endfor %}
                                                             </select>


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2482: into advsearch/fields-zone, the "type" of fields is now always "string" so the json build is ok
