### PR TITLE
PHRAS-2814_missing-es-options-for-tests

### DIFF
--- a/tests/Alchemy/Tests/Phrasea/Command/Setup/InstallTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Command/Setup/InstallTest.php
@@ -78,9 +78,12 @@ class InstallTest extends \PhraseanetTestCase
                     case 'db-password':
                         return $infoDb['database']['password'];
                         break;
-                    case 'yes':
-                        return true;
-                        break;
+                    case 'es-host':
+                        return 'localhost';
+                    case 'es-port':
+                        return 9200;
+                    case 'es-index':
+                        return 'phrasea_test';
                     default:
                         return '';
                 }

--- a/tests/bootstrap.sh
+++ b/tests/bootstrap.sh
@@ -34,7 +34,7 @@ then
     mv config/configuration.yml{,.backup}
     rm -f config/configuration-compiled.php
 fi
-./bin/setup system:install --email=test@phraseanet.com --password=test --db-user=root --db-template=en-simple --db-password=toor --databox=db_test --appbox=ab_test --server-name=http://127.0.0.1 -y $VERBOSITY
+./bin/setup system:install --email=test@phraseanet.com --password=test --db-user=root --db-template=en-simple --db-password=toor --databox=db_test --appbox=ab_test --server-name=http://127.0.0.1 --es-host=localhost --es-port=9200 --es-index=phrasea_test -y $VERBOSITY
 case "$INSTALL_MODE" in
     update)
         ./bin/developer ini:reset --email=test@phraseanet.com --password=test --run-patches --no-setup-dbs $VERBOSITY


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-2814: to complete https://github.com/alchemy-fr/Phraseanet/pull/3222/commits : add options to bootstrap for tests
