### PR TITLE
PHRAS-3192 - add inkscape apt package to Dokerfile for svg files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN echo "deb http://deb.debian.org/debian stretch main non-free" > /etc/apt/sou
         ghostscript \
         gpac \
         imagemagick \
+        ufraw \
+        inkscape \
         libav-tools \
         libfreetype6-dev \
         libicu-dev \
@@ -36,7 +38,6 @@ RUN echo "deb http://deb.debian.org/debian stretch main non-free" > /etc/apt/sou
         mcrypt \
         swftools \
         unoconv \
-        ufraw \
         unzip \
         poppler-utils \
         libreoffice-base-core \


### PR DESCRIPTION
## Changelog
### Adds
  - PHRAS-3192: add inkscape apt package to Dokerfile for svg files
  - add inkscape apt package to Dokerfile for svg files to fixe subview creation issues