### PR TITLE
PHRAS-3067 Prod - video tools - by default option "No Chapters Overlaps" need to be true 

### DIFF
--- a/templates/web/prod/actions/Tools/videoEditor.html.twig
+++ b/templates/web/prod/actions/Tools/videoEditor.html.twig
@@ -229,7 +229,7 @@
             {% endfor %}
         ],
         preferences: {
-            overlapChapters: {% if overlapChapters != NULL %}{{ overlapChapters }}{% else %}0{% endif %},
+            overlapChapters: {% if overlapChapters != NULL %}{{ overlapChapters }}{% else %}1{% endif %},
         }
 
     };


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-3067 Prod - video tools - by default option "No Chapters Overlaps" need to be true 