### PR TITLE
Phras 2729 datetime warnings 4.0

### DIFF
--- a/lib/Alchemy/Phrasea/Metadata/PhraseanetMetadataSetter.php
+++ b/lib/Alchemy/Phrasea/Metadata/PhraseanetMetadataSetter.php
@@ -16,6 +16,7 @@ use Alchemy\Phrasea\Databox\DataboxRepository;
 use Alchemy\Phrasea\Metadata\Tag\NoSource;
 use DateTime;
 use PHPExiftool\Driver\Metadata\Metadata;
+use Alchemy\Phrasea\SearchEngine\Elastic\RecordHelper;
 
 class PhraseanetMetadataSetter
 {
@@ -67,10 +68,13 @@ class PhraseanetMetadataSetter
                     continue;
                 }
 
-                if ($field->get_type() == 'date') {
+                if ($field->get_type() === $field::TYPE_DATE) {
                     try {
-                        $dateTime = new DateTime($value);
-                        $value = $dateTime->format('Y/m/d H:i:s');
+                        $clean_value = RecordHelper::sanitizeDate($value);
+                        if( $clean_value !== null) {
+                            $dateTime = new DateTime($clean_value);
+                            $value = $dateTime->format('Y-m-d H:i:s');
+                        }
                     } catch (\Exception $e) {
                         // $value unchanged
                     }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
@@ -98,7 +98,11 @@ class RecordHelper
     {
         $v_fix = null;
         try {
-            $a = explode(';', preg_replace('/\D+/', ';', trim($value)));
+            $a = [];
+            array_map(
+                function ($v) { if(is_numeric($v)) { $a[]=$v; }; },
+                explode(';', preg_replace('/\D+/', ';', trim($value)))
+            );
             switch (count($a)) {
                 case 1:     // yyyy
                     $date = new \DateTime($a[0] . '-01-01');    // will throw if date is not valid

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
@@ -105,27 +105,27 @@ class RecordHelper
             );
             switch (count($a)) {
                 case 1:     // yyyy
-                    $date = new \DateTime($a[0] . '-01-01');    // will throw if date is not valid
+                    $date = @new \DateTime($a[0] . '-01-01');    // will throw if date is not valid
                     $v_fix = $date->format('Y');
                     break;
                 case 2:     // yyyy;mm
-                    $date = new \DateTime( $a[0] . '-' . $a[1] . '-01');
+                    $date = @new \DateTime( $a[0] . '-' . $a[1] . '-01');
                     $v_fix = $date->format('Y-m');
                     break;
                 case 3:     // yyyy;mm;dd
-                    $date = new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2]);
+                    $date = @new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2]);
                     $v_fix = $date->format('Y-m-d');
                     break;
                 case 4:
-                    $date = new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2] . ' ' . $a[3] . ':00:00');
+                    $date = @new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2] . ' ' . $a[3] . ':00:00');
                     $v_fix = $date->format('Y-m-d H:i:s');
                     break;
                 case 5:
-                    $date = new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2] . ' ' . $a[3] . ':' . $a[4] . ':00');
+                    $date = @new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2] . ' ' . $a[3] . ':' . $a[4] . ':00');
                     $v_fix = $date->format('Y-m-d H:i:s');
                     break;
                 case 6:
-                    $date = new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2] . ' ' . $a[3] . ':' . $a[4] . ':' . $a[5]);
+                    $date = @new \DateTime($a[0] . '-' . $a[1] . '-' . $a[2] . ' ' . $a[3] . ':' . $a[4] . ':' . $a[5]);
                     $v_fix = $date->format('Y-m-d H:i:s');
                     break;
             }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
@@ -100,7 +100,7 @@ class RecordHelper
         try {
             $a = [];
             array_map(
-                function ($v) { if(is_numeric($v)) { $a[]=$v; }; },
+                function ($v) use (&$a) { if(is_numeric($v)) { $a[] = $v; }; },
                 explode(';', preg_replace('/\D+/', ';', trim($value)))
             );
             switch (count($a)) {

--- a/tests/Alchemy/Tests/Phrasea/Border/ManagerTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Border/ManagerTest.php
@@ -173,7 +173,12 @@ class ManagerTest extends \PhraseanetAuthenticatedWebTestCase
                 $file->addAttribute(new Metadata(new \PHPExiftool\Driver\Metadata\Metadata($databox_field->get_tag(), $value)));
             } else {
 
-                $data = ['Hello Mono ' . $databox_field->get_tag()->getTagname()];
+                if($databox_field->get_type() === $databox_field::TYPE_DATE) {
+                    $data = [ '2001-02-03 04:05:06'];
+                }
+                else {
+                    $data = ['Hello Mono ' . $databox_field->get_tag()->getTagname()];
+                }
 
                 if (!$first) {
                     if ($odd) {
@@ -291,7 +296,12 @@ class ManagerTest extends \PhraseanetAuthenticatedWebTestCase
                 $file->addAttribute(new Metadata(new \PHPExiftool\Driver\Metadata\Metadata($databox_field->get_tag(), $value)));
             } else {
 
-                $data = ['Hello Mono ' . $databox_field->get_tag()->getTagname()];
+                if($databox_field->get_type() === $databox_field::TYPE_DATE) {
+                    $data = [ '2001-02-03 04:05:06'];
+                }
+                else {
+                    $data = ['Hello Mono ' . $databox_field->get_tag()->getTagname()];
+                }
 
                 if ($odd) {
                     $value = new \PHPExiftool\Driver\Value\Mono(current($data));

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/RecordHelperTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/RecordHelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Alchemy\Tests\Phrasea\SearchEngine;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\RecordHelper;
+
+/**
+ * @group unit
+ * @group searchengine
+ */
+class RecordHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider datesProvider
+     */
+    public function testSanitizeDate($in, $out)
+    {
+        $this->assertEquals($out, RecordHelper::sanitizeDate($in));
+    }
+
+    public function datesProvider()
+    {
+        return [
+            ['', null],
+            ['foo', null],
+            ['55', '2055'],
+            ['95', '1995'],
+            ['2001/02','2001-02'],
+            ['2001/02/03','2001-02-03'],
+            ['2001/2/3','2001-02-03'],
+            ['2001/2/3 4','2001-02-03 04:00:00'],
+            ['2001/2/3 4.5','2001-02-03 04:05:00'],
+            ['2001/2/3 4.5-6','2001-02-03 04:05:06'],
+            ['2001/2/3 4.5-6-7', null],
+            ['film de 10 minutes','2010']
+        ];
+    }
+}


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-2729: a date value like "Film de Jan De BONT (1997)" was exploded as ["","1997",""], now non-numeric parts are excluded