### PR TITLE
PHRAS-2813 : 4.0 redis function delete is deprecated

### DIFF
--- a/lib/Alchemy/Phrasea/Cache/RedisCache.php
+++ b/lib/Alchemy/Phrasea/Cache/RedisCache.php
@@ -73,7 +73,7 @@ class RedisCache extends CacheProvider implements Cache
      */
     protected function doDelete($id)
     {
-        return $this->_redis->delete($id);
+        return $this->_redis->del($id);
     }
 
     /**

--- a/lib/Alchemy/Phrasea/Utilities/RedisSessionHandler.php
+++ b/lib/Alchemy/Phrasea/Utilities/RedisSessionHandler.php
@@ -80,7 +80,7 @@ class RedisSessionHandler implements \SessionHandlerInterface
      */
     public function destroy($sessionId)
     {
-        return 1 === $this->redis->delete($this->prefix.$sessionId);
+        return 1 === $this->redis->del($this->prefix.$sessionId);
     }
 
     /**


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2813: 4.0 redis function delete is deprecated


