### PR TITLE
PHRAS-3226 4.0 lower case composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
     },
     "require-dev":  {
         "phpunit/phpunit": "~4.5",
-        "mikey179/vfsStream": "~1.5"
+        "mikey179/vfsstream": "~1.5"
     },
     "autoload":     {
         "psr-0": {


### PR DESCRIPTION
### Fixes
  - PHRAS-3226: fix lower case composer dependencies
  - Since composer 2.0 does not allow upper case caracters. we change composer.json