### PR TITLE
PHRAS-2879-Define-facets-order-in-query-result

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -28,7 +28,8 @@ main:
             port: 11211
     search-engine:
         type: phrasea
-        options: []
+        options:
+            facets: []
     task-manager:
         status: started
         enabled: true

--- a/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
@@ -17,6 +17,7 @@ use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use databox_descriptionStructure;
 
 class SearchEngineController extends Controller
 {
@@ -77,6 +78,16 @@ class SearchEngineController extends Controller
      */
     private function saveElasticSearchOptions(ElasticsearchOptions $configuration)
     {
+        // save to databoxes fields for backward compatibility (useless ?)
+        foreach($configuration->getAggregableFields() as $fname=>$aggregableField) {
+            foreach ($this->app->getDataboxes() as $databox) {
+                if(!is_null($f = $databox->get_meta_structure()->get_element_by_name($fname, databox_descriptionStructure::STRICT_COMPARE))) {
+                    $f->set_aggregable($aggregableField['limit'])->save();
+                }
+            }
+        }
+
+        // save to conf
         $this->getConf()->set(['main', 'search-engine', 'options'], $configuration->toArray());
     }
 

--- a/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
@@ -33,7 +33,19 @@ class SearchEngineController extends Controller
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $this->saveElasticSearchOptions($form->getData());
+            /** @var ElasticsearchOptions $data */
+            $data = $form->getData();
+            // $q = $request->request->get('elasticsearch_settings');
+            $facetNames = [];   // rebuild the data "_customValues/facets" list following the form order
+            foreach($request->request->get('elasticsearch_settings') as $name=>$value) {
+                $matches = null;
+                if(preg_match('/^facets:(.+):limit$/', $name, $matches) === 1) {
+                    $facetNames[] = $matches[1];
+                }
+            }
+            $data->reorderAggregableFields($facetNames);
+
+            $this->saveElasticSearchOptions($data);
 
             return $this->app->redirectPath('admin_searchengine_form');
         }

--- a/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
+++ b/lib/Alchemy/Phrasea/Controller/Admin/SearchEngineController.php
@@ -13,6 +13,7 @@ namespace Alchemy\Phrasea\Controller\Admin;
 use Alchemy\Phrasea\Controller\Controller;
 use Alchemy\Phrasea\SearchEngine\Elastic\ElasticsearchSettingsFormType;
 use Alchemy\Phrasea\SearchEngine\Elastic\ElasticsearchOptions;
+use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -85,7 +86,10 @@ class SearchEngineController extends Controller
      */
     private function getConfigurationForm(ElasticsearchOptions $options)
     {
-        return $this->app->form(new ElasticsearchSettingsFormType(), $options, [
+        /** @var GlobalStructure $g */
+        $g = $this->app['search_engine.structure'];
+
+        return $this->app->form(new ElasticsearchSettingsFormType($g, $options), $options, [
             'action' => $this->app->url('admin_searchengine_form'),
         ]);
     }

--- a/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
@@ -360,7 +360,6 @@ class QueryController extends Controller
             // add technical fields
             $fieldsInfosByName = [];
             foreach(ElasticsearchOptions::getAggregableTechnicalFields() as $k => $f) {
-                $k = '_'.$k;
                 $fieldsInfosByName[$k] = $f;
                 $fieldsInfosByName[$k]['trans_label'] = $this->app->trans($f['label']);
                 $fieldsInfosByName[$k]['labels'] = [];

--- a/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/QueryController.php
@@ -360,6 +360,7 @@ class QueryController extends Controller
             // add technical fields
             $fieldsInfosByName = [];
             foreach(ElasticsearchOptions::getAggregableTechnicalFields() as $k => $f) {
+                $k = '_'.$k;
                 $fieldsInfosByName[$k] = $f;
                 $fieldsInfosByName[$k]['trans_label'] = $this->app->trans($f['label']);
                 $fieldsInfosByName[$k]['labels'] = [];
@@ -433,24 +434,15 @@ class QueryController extends Controller
 
             // populates facets (aggregates)
             $facets = [];
-            // $facetClauses = [];
             foreach ($result->getFacets() as $facet) {
                 $facetName = $facet['name'];
 
                 if(array_key_exists($facetName, $fieldsInfosByName)) {
-
                     $f = $fieldsInfosByName[$facetName];
-
                     $facet['label'] = $f['trans_label'];
                     $facet['labels'] = $f['labels'];
                     $facet['type'] = strtoupper($f['type']) . "-AGGREGATE";
                     $facets[] = $facet;
-
-                    // $facetClauses[] = [
-                    //    'type'  => strtoupper($f['type']) . "-AGGREGATE",
-                    //    'field' => $f['field'],
-                    //    'facet' => $facet
-                    // ];
                 }
             }
 

--- a/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
@@ -228,7 +228,8 @@ class SearchEngineServiceProvider implements ServiceProviderInterface
         });
 
         $app['elasticsearch.options'] = $app->share(function ($app) {
-            $options = ElasticsearchOptions::fromArray($app['conf']->get(['main', 'search-engine', 'options'], []));
+            $conf = $app['conf']->get(['main', 'search-engine', 'options'], []);
+            $options = ElasticsearchOptions::fromArray($conf);
 
             if (empty($options->getIndexName())) {
                 $options->setIndexName(strtolower(sprintf('phraseanet_%s', str_replace(

--- a/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
@@ -97,7 +97,7 @@ class SearchEngineServiceProvider implements ServiceProviderInterface
         });
 
         $app['elasticsearch.facets_response.factory'] = $app->protect(function (array $response) use ($app) {
-            return new FacetsResponse(new Escaper(), $response, $app['search_engine.structure']);
+            return new FacetsResponse($app['elasticsearch.options'], new Escaper(), $response, $app['search_engine.structure']);
         });
 
         return $app;

--- a/lib/Alchemy/Phrasea/Core/Version.php
+++ b/lib/Alchemy/Phrasea/Core/Version.php
@@ -16,7 +16,7 @@ class Version
     /**
      * @var string
      */
-    private $number = '4.1.0-alpha.20a';
+    private $number = '4.1.0-alpha.21a';
 
     /**
      * @var string

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -652,7 +652,7 @@ class ElasticSearchEngine implements SearchEngineInterface
         $aggs = [];
         // technical aggregates (enable + optional limit)
         foreach (ElasticsearchOptions::getAggregableTechnicalFields() as $k => $f) {
-            $size = $this->options->getAggregableFieldLimit('_'.$k);
+            $size = $this->options->getAggregableFieldLimit($k);
             if ($size !== databox_field::FACET_DISABLED) {
                 if ($size === databox_field::FACET_NO_LIMIT) {
                     $size = ESField::FACET_NO_LIMIT;
@@ -663,7 +663,7 @@ class ElasticSearchEngine implements SearchEngineInterface
                         'size'  => $size
                     ]
                 ];
-                $aggs['_'.$k] = $agg;
+                $aggs[$k] = $agg;
             }
         }
         // fields aggregates

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -652,7 +652,7 @@ class ElasticSearchEngine implements SearchEngineInterface
         $aggs = [];
         // technical aggregates (enable + optional limit)
         foreach (ElasticsearchOptions::getAggregableTechnicalFields() as $k => $f) {
-            $size = $this->options->getAggregableFieldLimit($k);
+            $size = $this->options->getAggregableFieldLimit('_'.$k);
             if ($size !== databox_field::FACET_DISABLED) {
                 if ($size === databox_field::FACET_NO_LIMIT) {
                     $size = ESField::FACET_NO_LIMIT;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -663,22 +663,25 @@ class ElasticSearchEngine implements SearchEngineInterface
                         'size'  => $size
                     ]
                 ];
-                $aggs[$k] = $agg;
+                $aggs['_'.$k] = $agg;
             }
         }
         // fields aggregates
         $structure = $this->context_factory->getLimitedStructure($options);
-        foreach ($structure->getFacetFields() as $name => $field) {
-            // 2015-05-26 (mdarse) Removed databox filtering.
-            // It was already done by the ACL filter in the query scope, so no
-            // document that shouldn't be displayed can go this far.
-            $agg = [
-                'terms' => [
-                    'field' => $field->getIndexField(true),
-                    'size'  => $field->getFacetValuesLimit()
-                ]
-            ];
-            $aggs[$name] = AggregationHelper::wrapPrivateFieldAggregation($field, $agg);
+        foreach($structure->getAllFields() as $name => $field) {
+            $size = $this->options->getAggregableFieldLimit($name);
+            if ($size !== databox_field::FACET_DISABLED) {
+                if ($size === databox_field::FACET_NO_LIMIT) {
+                    $size = ESField::FACET_NO_LIMIT;
+                }
+                $agg = [
+                    'terms' => [
+                        'field' => $field->getIndexField(true),
+                        'size'  => $size
+                    ]
+                ];
+                $aggs[$name] = AggregationHelper::wrapPrivateFieldAggregation($field, $agg);
+            }
         }
 
         return $aggs;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -9,6 +9,7 @@
  */
 namespace Alchemy\Phrasea\SearchEngine\Elastic;
 
+use databox_field;
 use igorw;
 
 
@@ -219,10 +220,24 @@ class ElasticsearchOptions
         $this->highlight = $highlight;
     }
 
+    public function setAggregableFieldLimit($key, $value)
+    {
+        if(is_null($this->getAggregableField($key))) {
+            $this->_customValues['facets'][$key] = [];
+        }
+        $this->_customValues['facets'][$key]['limit'] = $value;
+    }
+
     public function setAggregableField($key, $attributes)
     {
-        $facets = $this->getAggregableFields();
-        $facets[$key] = $attributes;
+        $this->getAggregableFields();    // ensure facets exists
+        $this->_customValues['facets'][$key] = $attributes;
+    }
+
+    public function getAggregableFieldLimit($key)
+    {
+        $facet = $this->getAggregableField($key);
+        return (is_array($facet) && array_key_exists('limit', $facet)) ? $facet['limit'] : databox_field::FACET_DISABLED;
     }
 
     public function getAggregableField($key)
@@ -231,7 +246,10 @@ class ElasticsearchOptions
         return array_key_exists($key, $facets) ? $facets[$key] : null;
     }
 
-    public function &getAggregableFields()
+    /**
+     * @return array
+     */
+    public function getAggregableFields()
     {
         if(!array_key_exists('facets', $this->_customValues) || !is_array($this->_customValues['facets'])) {
             $this->_customValues['facets'] = [];

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -38,7 +38,7 @@ class ElasticsearchOptions
     private $populateDirection;
 
     /** @var  int[] */
-    private $_customValues;
+    private $_customValues = [];
     private $activeTab;
 
     /**

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -282,42 +282,42 @@ class ElasticsearchOptions
     public static function getAggregableTechnicalFields()
     {
         return [
-            'base' => [
+            '_base' => [
                 'type'    => 'string',
                 'label'   => 'prod::facet:base_label',
                 'field'   => "database",
                 'esfield' => 'databox_name',
                 'query'   => 'database:%s',
             ],
-            'collection' => [
+            '_collection' => [
                 'type'    => 'string',
                 'label'   => 'prod::facet:collection_label',
                 'field'   => "collection",
                 'esfield' => 'collection_name',
                 'query'   => 'collection:%s',
             ],
-            'doctype' => [
+            '_doctype' => [
                 'type'    => 'string',
                 'label'   => 'prod::facet:doctype_label',
                 'field'   => "type",
                 'esfield' => 'type',
                 'query'   => 'type:%s',
             ],
-            'camera_model' => [
+            '_camera_model' => [
                 'type'    => 'string',
                 'label'   => 'Camera Model',
                 'field'   => "meta.CameraModel",
                 'esfield' => 'metadata_tags.CameraModel',
                 'query'   => 'meta.CameraModel:%s',
             ],
-            'iso' => [
+            '_iso' => [
                 'type'    => 'number',
                 'label'   => 'ISO',
                 'field'   => "meta.ISO",
                 'esfield' => 'metadata_tags.ISO',
                 'query'   => 'meta.ISO=%s',
             ],
-            'aperture' => [
+            '_aperture' => [
                 'type'    => 'number',
                 'label'   => 'Aperture',
                 'field'   => "meta.Aperture",
@@ -327,7 +327,7 @@ class ElasticsearchOptions
                     return round($value, 1);
                 },
             ],
-            'shutterspeed' => [
+            '_shutterspeed' => [
                 'type'    => 'number',
                 'label'   => 'Shutter speed',
                 'field'   => "meta.ShutterSpeed",
@@ -340,7 +340,7 @@ class ElasticsearchOptions
                     return $value . ' s.';
                 },
             ],
-            'flashfired' => [
+            '_flashfired' => [
                 'type'    => 'boolean',
                 'label'   => 'FlashFired',
                 'field'   => "meta.FlashFired",
@@ -354,49 +354,49 @@ class ElasticsearchOptions
                     return array_key_exists($value, $map) ? $map[$value] : $value;
                 },
             ],
-            'framerate' => [
+            '_framerate' => [
                 'type'    => 'number',
                 'label'   => 'FrameRate',
                 'field'   => "meta.FrameRate",
                 'esfield' => 'metadata_tags.FrameRate',
                 'query'   => 'meta.FrameRate=%s',
             ],
-            'audiosamplerate' => [
+            '_audiosamplerate' => [
                 'type'    => 'number',
                 'label'   => 'Audio Samplerate',
                 'field'   => "meta.AudioSamplerate",
                 'esfield' => 'metadata_tags.AudioSamplerate',
                 'query'   => 'meta.AudioSamplerate=%s',
             ],
-            'videocodec' => [
+            '_videocodec' => [
                 'type'    => 'string',
                 'label'   => 'Video codec',
                 'field'   => "meta.VideoCodec",
                 'esfield' => 'metadata_tags.VideoCodec',
                 'query'   => 'meta.VideoCodec:%s',
             ],
-            'audiocodec' => [
+            '_audiocodec' => [
                 'type'    => 'string',
                 'label'   => 'Audio codec',
                 'field'   => "meta.AudioCodec",
                 'esfield' => 'metadata_tags.AudioCodec',
                 'query'   => 'meta.AudioCodec:%s',
             ],
-            'orientation' => [
+            '_orientation' => [
                 'type'    => 'string',
                 'label'   => 'Orientation',
                 'field'   => "meta.Orientation",
                 'esfield' => 'metadata_tags.Orientation',
                 'query'   => 'meta.Orientation=%s',
             ],
-            'colorspace' => [
+            '_colorspace' => [
                 'type'    => 'string',
                 'label'   => 'Colorspace',
                 'field'   => "meta.ColorSpace",
                 'esfield' => 'metadata_tags.ColorSpace',
                 'query'   => 'meta.ColorSpace:%s',
             ],
-            'mimetype' => [
+            '_mimetype' => [
                 'type'    => 'string',
                 'label'   => 'MimeType',
                 'field'   => "meta.MimeType",

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -60,6 +60,7 @@ class ElasticsearchOptions
             'populate_order'     => self::POPULATE_ORDER_RID,
             'populate_direction' => self::POPULATE_DIRECTION_DESC,
             'activeTab' => null,
+            'facets' => []
         ];
         $options = array_replace($defaultOptions, $options);
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -257,6 +257,18 @@ class ElasticsearchOptions
         return $this->_customValues['facets'];
     }
 
+    // set to change the facets order during admin/form save
+    public function reorderAggregableFields($facetNames)
+    {
+        $newFacets = [];
+        foreach ($facetNames as $name) {
+            if(($facet = $this->getAggregableField($name)) !== null) {
+                $newFacets[$name] = $facet;
+            }
+        }
+        $this->_customValues['facets'] = $newFacets;
+    }
+
     public function getActiveTab()
     {
         return $this->activeTab;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -100,8 +100,8 @@ class ElasticsearchOptions
             'activeTab' => $this->activeTab,
             'aggregates' => []
         ];
-        foreach($this->_customValues['aggregates'] as $fieldname=>$attributes) {
-            $ret['aggregates'][$fieldname] = $attributes;
+        foreach($this->getAggregableFields() as $fieldname=>$attributes) {
+            $ret['facets'][$fieldname] = $attributes;
         }
 
         return $ret;
@@ -221,17 +221,22 @@ class ElasticsearchOptions
 
     public function setAggregableField($key, $attributes)
     {
-        $this->_customValues['aggregates'][$key] = $attributes;
+        $facets = $this->getAggregableFields();
+        $facets[$key] = $attributes;
     }
 
     public function getAggregableField($key)
     {
-        return $this->_customValues['aggregates'][$key];
+        $facets = $this->getAggregableFields();
+        return array_key_exists($key, $facets) ? $facets[$key] : null;
     }
 
-    public function getAggregableFields()
+    public function &getAggregableFields()
     {
-        return $this->_customValues['aggregates'];
+        if(!array_key_exists('facets', $this->_customValues) || !is_array($this->_customValues['facets'])) {
+            $this->_customValues['facets'] = [];
+        }
+        return $this->_customValues['facets'];
     }
 
     public function getActiveTab()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -76,7 +76,7 @@ class ElasticsearchOptions
         $self->setPopulateOrder($options['populate_order']);
         $self->setPopulateDirection($options['populate_direction']);
         $self->setActiveTab($options['activeTab']);
-        foreach($options['aggregates'] as $fieldname=>$attributes) {
+        foreach($options['facets'] as $fieldname=>$attributes) {
             $self->setAggregableField($fieldname, $attributes);
         }
 
@@ -99,7 +99,7 @@ class ElasticsearchOptions
             'populate_order'     => $this->populateOrder,
             'populate_direction' => $this->populateDirection,
             'activeTab' => $this->activeTab,
-            'aggregates' => []
+            'facets' => []
         ];
         foreach($this->getAggregableFields() as $fieldname=>$attributes) {
             $ret['facets'][$fieldname] = $attributes;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
@@ -149,7 +149,7 @@ class ElasticsearchSettingsFormType extends AbstractType
 
         // populate aggs to form
         foreach($aggs as $k=>$agg) {
-            $builder->add('aggregates:' . $k . ':limit', ChoiceType::class, $agg);
+            $builder->add('facets:' . $k . ':limit', ChoiceType::class, $agg);
         }
 
     }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
@@ -129,11 +129,11 @@ class ElasticsearchSettingsFormType extends AbstractType
             $choices = array_key_exists('choices', $f) ? $f['choices'] : null;   // a tech-field can publish it's own choices
             $help = null;
             $label = '#' . $k;
-            if(!array_key_exists('_'.$k, $aggs)) {
+            if(!array_key_exists($k, $aggs)) {
                 $label = "/!\\ " . $label;
                 $help = "New field, please confirm setting.";
             }
-            $addAgg('_'.$k, $label, $help, false, $choices);
+            $addAgg($k, $label, $help, false, $choices);
         }
 
         // add or replace all databoxes fields (nb: new db field - unknown in conf - will be a the end)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
@@ -9,6 +9,7 @@
  */
 namespace Alchemy\Phrasea\SearchEngine\Elastic;
 
+use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,6 +18,18 @@ use Symfony\Component\Validator\Constraints\Range;
 
 class ElasticsearchSettingsFormType extends AbstractType
 {
+    /** @var GlobalStructure  */
+    private $globalStructure;
+
+    /** @var ElasticsearchOptions  */
+    private $esSettings;
+
+    public function  __construct(GlobalStructure $g, ElasticsearchOptions $settings)
+    {
+        $this->globalStructure = $g;
+        $this->esSettings = $settings;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -56,59 +69,89 @@ class ElasticsearchSettingsFormType extends AbstractType
             ->add('minScore', 'integer', [
                 'label' => 'Thesaurus Min score',
                 'constraints' => new Range(['min' => 0]),
-            ]);
+            ])
+            ->add('highlight', 'checkbox', [
+                'label' => 'Activate highlight',
+                'required' => false
+            ])
+            //                ->add('save', 'submit', [
+            //                    'attr' => ['class' => 'btn btn-primary']
+            //                ])
+            ->add('esSettingFromIndex', 'button', [
+                'label' => 'Get setting form index',
+                'attr' => [
+                    'onClick' => 'esSettingFromIndex()',
+                    'class' => 'btn'
+                ]
+            ])
+            ->add('dumpField', 'textarea', [
+                'label' => false,
+                'required' => false,
+                'mapped' => false,
+                'attr' => ['class' => 'dumpfield hide']
+            ])
+            ->add('activeTab', 'hidden');
 
-            foreach(ElasticsearchOptions::getAggregableTechnicalFields() as $k => $f) {
-                if(array_key_exists('choices', $f)) {
-                    // choices[] : choice_key => choice_value
-                    $choices = $f['choices'];
-                }
-                else {
-                    $choices = [
-                        "10 values" => 10,
-                        "20 values" => 20,
-                        "50 values" => 50,
-                        "100 values" => 100,
-                        "all values" => -1
-                    ];
-                }
-                // array_unshift($choices, "not aggregated");  //  always as first choice
-                $choices = array_merge(["not aggregated" => 0], $choices);
-                $builder
-                    ->add($k.'_limit', ChoiceType::class, [
-                        // 'label' => $f['label'],// . ' ' . 'aggregate limit',
-                        'choices_as_values' => true,
-                        'choices'           => $choices,
-                        'attr'              => [
-                            'class' => 'aggregate'
-                        ]
-                    ]);
+        // keep aggregates in configuration order with this intermediate array
+        $aggs = [];
+
+        // helper fct to add aggregate to a tmp list
+        $addAgg = function($k, $label, $help, $disabled=false, $choices=null) use (&$aggs) {
+            if(!$choices) {
+                $choices = [
+                    "10 values"      => 10,
+                    "50 values"      => 50,
+                    "100 values"     => 100,
+                    "all values"     => -1
+                ];
             }
+            $choices = array_merge(["not aggregated" => 0], $choices);  //  add this option always as first choice
+            $aggs[$k] = [   // default value will be replaced by hardcoded tech fields & all databoxes fields
+                'label'              => $label,
+                'choices_as_values'  => true,
+                'choices' => $choices,
+                'attr'               => [
+                    'class' => 'aggregate'
+                ],
+                'disabled'           => $disabled,
+                'help_message'       => $help     // todo : not displayed ?
+            ];
+        };
 
-            $builder
-                ->add('highlight', 'checkbox', [
-                    'label' => 'Activate highlight',
-                    'required' => false
-                ])
-//                ->add('save', 'submit', [
-//                    'attr' => ['class' => 'btn btn-primary']
-//                ])
-                ->add('esSettingFromIndex', 'button', [
-                    'label' => 'Get setting form index',
-                    'attr' => [
-                        'onClick' => 'esSettingFromIndex()',
-                        'class' => 'btn'
-                    ]
-                ])
-                ->add('dumpField', 'textarea', [
-                    'label' => false,
-                    'required' => false,
-                    'mapped' => false,
-                    'attr' => ['class' => 'dumpfield hide']
-                ])
-                ->add('activeTab', 'hidden');
+        // all fields fron conf
+        foreach($this->esSettings->getAggregableFields() as $k=>$f) {
+            // default value will be replaced by hardcoded tech fields & all databoxes fields
+            $addAgg($k, "/?\\ " . $k, "This field does not exists in current databoxes.", true);
+        }
 
-            ;
+        // add or replace hardcoded tech fields
+        foreach(ElasticsearchOptions::getAggregableTechnicalFields() as $k => $f) {
+            $choices = array_key_exists('choices', $f) ? $f['choices'] : null;   // a tech-field can publish it's own choices
+            $help = null;
+            $label = '#' . $k;
+            if(!array_key_exists('_'.$k, $aggs)) {
+                $label = "/!\\ " . $label;
+                $help = "New field, please confirm setting.";
+            }
+            $addAgg('_'.$k, $label, $help, false, $choices);
+        }
+
+        // add or replace all databoxes fields (nb: new db field - unknown in conf - will be a the end)
+        foreach($this->globalStructure->getAllFields() as $field) {
+            $k = $label = $field->getName();
+            $help = null;
+            if(!array_key_exists($field->getName(), $aggs)) {
+                $label = "/!\\ " . $label;
+                $help = "New field, please confirm setting.";
+            }
+            $addAgg($k, $label, $help);     // default choices
+        }
+
+        // populate aggs to form
+        foreach($aggs as $k=>$agg) {
+            $builder->add('aggregates:' . $k . ':limit', ChoiceType::class, $agg);
+        }
+
     }
 
     public function getName()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
@@ -15,7 +15,7 @@ class FacetsResponse
     private $escaper;
     private $facets = array();
 
-    public function __construct(Escaper $escaper, array $response, GlobalStructure $structure)
+    public function __construct(ElasticsearchOptions $options, Escaper $escaper, array $response, GlobalStructure $structure)
     {
         $this->escaper = $escaper;
 
@@ -25,7 +25,13 @@ class FacetsResponse
 
         $atf = ElasticsearchOptions::getAggregableTechnicalFields();
 
-        foreach ($response['aggregations'] as $name => $aggregation) {
+        // sort facets respecting the order defined in options
+        foreach($options->getAggregableFields() as $name=>$foptions) {
+            if(!array_key_exists($name, $response['aggregations'])) {
+                continue;
+            }
+            $aggregation = $response['aggregations'][$name];
+
             $tf = null;
             $valueFormatter = function($v){ return $v; };    // default equality formatter
 
@@ -78,6 +84,7 @@ class FacetsResponse
                 ];
             }
         }
+
     }
 
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/GlobalStructure.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/GlobalStructure.php
@@ -36,11 +36,6 @@ final class GlobalStructure implements Structure
     private $private = array();
 
     /**
-     * @var Field[]
-     */
-    private $facets = array();
-
-    /**
      * @var Flag[]
      */
     private $flags = array();
@@ -145,9 +140,11 @@ final class GlobalStructure implements Structure
             $this->private[$name] = $field;
         }
 
+        /*
         if ($field->isFacet() && $field->isSearchable()) {
             $this->facets[$name] = $field;
         }
+        */
 
         if ($field->hasConceptInference()) {
             $this->thesaurus_fields[$name] = $field;
@@ -181,14 +178,6 @@ final class GlobalStructure implements Structure
     public function getPrivateFields()
     {
         return $this->private;
-    }
-
-    /**
-     * @return Field[]
-     */
-    public function getFacetFields()
-    {
-        return $this->facets;
     }
 
     /**

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/LimitedStructure.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/LimitedStructure.php
@@ -47,14 +47,6 @@ final class LimitedStructure implements Structure
         return $this->limit($this->structure->getPrivateFields());
     }
 
-    /**
-     * @return Field[]
-     */
-    public function getFacetFields()
-    {
-        return $this->limit($this->structure->getFacetFields());
-    }
-
     public function getThesaurusEnabledFields()
     {
         return $this->limit($this->structure->getThesaurusEnabledFields());

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Structure.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Structure.php
@@ -36,11 +36,6 @@ interface Structure
     /**
      * @return Field[]
      */
-    public function getFacetFields();
-
-    /**
-     * @return Field[]
-     */
     public function getThesaurusEnabledFields();
 
     /**

--- a/lib/classes/patch/410alpha21a.php
+++ b/lib/classes/patch/410alpha21a.php
@@ -11,10 +11,10 @@
 
 use Alchemy\Phrasea\Application;
 
-class patch_410alpha20a implements patchInterface
+class patch_410alpha21a implements patchInterface
 {
     /** @var string */
-    private $release = '4.1.0-alpha.20a';
+    private $release = '4.1.0-alpha.21a';
 
     /** @var array */
     private $concern = [base::DATA_BOX];

--- a/templates/web/admin/fields/templates.html.twig
+++ b/templates/web/admin/fields/templates.html.twig
@@ -238,14 +238,12 @@
                         <label for="aggregable">{% trans %}Aggregation{% endtrans %}</label>
                     </td>
                     <td>
-                        <select id="aggregable">
-                            <option <%= field['aggregable'] == "0" ? 'selected' : '' %> value='0'>{% trans %}Not aggregated{% endtrans %}</option>
-                            <option <%= field['aggregable'] == "10" ? 'selected' : '' %> value='10'>10 values</option>
-                            <option <%= field['aggregable'] == "20" ? 'selected' : '' %> value='20'>20 values</option>
-                            <option <%= field['aggregable'] == "50" ? 'selected' : '' %> value='50'>50 values</option>
-                            <option <%= field['aggregable'] == "100" ? 'selected' : '' %> value='100'>100 values</option>
-                            <option <%= field['aggregable'] == "-1" ? 'selected' : '' %> value='-1'>{% trans %}All values{% endtrans %}</option>
-                        </select>
+                        <%= field['aggregable'] == "0" ? '{% trans %}Not aggregated{% endtrans %}' : '' %>
+                        <%= field['aggregable'] == "10" ? '10 values' : '' %>
+                        <%= field['aggregable'] == "20" ? '20 values' : '' %>
+                        <%= field['aggregable'] == "50" ? '50 values' : '' %>
+                        <%= field['aggregable'] == "100" ? '100 values' : '' %>
+                        <%= field['aggregable'] == "-1" ? 'All values' : '' %>
                     </td>
                 </tr>
                 <tr>

--- a/templates/web/admin/search-engine/general-aggregation.html.twig
+++ b/templates/web/admin/search-engine/general-aggregation.html.twig
@@ -1,12 +1,37 @@
 <div class="general-aggregation-layout">
+    <button type="submit" id="elasticsearch_settings_save_facets" name="elasticsearch_settings[save]"
+            class="btn btn-primary">{{ 'Save' | trans }}</button>
+    <div id="basket-filter" class="facet-filter unstyled" style="float: right; padding-top: 27px;">
+        {#<span class="filter-title">{{ 'See' | trans }} : </span>#}
+        <span class="filter-item">
+              <label id="aggregated-list" class="checkbox inline" for="basketFilter">
+                  <input type="checkbox" class="checkbox " value="aggregated" checked
+                         style="margin-top: 1px">
+                  {{ 'Aggregated' | trans }}
+              </label>
+          </span>
+        <span class="filter-item" style="margin-left: 10px">
+              <label id="not-aggregated-list" class="checkbox inline" for="basketFilter">
+                  <input type="checkbox" class="checkbox " value="not-aggregated" checked
+                         style="margin-top: 1px">
+                  {{ 'Not aggregated' | trans }}
+              </label>
+          </span>
+
+    </div>
     <ul class="unstyled aggregation-collection">
         {% for formdata in form %}
             {% set attr = formdata.vars['attr']|join(',') %}
+            {% set label = formdata.vars['label']|join(',') %}
             {% if attr == 'aggregate' %}
-                <li>
+                <li id="{{ label }}" class="field-row  {% if label starts with '#_' %}lightblue{% endif %}">
+
                     <table>
                         <tbody>
                         <tr>
+                            <td class="handle">
+                                <i class="fa fa-arrows" aria-hidden="true"></i>
+                            </td>
                             <td>
                                 {{ form_label(formdata, null, {
                                     'label_attr': {'class': 'label-aggregation'}
@@ -22,6 +47,39 @@
             {% endif %}
         {% endfor %}
     </ul>
-    <button type="submit" id="elasticsearch_settings_save" name="elasticsearch_settings[save]"
-            class="btn btn-primary">{{ 'Save' | trans }}</button>
+    <input type="hidden" id="listValues" name="facet_list_values"/>
 </div>
+
+<script type="text/javascript">
+    /*Add a sort for the  list*/
+    function filterFacet() {
+        $.each($(".aggregate option:selected"), function () {
+            if ($(this).val() == 0) {
+                $(this).closest('.field-row').addClass('not-aggregated')
+            }
+            else {
+                $(this).closest('.field-row').addClass('aggregated')
+            }
+        });
+        $('#aggregated-list input').click(function () {
+            $('.aggregated').toggleClass('hidden');
+        });
+        $('#not-aggregated-list input').click(function () {
+            $('.not-aggregated').toggleClass('hidden');
+        });
+    }
+    /*Get the order of new list*/
+    var sortEventHandler = function (event, ui) {
+        $('#listValues').val(JSON.stringify($('form').serializeArray()));
+    };
+    $(document).ready(function () {
+        $('.lightblue .label-aggregation').css('color','mediumblue');
+        $('.aggregation-collection').sortable({
+            handle: ".handle",
+            stop: sortEventHandler
+        });
+        // sortEventHandler(null, null);   // enforce build list
+        filterFacet();
+        $("#elasticsearch_settings_save_facets").click(function(){sortEventHandler(null, null);});
+    });
+</script>

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
@@ -20,7 +20,6 @@ class StructureTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($structure->getAllFields());
         $this->assertEmpty($structure->getUnrestrictedFields());
         $this->assertEmpty($structure->getPrivateFields());
-        $this->assertEmpty($structure->getFacetFields());
         $this->assertEmpty($structure->getThesaurusEnabledFields());
         $this->assertEmpty($structure->getDateFields());
     }
@@ -93,19 +92,6 @@ class StructureTest extends \PHPUnit_Framework_TestCase
         $private_fields = $structure->getPrivateFields();
         $this->assertContains($private_field, $private_fields);
         $this->assertNotContains($unrestricted_field, $private_fields);
-    }
-
-    public function testGetFacetFields()
-    {
-        $facet = new Field('foo', FieldMapping::TYPE_STRING, ['facet' => Field::FACET_NO_LIMIT]);
-        $not_facet = new Field('bar', FieldMapping::TYPE_STRING, ['facet' => Field::FACET_DISABLED]);
-        $structure = new Structure();
-        $structure->add($facet);
-        $this->assertContains($facet, $structure->getFacetFields());
-        $structure->add($not_facet);
-        $facet_fields = $structure->getFacetFields();
-        $this->assertContains($facet, $facet_fields);
-        $this->assertNotContains($not_facet, $facet_fields);
     }
 
     public function testGetDateFields()


### PR DESCRIPTION
OK to test

## Changelog
### Changed
- PHRAS-2879: ~Save all facet settings in conf, order is preserved in admin/search-engine-settings.~ DONE
   ~todo : respect order of the admin form while saving.~ DONE
   ~todo : return facets into query results in this setting order.~ DONE
   ~todo : migration from dbox settings (field struct) to conf~ DONE
   todo : remove field facet setting from admin ux ?
   ~todo : fix tests~ DONE

### readme
- facet rendered with /!\ means "new field, not yet configured" (= new dbox mounted ?). The sign will disappear as soon as the settings are saved.
- facet rendered with /?\ means "facet in config, but unknown in current dboxes/structures" (= a dbox was unmounted ?) - the setting is preserved just in case.
- facet with "#" is tech facet