### PR TITLE
PHRAS-3265 Port to 4.1 - taken in account max_result_window when create elastisearch index

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchOptions.php
@@ -33,6 +33,8 @@ class ElasticsearchOptions
     private $minScore;
     /** @var  bool */
     private $highlight;
+    /** @var int */
+    private $maxResultWindow;
     /** @var string */
     private $populateOrder;
     /** @var string */
@@ -58,6 +60,7 @@ class ElasticsearchOptions
             'replicas' => 0,
             'minScore' => 4,
             'highlight' => true,
+            'max_result_window'  => 500000,
             'populate_order'     => self::POPULATE_ORDER_RID,
             'populate_direction' => self::POPULATE_DIRECTION_DESC,
             'activeTab' => null,
@@ -73,6 +76,7 @@ class ElasticsearchOptions
         $self->setReplicas($options['replicas']);
         $self->setMinScore($options['minScore']);
         $self->setHighlight($options['highlight']);
+        $self->setMaxResultWindow($options['max_result_window']);
         $self->setPopulateOrder($options['populate_order']);
         $self->setPopulateDirection($options['populate_direction']);
         $self->setActiveTab($options['activeTab']);
@@ -96,6 +100,7 @@ class ElasticsearchOptions
             'replicas' => $this->replicas,
             'minScore' => $this->minScore,
             'highlight' => $this->highlight,
+            'maxResultWindow'    => $this->maxResultWindow,
             'populate_order'     => $this->populateOrder,
             'populate_direction' => $this->populateDirection,
             'activeTab' => $this->activeTab,
@@ -218,6 +223,22 @@ class ElasticsearchOptions
     public function setHighlight($highlight)
     {
         $this->highlight = $highlight;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxResultWindow()
+    {
+        return $this->maxResultWindow;
+    }
+
+    /**
+     * @param int $maxResultWindow
+     */
+    public function setMaxResultWindow($maxResultWindow)
+    {
+        $this->maxResultWindow = (int)$maxResultWindow;
     }
 
     public function setAggregableFieldLimit($key, $value)


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3265: Port to 4.1 - taken in account max_result_window when create elastisearch index



