### PR TITLE
PHRAS-2834: When create a database from model, all fields have properties gui_editable gui_visible set to false

### DIFF
--- a/lib/classes/databox.php
+++ b/lib/classes/databox.php
@@ -463,8 +463,8 @@ class databox extends base implements ThumbnailedElement
                 ->set_type($type)
                 ->set_tbranch(isset($field['tbranch']) ? (string) $field['tbranch'] : '')
                 ->set_generate_cterms((isset($field['generate_cterms']) && (string) $field['generate_cterms'] == 1))
-                ->set_gui_editable((isset($field['gui_editable']) && (string) $field['gui_editable'] == 1))
-                ->set_gui_visible((isset($field['gui_editable']) && (string) $field['gui_visible'] == 1))
+                ->set_gui_editable((!isset($field['gui_editable']) || (isset($field['gui_editable']) && (string) $field['gui_editable'] == 1)))
+                ->set_gui_visible((!isset($field['gui_visible']) || (isset($field['gui_visible']) && (string) $field['gui_visible'] == 1)))
                 ->set_thumbtitle(isset($field['thumbtitle']) ? (string) $field['thumbtitle'] : (isset($field['thumbTitle']) ? $field['thumbTitle'] : '0'))
                 ->set_report(isset($field['report']) ? (string) $field['report'] : '1')
                 ->save();


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2834: When create a database from model, all fields have properties gui_editable gui_visible set to false
  - gui_editable and gui_visible  default to true if not set



