### PR TITLE
PHRAS-3003_large-value-32ko-es_4.1

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/RecordHelper.php
@@ -151,6 +151,7 @@ class RecordHelper
                 return (bool) $value;
 
             case FieldMapping::TYPE_STRING:
+                $value = substr($value, 0, 32766);      // for lucene limit, before a better solution
                 return str_replace("\0", '', $value);
 
             default:


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3003: fix (temporary ?) : text values are kept full in metadata table, but truncated to 32Ko by indexer.