### PR TITLE
adding phraseanet-docker hostnames to circleci hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
     # This is based on your 1.0 configuration file or project settings
+    - run: echo 127.0.0.1 redis elasticsearch db rabbitmq | sudo tee -a /etc/hosts
     - run: git clone https://github.com/alanxz/rabbitmq-c
     - run: cd rabbitmq-c && git checkout 2ca1774489328cde71195f5fa95e17cf3a80cb8a
     - run: cd rabbitmq-c && git submodule init && git submodule update && autoreconf -i && ./configure && make && sudo make install


### PR DESCRIPTION
### Adds
  - PHRAS-2532: adding phraseanet-docker hostnames to circleci machine hosts
  - adding redis elasticsearch db rabbitmq to /etc/hosts on circleci machine