### PR TITLE
PHRAS-2714 : API leaves a copy of the file into the system temporary directory 4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -903,7 +903,7 @@ class V1Controller extends Controller
                 }
 
                 $originalName = $pi['filename'] . '.' . $pi['extension'];
-                $newPathname = $tempfile;
+                $uploadedFilename = $newPathname = $tempfile;
             }
         }
         else {
@@ -915,9 +915,12 @@ class V1Controller extends Controller
             if (!$file->isValid()) {
                 return $this->getBadRequestAction($request, 'Data corrupted, please try again');
             }
+
+            $uploadedFilename = $file->getPathname();
             $originalName = $file->getClientOriginalName();
             $newPathname = $file->getPathname() . '.' . $file->getClientOriginalExtension();
-            if (false === rename($file->getPathname(), $newPathname)) {
+
+            if (false === rename($uploadedFilename, $newPathname)) {
                 return Result::createError($request, 403, 'Error while renaming file')->createResponse();
             }
         }
@@ -969,6 +972,11 @@ class V1Controller extends Controller
         $nosubdef = $request->get('nosubdefs') === '' || \p4field::isyes($request->get('nosubdefs'));
         $this->getBorderManager()->process($session, $Package, $callback, $behavior, $nosubdef);
 
+        // remove $newPathname on temporary directory
+        if ($newPathname !== $uploadedFilename) {
+            @rename($newPathname, $uploadedFilename);
+        }
+
         $ret = ['entity' => null];
 
         if ($output instanceof \record_adapter) {
@@ -1009,8 +1017,9 @@ class V1Controller extends Controller
             return $this->getBadRequestAction($request, 'Missing name parameter');
         }
 
+        $uploadedFilename = $file->getPathname();
         $newPathname = $file->getPathname().'.'.$file->getClientOriginalExtension();
-        if (false === rename($file->getPathname(), $newPathname)) {
+        if (false === rename($uploadedFilename, $newPathname)) {
             $this->getBadRequestAction($request, 'Error while renaming file');
         }
 
@@ -1036,6 +1045,11 @@ class V1Controller extends Controller
                 null !== ($subdef = $this->listEmbeddableMedia($request, $record, $media))) {
                 $ret[] = $subdef;
             }
+        }
+
+        // remove $newPathname on temporary directory
+        if ($newPathname !== $uploadedFilename) {
+            @rename($newPathname, $uploadedFilename);
         }
 
         return Result::create($request, $ret)->createResponse();


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2714: API leaves a copy of the file into the system temporary directory
  - concerned route : /api/v1/embed/substitute/  and   /api/v1/records/add/

 

