### PR TITLE
PHRAS-2524 : put worker log to ELK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 # Exclude configuration folder exception the configuration sample file
 /config
 !/config/configuration.sample.yml
+!/config/filebeat.yml
+!/config/logstash.conf
 
 # Exclude generated proxies from doctrine2
 #/resources/proxies

--- a/config/filebeat.yml
+++ b/config/filebeat.yml
@@ -1,0 +1,9 @@
+filebeat:
+  inputs:
+    - type: log
+      enabled: true
+      paths:
+      - /var/alchemy/Phraseanet/logs/task_*.log
+      - /var/alchemy/Phraseanet/logs/worker_service*.log
+output.logstash:
+  hosts: ["logstash:5044"]

--- a/config/filebeat.yml
+++ b/config/filebeat.yml
@@ -5,5 +5,6 @@ filebeat:
       paths:
       - /var/alchemy/Phraseanet/logs/task_*.log
       - /var/alchemy/Phraseanet/logs/worker_service*.log
+      - /var/alchemy/Phraseanet/logs/app_error*.log
 output.logstash:
   hosts: ["logstash:5044"]

--- a/config/logstash.conf
+++ b/config/logstash.conf
@@ -1,0 +1,36 @@
+input {
+  beats {
+    port => 5044
+  }
+}
+filter {
+  clone {
+    clones => ["to_stdout"]
+  }
+
+  if [type] == "to_stdout" {
+  #display only message field in the logstash stdout
+    prune {
+        whitelist_names => ["message"]
+    }
+    mutate {
+        add_field => { "[@metadata][type]" => "to_stdout" }
+    }
+  }
+  else {
+    mutate {
+        add_field => { "[@metadata][type]" => "to_elasticsearch" }
+    }
+  }
+
+}
+output {
+    if [@metadata][type][1] == "to_stdout" {
+        stdout {
+            codec => rubydebug
+        }
+    }
+    else {
+        elasticsearch { hosts => ["elasticsearch:9200"] }
+    }
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -91,6 +91,30 @@ services:
     image: kibana:4.6.6
     ports:
     - 5601:5601
+    links:
+    - elasticsearch
+    depends_on:
+    - elasticsearch
+
+  logstash:
+    image: logstash:7.6.2
+    links:
+    - elasticsearch
+    volumes:
+    - ${PHRASEANET_CONFIG_DIR}:/var/alchemy/Phraseanet/config:rw
+    command: logstash -f /var/alchemy/Phraseanet/config/logstash.conf
+    depends_on:
+    - elasticsearch
+    restart: on-failure
+
+  filebeat:
+    hostname: filebeat
+    image: "docker.elastic.co/beats/filebeat:7.6.2"
+    volumes:
+    - ${PHRASEANET_CONFIG_DIR}/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+    - ${PHRASEANET_LOGS_DIR}:/var/alchemy/Phraseanet/logs:ro
+    command: filebeat run -e --strict.perms=false
+    restart: on-failure
 
 networks:
   default:


### PR DESCRIPTION
## Changelog

use filebeat to get worker log from file and push it to ELK and to logstash stdout
### Adds
  - PHRAS-2524: put worker log to ELK
  - add logstash container
  - add filebeat container
  - _docker-compose logs -f logstash_ to see task log message
 - elasticsearch index prefixed by _logstash-_  

