### PR TITLE
PHRAS-3209 JS Error message during upload: "img.toDataURL is not a function" on 4.0.12

### DIFF
--- a/templates/web/prod/upload/upload.html.twig
+++ b/templates/web/prod/upload/upload.html.twig
@@ -440,7 +440,8 @@ $(document).ready(function () {
                     UploaderManager.Preview.render(file, function (img) {
                         context.find('.thumbnail .canva-wrapper').prepend(img);
                         UploaderManager.addAttributeToData(uploadIndex, 'image', img);
-                        UploaderManager.addAttributeToData(uploadIndex, 'b64_image', img.toDataURL("image/png") || '');
+                        //  *** base64 url is still deprecated and unused ***
+                        //  UploaderManager.addAttributeToData(uploadIndex, 'b64_image', img.toDataURL("image/png") || '');
                     });
                 }
             });


### PR DESCRIPTION
## Changelog

### Removes
  - PHRAS-3209 JS Error message during upload: "img.toDataURL is not a function" on 4.0.12

     This js part is removed as it is deprecated

