### PR TITLE
PHRAS-2153 Administration : No user search possible with the field "Company" and field "Country"

### DIFF
--- a/templates/web/admin/users.html.twig
+++ b/templates/web/admin/users.html.twig
@@ -37,8 +37,8 @@
                 <select name="like_field" class="input-medium">
                     <option {% if parm['like_field'] == "login" %}selected="selected"{% endif %} value="login">{{ 'Push::filter on login' | trans }}</option>
                     <option {% if parm['like_field'] == "name" %}selected="selected"{% endif %} value="name">{{ 'First/Last Name' | trans }}</option>
-                    <option {% if parm['like_field'] == "pays" %}selected="selected"{% endif %} value="pays">{{ 'Push::filter on countries' | trans }}</option>
-                    <option {% if parm['like_field'] == "societe" %}selected="selected"{% endif %} value="societe">{{ 'Push::filter on companies' | trans }}</option>
+                    <option {% if parm['like_field'] == "country" %}selected="selected"{% endif %} value="country">{{ 'Push::filter on countries' | trans }}</option>
+                    <option {% if parm['like_field'] == "company" %}selected="selected"{% endif %} value="company">{{ 'Push::filter on companies' | trans }}</option>
                     <option {% if parm['like_field'] == "email" %}selected="selected"{% endif %} value="email">{{ 'Push::filter on emails' | trans }}</option>
                 </select>
                 <span>{{ 'Push::filter starts' | trans }}</span>


### PR DESCRIPTION

  
### Fixes
  - PHRAS-2153: Administration : No user search possible with the field "Company" and field "Country"
  - 1/ Go to Phraseanet Administration
   2/ Search for a user, using the "Company" field. Enter the first letters
   Nothing happens, the whole list is being displayed. Search on a company is impossible.




