### PR TITLE
PRHAS-2621   update embed-bundle and configuration.yml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "php": ">=5.5.9",
     "ext-intl": "*",
     "alchemy-fr/tcpdf-clone": "~6.0",
-    "alchemy/embed-bundle": "^2.0.5",
+    "alchemy/embed-bundle": "^2.0.6",
     "alchemy/geonames-api-consumer": "~0.1.0",
     "alchemy/mediavorus": "^0.4.4",
     "alchemy/oauth2php": "1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -131,16 +131,16 @@
         },
         {
             "name": "alchemy/embed-bundle",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/alchemy-fr/embed-bundle.git",
-                "reference": "99a701d1a201bbe79e7c6c20a0797c5e9182a001"
+                "reference": "53ba295dfd0554a31c35e93902a5ef6cb8eca31a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/alchemy-fr/embed-bundle/zipball/99a701d1a201bbe79e7c6c20a0797c5e9182a001",
-                "reference": "99a701d1a201bbe79e7c6c20a0797c5e9182a001",
+                "url": "https://api.github.com/repos/alchemy-fr/embed-bundle/zipball/53ba295dfd0554a31c35e93902a5ef6cb8eca31a",
+                "reference": "53ba295dfd0554a31c35e93902a5ef6cb8eca31a",
                 "shasum": ""
             },
             "require-dev": {
@@ -178,10 +178,10 @@
             ],
             "description": "Embed resources bundle",
             "support": {
-                "source": "https://github.com/alchemy-fr/embed-bundle/tree/2.0.5",
+                "source": "https://github.com/alchemy-fr/embed-bundle/tree/2.0.6",
                 "issues": "https://github.com/alchemy-fr/embed-bundle/issues"
             },
-            "time": "2019-06-20T13:32:05+00:00"
+            "time": "2019-07-11T12:59:49+00:00"
         },
         {
             "name": "alchemy/geonames-api-consumer",
@@ -7789,12 +7789,12 @@
             "version": "v1.6.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
                 "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
                 "shasum": ""
             },

--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -231,17 +231,19 @@ embed_bundle:
     video:
         player: videojs
         autoplay: false
-        coverSubdef: previewx4
-        available-speeds:
+        cover_subdef: thumbnail
+        message_start: StartOfMessage
+        available_speeds:
             - 1
             - 1.5
             - 3
     audio:
         player: videojs
         autoplay: false
+        cover_subdef: thumbnail
     document:
         player: flexpaper
-        enable-pdfjs: true
+        enable_pdfjs: true
 geocoding-providers:
     -
         map-provider: mapboxWebGL

--- a/lib/conf.d/configuration.yml
+++ b/lib/conf.d/configuration.yml
@@ -44,7 +44,7 @@ main:
             doctype_aggregate_limit: 0
             camera_model_aggregate_limit: 0
             iso_aggregate_limit: 0
-            aperture_aggregate_limit: 0   
+            aperture_aggregate_limit: 0
             shutterspeed_aggregate_limit: 0
             flashfired_aggregate_limit: 0
             framerate_aggregate_limit: 0
@@ -234,6 +234,7 @@ embed_bundle:
     audio:
         player: videojs
         autoplay: false
+        cover_subdef: thumbnail
     document:
         #player: flexpaper
         enable_pdfjs: true
@@ -297,6 +298,6 @@ rabbitmq:
         user: ''
         password: ''
         vhost: /
-        
+
 Console_logger_enabled_environments: [test]
 


### PR DESCRIPTION

  ## Changelog
### Changed
  - embed-bundle@2.0.6
  
### Fixes
  - PHRAS-2623 add videojs subtitle icons

### Adds
  - PHRAS-2621: Define a cover subdef for audio kind (file)