### PR TITLE
PHRAS-3244 : worker - admin - populate - populate again a databases after manual interruption is not possible

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Repositories/WorkerRunningJobRepository.php
+++ b/lib/Alchemy/Phrasea/Model/Repositories/WorkerRunningJobRepository.php
@@ -85,8 +85,8 @@ class WorkerRunningJobRepository extends EntityRepository
         $qb = $this->createQueryBuilder('w');
         $qb->where($qb->expr()->in('w.databoxId', $databoxIds))
             ->andWhere('w.work = :work')
-            ->andWhere('w.status != :status')
-            ->setParameters([ 'work' => MessagePublisher::POPULATE_INDEX_TYPE, 'status' => WorkerRunningJob::FINISHED])
+            ->andWhere('w.status = :status')
+            ->setParameters([ 'work' => MessagePublisher::POPULATE_INDEX_TYPE, 'status' => WorkerRunningJob::RUNNING])
         ;
 
         return count($qb->getQuery()->getResult());

--- a/lib/Alchemy/Phrasea/WorkerManager/Controller/AdminConfigurationController.php
+++ b/lib/Alchemy/Phrasea/WorkerManager/Controller/AdminConfigurationController.php
@@ -102,7 +102,9 @@ class AdminConfigurationController extends Controller
 
     /**
      * @param Request $request
-     * @param integer $workerId
+     * @param $workerId
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @throws \Doctrine\ORM\OptimisticLockException
      */
     public function changeStatusAction(Request $request, $workerId)
     {


### PR DESCRIPTION
#time 1h

## Changelog

### Fixes
  - PHRAS-3244: worker - admin - populate - populate again a databases after manual interruption is not possible


