### PR TITLE
fix broken term of use link

### DIFF
--- a/templates/web/login/common/macros.html.twig
+++ b/templates/web/login/common/macros.html.twig
@@ -39,7 +39,7 @@
 {% macro checkboxInput(field, label = '') %}
     <label for="{{ field.vars.id }}" class="checkbox">
         {{ form_widget(field) }}
-        {{ label | default(field.vars.label) | trans }}
+        {{ label | default(field.vars.label) }}
     </label>
     <div class="error-view"></div>
     {{  form_errors(field) }}


### PR DESCRIPTION
### Fixes
  - PHRAS-2567: Registration Form / Term of use link is broken
  - The term of use link is broken.