### PR TITLE
PHRAS-2877 User manipulator does not allow to set a null email

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Manipulator/UserManipulator.php
+++ b/lib/Alchemy/Phrasea/Model/Manipulator/UserManipulator.php
@@ -337,7 +337,7 @@ class UserManipulator implements ManipulatorInterface
             throw new InvalidArgumentException(sprintf('Email %s is not legal.', $email));
         }
 
-        if (null !== $this->repository->findByEmail($email)) {
+        if (($email !== null) && (null !== $this->repository->findByEmail($email))) {
             throw new RuntimeException(sprintf('User with email %s already exists.', $email));
         }
 


### PR DESCRIPTION
# Fixes
  - PHRAS-2877: User manipulator does not allow to set a null email
  - User manipulator does not allow to set a null email