### PR TITLE
PHRAS-2574 update phraseanet-production-client version to 0.34.15-d

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "normalize-css": "^2.1.0",
     "npm": "^6.0.0",
     "npm-modernizr": "^2.8.3",
-    "phraseanet-production-client": "0.34.12-d",
+    "phraseanet-production-client": "^0.34.15-d",
     "requirejs": "^2.3.5",
     "tinymce": "^4.0.28",
     "underscore": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7560,10 +7560,10 @@ phraseanet-common@^0.4.1:
     js-cookie "^2.1.0"
     pym.js "^1.3.1"
 
-phraseanet-production-client@0.34.12-d:
-  version "0.34.12-d"
-  resolved "https://registry.yarnpkg.com/phraseanet-production-client/-/phraseanet-production-client-0.34.12-d.tgz#ed3ef9a5e261a61d24d9abad44fbca5ca37b38e6"
-  integrity sha512-23y7fpOa+zKCJU2bpyCrGs03GTHAnbUhIabmTZPnee2gff9gIS/gBiZ2tugsougT59uCQeQUVVDwjbqBsLvKOw==
+phraseanet-production-client@^0.34.15-d:
+  version "0.34.15-d"
+  resolved "https://registry.yarnpkg.com/phraseanet-production-client/-/phraseanet-production-client-0.34.15-d.tgz#58335ce4747e00b58d2b31f1e1f61c4e9c0ebfb0"
+  integrity sha512-BQHPj7tO285KawxZh+M7ki2aKKqFil+pHxSgdFXcpPmfHqV4vyew7h2QL4XL8E6fu18tKIxxpQ6k2EDrKeCO4w==
   dependencies:
     "@mapbox/mapbox-gl-language" "^0.9.2"
     "@turf/turf" "^5.1.6"


### PR DESCRIPTION


## Changelog
### Changed
  - Breaking change
  
### Fixes
  - PHRAS-2574: New search don't reset facets, use cross for remove it
  - PHRAS-2613: Don't auto start video when openning video tool




