### PR TITLE
PHRAS-2552 embed-bundle-edit-workflow for deployment

### DIFF
--- a/resources/gulp/components/vendors/alchemy-embed.js
+++ b/resources/gulp/components/vendors/alchemy-embed.js
@@ -11,12 +11,16 @@ gulp.task('copy-alchemy-embed-debug', function(){
 
 gulp.task('copy-alchemy-embed', function(){
     // copy all dist folder:
-    if( debugMode === true) {
-        return gulp.src('vendor/alchemy/embed-bundle/dist/**/*')
+    return gulp.src('vendor/alchemy/embed-bundle/dist/**/*')
+        .pipe(gulp.dest( config.paths.build + 'vendors/alchemy-embed-medias'));
+
+    
+   /* if( debugMode === true) {
+        return gulp.src('vendor/alchemy/embed-bundle/dist/!**!/!*')
             .pipe(gulp.dest( config.paths.build + 'vendors/alchemy-embed-medias'));
     }
-    return gulp.src(config.paths.nodes + 'alchemy-embed-medias/dist/**/*')
-        .pipe(gulp.dest( config.paths.build + 'vendors/alchemy-embed-medias'));
+    return gulp.src(config.paths.nodes + 'alchemy-embed-medias/dist/!**!/!*')
+        .pipe(gulp.dest( config.paths.build + 'vendors/alchemy-embed-medias'));*/
 });
 gulp.task('watch-alchemy-embed-js', function() {
     debugMode = true;


### PR DESCRIPTION


### Adds
  - PHRAS-2552: Deploy alchemy-embed-medias from vendor 
  Run   

> ./node_modules/.bin/gulp  build-alchemy-embed

### Removes
  - Don't use alchemy-embed-medias from npm-package

