### PR TITLE
PHRAS-2751_geoloc-search-403err_master

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/GeolocationKey.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/KeyValue/GeolocationKey.php
@@ -58,6 +58,11 @@ class GeolocationKey implements Key
         $this->key = $key;
     }
 
+    public function getFieldType(QueryContext $context)
+    {
+        return $this->type;
+    }
+
     public function getIndexField(QueryContext $context, $raw = false)
     {
         return $this->key;


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2751: geoloc search should work again (missed method during PHRAS-2707)
