### PR TITLE
PHRAS-3025 : send Phraseanet log on stdout

### DIFF
--- a/docker/phraseanet/entrypoint.sh
+++ b/docker/phraseanet/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 envsubst < "docker/phraseanet/php.ini.sample" > /usr/local/etc/php/php.ini
 envsubst < "docker/phraseanet/php-fpm.conf.sample" > /usr/local/etc/php-fpm.conf
+envsubst < "docker/phraseanet/root/usr/local/etc/php-fpm.d/zz-docker.conf" > /usr/local/etc/php-fpm.d/zz-docker.conf
 
 chown -R app:app \
     cache \

--- a/docker/phraseanet/root/usr/local/etc/php-fpm.d/zz-docker.conf
+++ b/docker/phraseanet/root/usr/local/etc/php-fpm.d/zz-docker.conf
@@ -1,6 +1,5 @@
 [global]
 daemonize = no
-error_log = /var/log/fpm-php.www.log
 process.max = 128
 
 [www]


### PR DESCRIPTION
## Changelog
### Changed
  -  use stderr output instead of php fpm error log file


  



