### PR TITLE
PHRAS-2480:With SAML based authentication Order Managers are flushed when re-authenticate

### DIFF
--- a/lib/Alchemy/Phrasea/Collection/CollectionService.php
+++ b/lib/Alchemy/Phrasea/Collection/CollectionService.php
@@ -320,6 +320,7 @@ class CollectionService
 
             $result = $userQuery->on_base_ids([ $reference->getBaseId()] )
                 ->who_have_right([\ACL::ORDER_MASTER])
+                ->include_templates(true)
                 ->execute()->get_results();
 
             /** @var ACLProvider $acl */

--- a/lib/Alchemy/Phrasea/Controller/Admin/CollectionController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/CollectionController.php
@@ -50,6 +50,7 @@ class CollectionController extends Controller
             $query = $this->createUserQuery();
             $admins = $query->on_base_ids([$bas_id])
                 ->who_have_right([\ACL::ORDER_MASTER])
+                ->include_templates(true)
                 ->execute()
                 ->get_results();
         }

--- a/lib/Alchemy/Phrasea/Controller/Admin/UserController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/UserController.php
@@ -233,6 +233,7 @@ class UserController extends Controller
             ->who_have_right($have_right)
             ->who_have_not_right($have_not_right)
             ->on_base_ids($on_base)
+            ->include_templates(true)
             ->execute()
             ->get_results();
 


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2480: With SAML based authentication Order Managers are flushed when re-authenticate
  - Allow model as order manager


