### PR TITLE
PHRAS-2922  Fix Lost javascript on Prod-Workzone filter 

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "normalize-css": "^2.1.0",
     "npm": "^6.0.0",
     "npm-modernizr": "^2.8.3",
-    "phraseanet-production-client": "0.34.126-d",
+    "phraseanet-production-client": "0.34.130-d",
     "requirejs": "^2.3.5",
     "tinymce": "^4.0.28",
     "underscore": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7577,10 +7577,10 @@ phraseanet-common@^0.4.5-d:
     js-cookie "^2.1.0"
     pym.js "^1.3.1"
 
-phraseanet-production-client@0.34.126-d:
-  version "0.34.126-d"
-  resolved "https://registry.yarnpkg.com/phraseanet-production-client/-/phraseanet-production-client-0.34.126-d.tgz#93ca77826eb637bcc089887bc0a2cc43ef3b8c3e"
-  integrity sha512-x2P5Ckty4iRN6ju/3b43Ljtu0cd8jRdgEQbSGRcaVjd+DuFGgpFqJn5NkoqwSKIXpvutT4sqWTHb0UfZ/sBjPQ==
+phraseanet-production-client@0.34.130-d:
+  version "0.34.130-d"
+  resolved "https://registry.yarnpkg.com/phraseanet-production-client/-/phraseanet-production-client-0.34.130-d.tgz#8f25d1d099ee9db4ef426faaaabec130d9ab17ae"
+  integrity sha512-yBC5f/CpLbq7zmN4I0sgx2LlFwNSFDdvxR1Y78Xb7ws7yLvYji2Z/FOx0s+aXY3NUsWT/3EuTwfNCvHvmByV+g==
   dependencies:
     "@mapbox/mapbox-gl-language" "^0.9.2"
     "@turf/turf" "^5.1.6"


### PR DESCRIPTION
## Changelog
### Changed
  - phraseanet-production-client@0.34.130-d 
  
### Fixes
  - PHRAS-2922: Prod - filter on workzone- loose javascipt on some action
  - The javascript was lost on these cases : 
     Add new story 
     Add new basket
    Sort by date
    Sort by name

