### PR TITLE
PHRAS-2625 release version 4.0.9

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Phraseanet",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "dependencies": {
     "jquery": "~1.11.3",
     "jquery-ui": "~1.10.4",

--- a/lib/Alchemy/Phrasea/Core/Version.php
+++ b/lib/Alchemy/Phrasea/Core/Version.php
@@ -16,7 +16,7 @@ class Version
     /**
      * @var string
      */
-    private $number = '4.0.8';
+    private $number = '4.0.9';
 
     /**
      * @var string


### PR DESCRIPTION
## Changelog
### Changed
   

### Adds

- PHRAS-2535 - Back / Front - Unsubscription: It's now possible to request a validation by email to delete a Phraseanet user account.

- PHRAS-2480 - Back / Front - It's now possible to add a user model as order manager on a collection:All users with this model applied can manage orders on this collection. This features fixes an issue when users is provided by SAML and the orders manager is lost when user logs in.

- PHRAS-2474 - Back / front. - Searched terms are now found even if the searched terms are split in Business Field and regular Field.

- PHRAS-2462 - Front - Share media on LinkedIn as you can do on Facebook, Twitter.

- PHRAS-2417 - Front - Skin: grey and white, graphic enhancements.

- PHRAS-2067 - Front - Introducing thumbnail & preview generic images for Fonts

### Fixes
 - PHRAS-2491 - Front - Click on facets title (expand/collapse) launched a bad query, due to jquery error.

- PHRAS-2510 - Front - Facets values appear Truncated  after 15th character.

- PHRAS-2153 - Front - No user search possible with the field "Company" and field "Country".

- PHRAS-2154 - Front - Bug on Chrome only - selected 1 document instead of all for the feedback.

- PHRAS-2538 - Back - Some MP4 files were not correctly detected by Phraseanet.



