### PR TITLE
PHRAS-2652 : fix Fields "Phraseanet::no-source" are pushed to exiftool

### DIFF
--- a/lib/Alchemy/Phrasea/TaskManager/Job/WriteMetadataJob.php
+++ b/lib/Alchemy/Phrasea/TaskManager/Job/WriteMetadataJob.php
@@ -126,7 +126,7 @@ class WriteMetadataJob extends AbstractJob
                     $fieldName = $fieldStructure->get_name();
 
                     // skip fields with no src
-                    if($tagName == '') {
+                    if($tagName == '' || $tagName == 'Phraseanet:no-source') {
                         continue;
                     }
 
@@ -144,13 +144,13 @@ class WriteMetadataJob extends AbstractJob
                         if ($fieldStructure->is_multi()) {
                             $values = array();
                             foreach ($fieldValues as $value) {
-                                $values[] = $value->getValue();
+                                $values[] = $this->removeNulChar($value->getValue());
                             }
 
                             $value = new Value\Multi($values);
                         } else {
                             $fieldValue = array_pop($fieldValues);
-                            $value = $fieldValue->getValue();
+                            $value = $this->removeNulChar($fieldValue->getValue());
 
                             $value = new Value\Mono($value);
                         }
@@ -226,5 +226,10 @@ class WriteMetadataJob extends AbstractJob
         }
 
         return false;
+    }
+
+    private function removeNulChar($value)
+    {
+        return str_replace("\0", "", $value);
     }
 }


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2652: do not push Fields "Phraseanet::no-source" to exiftool



