### PR TITLE
PHRAS-3027 : Backport To 4.0 - Populate - Slow query - due to LIMIT 508600, 200

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Version.php
+++ b/lib/Alchemy/Phrasea/Core/Version.php
@@ -16,7 +16,7 @@ class Version
     /**
      * @var string
      */
-    private $number = '4.0.11';
+    private $number = '4.0.12';
 
     /**
      * @var string

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -35,7 +35,7 @@ class ElasticsearchOptions
     private $populateOrder;
     /** @var string */
     private $populateDirection;
-    /** @var  int[] */
+    /** @var  int[][] */
     private $_customValues;
     private $activeTab;
 
@@ -283,15 +283,17 @@ class ElasticsearchOptions
     /**
      * @return string
      */
-    public function getPopulateOrderAsSQL()
+    public function getPopulateOrder()
     {
-        static $orderAsColumn = [
-            self::POPULATE_ORDER_RID     => "`record_id`",
-            self::POPULATE_ORDER_MODDATE => "`moddate`",
-        ];
+        return $this->populateOrder;
+    }
 
-        // populateOrder IS one of the keys (ensured by setPopulateOrder)
-        return $orderAsColumn[$this->populateOrder];
+    /**
+     * @return string
+     */
+    public function getPopulateDirection()
+    {
+        return $this->populateDirection;
     }
 
     /**

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Delegate/RecordListFetcherDelegate.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Delegate/RecordListFetcherDelegate.php
@@ -24,7 +24,7 @@ class RecordListFetcherDelegate implements FetcherDelegateInterface
 
     public function buildWhereClause()
     {
-        return 'WHERE r.record_id IN (:record_identifiers)';
+        return 'record_id IN (:record_identifiers)';
     }
 
     public function getParameters()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Delegate/ScheduledFetcherDelegate.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Delegate/ScheduledFetcherDelegate.php
@@ -18,7 +18,7 @@ class ScheduledFetcherDelegate implements FetcherDelegateInterface
 {
     public function buildWhereClause()
     {
-        return 'WHERE (r.jeton & :to_index) > 0 AND (jeton & :indexing) = 0';
+        return '(jeton & :to_index) > 0 AND (jeton & :indexing) = 0';
     }
 
     public function getParameters()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Fetcher.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Fetcher.php
@@ -11,7 +11,6 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic\Indexer\Record;
 
-use Alchemy\Phrasea\Core\PhraseaTokens;
 use Alchemy\Phrasea\SearchEngine\Elastic\ElasticsearchOptions;
 use Alchemy\Phrasea\SearchEngine\Elastic\Exception\Exception;
 use Alchemy\Phrasea\SearchEngine\Elastic\Indexer\Record\Delegate\FetcherDelegate;
@@ -19,7 +18,9 @@ use Alchemy\Phrasea\SearchEngine\Elastic\Indexer\Record\Delegate\FetcherDelegate
 use Closure;
 use databox;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Statement;
+use LogicException;
 use PDO;
 
 class Fetcher
@@ -30,7 +31,14 @@ class Fetcher
     private $statement;
     private $delegate;
 
-    private $offset = 0;
+    // since we fetch records by different order/direction, we setup sql limit
+    /** @var int|string  */
+    private $boundLimit;           // may be highest or lowest int or date, as a startup condition for sql or loop
+    /** @var int|string */
+    private $lastLimit;            // the last value fetched
+    /** @var Closure  */
+    private $updateLastLimitDelegate;   // must update the lastLimit by comparing the current record rid or moddate while fetching
+
     private $batchSize = 1;
     private $buffer = array();
 
@@ -45,6 +53,46 @@ class Fetcher
         $this->connection = $databox->get_connection();;
         $this->hydrators  = $hydrators;
         $this->delegate   = $delegate ?: new FetcherDelegate();
+
+        // set the boundLimit and updateDelegate, depends on populate-order and populate-direction
+        // the bound limit value is used on first run, but also as initial value on fetch loop
+
+        // too bad we cannot assign to a variable a builtin function ("min" or "max") as a closure (= vector)
+        // we need to encapsulate the builtin function into a closure in php.
+        //
+        if($options->getPopulateOrder() === ElasticsearchOptions::POPULATE_ORDER_RID) {
+            // record_id
+            if ($options->getPopulateDirection() === ElasticsearchOptions::POPULATE_DIRECTION_ASC) {
+                $this->boundLimit = 0;
+                $this->updateLastLimitDelegate = function ($record) {
+                    $this->lastLimit = max($this->lastLimit, (int)($record['record_id']));
+                };
+            }
+            else {
+                $this->boundLimit = PHP_INT_MAX;
+                $this->updateLastLimitDelegate = function ($record) {
+                    $this->lastLimit = min($this->lastLimit, (int)($record['record_id']));
+                };
+            }
+        }
+        else {
+            // moddate ; max() min() is ok on strings !
+            if ($options->getPopulateDirection() === ElasticsearchOptions::POPULATE_DIRECTION_ASC) {
+                $this->boundLimit = '0000-00-00 00:00:00';
+                $this->updateLastLimitDelegate = function ($record) {
+                    $this->lastLimit = max($this->lastLimit, $record['updated_on']);
+                };
+            }
+            else {
+                $this->boundLimit = '9999-12-31 23:59:59';
+                $this->updateLastLimitDelegate = function ($record) {
+                    $this->lastLimit = min($this->lastLimit, $record['updated_on']);
+                };
+            }
+        }
+
+        // limit for first run
+        $this->lastLimit = $this->boundLimit;
     }
 
     public function getDatabox()
@@ -52,6 +100,11 @@ class Fetcher
         return $this->databox;
     }
 
+    /**
+     * @return mixed
+     * @throws DBALException
+     * @throws Exception
+     */
     public function fetch()
     {
         if (empty($this->buffer)) {
@@ -64,20 +117,29 @@ class Fetcher
         return array_pop($this->buffer);
     }
 
+    /**
+     * @return array
+     * @throws DBALException
+     * @throws Exception
+     */
     private function fetchBatch()
     {
         // Fetch records rows
         $statement = $this->getExecutedStatement();
-        // printf("Query %d/%d -> %d rows\n", $this->offset, $this->batchSize, $statement->rowCount());
+        // printf("Query %s (%d) -> %d rows\n", $this->lastLimit, $this->batchSize, $statement->rowCount());
 
         $records = [];
+        $this->lastLimit = $this->boundLimit;   // initial low or high value
         while ($record = $statement->fetch()) {
             $records[$record['record_id']] = $record;
-            $this->offset++;
+            // compare/update limit
+            // ($this->updateLastLimitDelegate)($record);       // php 7.2 only
+            call_user_func($this->updateLastLimitDelegate, $record);
         }
         if (empty($records)) {
+            /** @noinspection PhpUndefinedMethodInspection */
             $this->onDrain->__invoke();
-            return;
+            return [];
         }
 
         // Hydrate records
@@ -91,6 +153,7 @@ class Fetcher
         }
 
         if ($this->postFetch) {
+            /** @noinspection PhpUndefinedMethodInspection */
             $this->postFetch->__invoke($records);
         }
 
@@ -100,13 +163,13 @@ class Fetcher
     public function restart()
     {
         $this->buffer = array();
-        $this->offset = 0;
+        $this->lastLimit = $this->boundLimit;
     }
 
     public function setBatchSize($size)
     {
         if ($size < 1) {
-            throw new \LogicException("Batch size must be greater than or equal to 1");
+            throw new LogicException("Batch size must be greater than or equal to 1");
         }
         $this->batchSize = (int) $size;
     }
@@ -122,30 +185,38 @@ class Fetcher
     }
 
     /**
-     * @return \Doctrine\DBAL\Driver\Statement
-     * @throws \Doctrine\DBAL\DBALException
+     * @return Statement
+     * @throws DBALException
      */
     private function getExecutedStatement()
     {
         if (!$this->statement) {
 
-           $sql =  "SELECT r.*, c.asciiname AS collection_name, subdef.width, subdef.height, subdef.size\n"
-                 . " FROM ((\n"
-                 . "     SELECT r.record_id, r.coll_id AS collection_id, r.uuid, r.status AS flags_bitfield, r.sha256,\n"
-                 . "            r.originalname AS original_name, r.mime, r.type, r.parent_record_id,\n"
-                 . "            r.credate AS created_on, r.moddate AS updated_on, r.coll_id\n"
-                 . "     FROM record r\n"
-                 . "     -- WHERE\n"
-                 . "     ORDER BY " . $this->options->getPopulateOrderAsSQL() . " " . $this->options->getPopulateDirectionAsSQL() . "\n"
-                 . "     LIMIT :offset, :limit\n"
-                 . "   ) AS r\n"
-                 . "   INNER JOIN coll c ON (c.coll_id = r.coll_id)\n"
-                 . " )\n"
-                 . " LEFT JOIN\n"
-                 . " subdef ON subdef.record_id=r.record_id AND subdef.name='document'\n"
-                 . " ORDER BY " . $this->options->getPopulateOrderAsSQL() . " " . $this->options->getPopulateDirectionAsSQL() . "";
+            $sql =  "SELECT r.*, c.asciiname AS collection_name, subdef.width, subdef.height, subdef.size\n"
+                . " FROM ((\n"
+                . "     SELECT record_id, coll_id AS collection_id, uuid, status AS flags_bitfield, sha256,\n"
+                . "            originalname AS original_name, mime, type, parent_record_id,\n"
+                . "            credate AS created_on, moddate AS updated_on, coll_id\n"
+                . "     FROM record\n"
+                . "     WHERE -- WHERE\n"
+                . "     ORDER BY " . ($this->options->getPopulateOrder() === ElasticsearchOptions::POPULATE_ORDER_RID ? 'record_id':'moddate')
+                . " " . $this->options->getPopulateDirectionAsSQL() . "\n"
+                . "     LIMIT :limit\n"
+                . "   ) AS r\n"
+                . "   INNER JOIN coll c ON (c.coll_id = r.coll_id)\n"
+                . " )\n"
+                . " LEFT JOIN\n"
+                . " subdef ON subdef.record_id=r.record_id AND subdef.name='document'\n"
+                . " ORDER BY " . ($this->options->getPopulateOrder() === ElasticsearchOptions::POPULATE_ORDER_RID ? 'record_id':'updated_on')
+                . " " . $this->options->getPopulateDirectionAsSQL() . "";
 
-            $where = $this->delegate->buildWhereClause();
+            $where = ($this->options->getPopulateOrder() === ElasticsearchOptions::POPULATE_ORDER_RID ? 'record_id' : 'moddate') .
+                ($this->options->getPopulateDirection() === ElasticsearchOptions::POPULATE_DIRECTION_DESC ? ' < ' : ' > ') .
+                ':bound';
+
+            if( ($w = $this->delegate->buildWhereClause()) != '') {
+                $where = '(' . $where . ') AND (' . $w . ')';
+            }
             $sql = str_replace('-- WHERE', $where, $sql);
 
             // Build parameters list
@@ -169,12 +240,12 @@ class Fetcher
                     }
                 }
                 // Reference bound parameters
-                $statement->bindParam(':offset', $this->offset, PDO::PARAM_INT);
+                $statement->bindParam(':bound', $this->lastLimit, PDO::PARAM_INT);
                 $statement->bindParam(':limit', $this->batchSize, PDO::PARAM_INT);
                 $this->statement = $statement;
             } else {
                 // Inject own query parameters
-                $params[':offset'] = $this->offset;
+                $params[':bound'] = $this->lastLimit;
                 $params[':limit'] = $this->batchSize;
                 $types[':offset'] = $types[':limit'] = PDO::PARAM_INT;
 

--- a/lib/classes/patch/4012.php
+++ b/lib/classes/patch/4012.php
@@ -81,7 +81,7 @@ class patch_4012 implements patchInterface
                             ':mask_xor' => $acl->get_mask_xor($collection->get_base_id()),
                             ':ord'      => $iord++
                         ]);
-                    } catch (DBALException $e) {
+                    } catch (\Doctrine\DBAL\DBALException $e) {
 
                     }
                 }
@@ -90,6 +90,17 @@ class patch_4012 implements patchInterface
             }
 
             unset($acl);
+        }
+
+        // script used for the slow query indexing fix
+        $sql = "ALTER TABLE `record` ADD INDEX `moddate` (`moddate`);";
+        try {
+            $stmt = $databox->get_connection()->prepare($sql);
+            $stmt->execute();
+            $stmt->closeCursor();
+        }
+        catch (\Exception $e) {
+            // the index already exists ?
         }
 
         return true;

--- a/lib/conf.d/bases_structure.xml
+++ b/lib/conf.d/bases_structure.xml
@@ -3846,6 +3846,13 @@
               <field>parent_record_id</field>
             </fields>
           </index>
+          <index>
+            <name>moddate</name>
+            <type>INDEX</type>
+            <fields>
+              <field>moddate</field>
+            </fields>
+          </index>
         </indexes>
         <engine>InnoDB</engine>
       </table>


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-3027: Backport To 4.0 - Populate - Slow query - due to LIMIT 508600, 200
  - bump version 4.0.12



