### PR TITLE
PHRAS-1428 : Phraseanet Binaries in configuration not used in some alchemy-fr libraries

### DIFF
--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -241,9 +241,10 @@ class Application extends SilexApplication
                     'pdftotext.binaries' => isset($binariesConfig['pdftotext_binary']) ? $binariesConfig['pdftotext_binary'] : $executableFinder->find('pdftotext'),
                 ]
             ]);
+
+            $this->setupXpdf();
         }
 
-        $this->setupXpdf();
         $this->register(new FileServeServiceProvider());
         $this->register(new ManipulatorServiceProvider());
         $this->register(new PluginServiceProvider());

--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -109,6 +109,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Process\ExecutableFinder;
 use Unoconv\UnoconvServiceProvider;
 use XPDF\PdfToText;
 use XPDF\XPDFServiceProvider;
@@ -231,7 +232,15 @@ class Application extends SilexApplication
 
         $this->register(new UnicodeServiceProvider());
         $this->register(new ValidatorServiceProvider());
-        $this->register(new XPDFServiceProvider());
+
+        $binariesConfig = $this['conf']->get(['main', 'binaries']);
+        $executableFinder = new ExecutableFinder();
+        $this->register(new XPDFServiceProvider(), [
+            'xpdf.configuration' => [
+                'pdftotext.binaries' => isset($binariesConfig['pdftotext_binary']) ? $binariesConfig['pdftotext_binary'] : $executableFinder->find('pdftotext'),
+            ]
+        ]);
+
         $this->setupXpdf();
         $this->register(new FileServeServiceProvider());
         $this->register(new ManipulatorServiceProvider());

--- a/lib/Alchemy/Phrasea/Application.php
+++ b/lib/Alchemy/Phrasea/Application.php
@@ -233,13 +233,15 @@ class Application extends SilexApplication
         $this->register(new UnicodeServiceProvider());
         $this->register(new ValidatorServiceProvider());
 
-        $binariesConfig = $this['conf']->get(['main', 'binaries']);
-        $executableFinder = new ExecutableFinder();
-        $this->register(new XPDFServiceProvider(), [
-            'xpdf.configuration' => [
-                'pdftotext.binaries' => isset($binariesConfig['pdftotext_binary']) ? $binariesConfig['pdftotext_binary'] : $executableFinder->find('pdftotext'),
-            ]
-        ]);
+        if ($this['configuration.store']->isSetup()) {
+            $binariesConfig = $this['conf']->get(['main', 'binaries']);
+            $executableFinder = new ExecutableFinder();
+            $this->register(new XPDFServiceProvider(), [
+                'xpdf.configuration' => [
+                    'pdftotext.binaries' => isset($binariesConfig['pdftotext_binary']) ? $binariesConfig['pdftotext_binary'] : $executableFinder->find('pdftotext'),
+                ]
+            ]);
+        }
 
         $this->setupXpdf();
         $this->register(new FileServeServiceProvider());


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-1428: Phraseanet Binaries in configuration not used in some alchemy-fr libraries
  - use  pdftotext_binary binary setting from the configuration.yml


