### PR TITLE
PHRAS-3036 Tag docker image to 4.0.12 

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ PHRASEANET_PROJECT_NAME=Phraseanet
 # Registry from where you pull Docker images
 PHRASEANET_DOCKER_REGISTRY=local
 # Tag of the Docker images
-PHRASEANET_DOCKER_TAG=latest
+PHRASEANET_DOCKER_TAG=4.0.12
 # APPLICATION PORT
 PHRASEANET_APP_PORT=8082
 # RabbitMQ configuration


### PR DESCRIPTION
## Changelog
### Changed
  - Tag docker images to 4.0.12 in .env
 