### PR TITLE
PHRAS-2894  Quarantine: allow to substitute without selecting target record, (when match only one record).

### DIFF
--- a/templates/web/prod/upload/lazaret.html.twig
+++ b/templates/web/prod/upload/lazaret.html.twig
@@ -356,15 +356,20 @@
             var elements = [];
             var nbElement = 0;
 
-            if (nbProposals >= 1) {
+
+
+            if (nbProposals > 1) {
                 elements = $(".selected", container);
                 nbElement = elements.length;
-            } else {
-                return false;
+            } else if (nbProposals == 1) {
+                elements = $(".records-subititution > div", container);
+                } else {
+                    return false;
             }
 
-            if (nbElement === 0) {
+            if (nbElement === 0 && nbProposals > 1) {
                 alert(language.selectOneRecord);
+
                 return false;
             } else if (nbElement > 1) {
                 alert(language.onlyOneRecord);


### PR DESCRIPTION
  
### Fixes
  - PHRAS-2894  Quarantine: allow to substitute without selecting target record, (when match only one record).
