### PR TITLE
PHRAS-3279_api-v3-permalinks-to-es_4.1

### DIFF
--- a/config/configuration.sample.yml
+++ b/config/configuration.sample.yml
@@ -36,6 +36,7 @@ main:
             highlight: true
             populate_order: RECORD_ID
             populate_direction: DESC
+            populate_permalinks: false
             activeTab: ''
             facets:
                 _base:

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
@@ -2,6 +2,7 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic;
 
+use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Core\Configuration\PropertyAccess;
 use Alchemy\Phrasea\SearchEngine\Elastic\Indexer\Record\Delegate\FetcherDelegateInterface;
 use Alchemy\Phrasea\SearchEngine\Elastic\Indexer\Record\Fetcher;
@@ -23,9 +24,9 @@ class DataboxFetcherFactory
     private $conf;
 
     /**
-     * @var \ArrayAccess
+     * @var Application
      */
-    private $container;
+    private $app;
 
     /**
      * @var string
@@ -49,16 +50,16 @@ class DataboxFetcherFactory
      * @param PropertyAccess $conf
      * @param RecordHelper $recordHelper
      * @param ElasticsearchOptions $options
-     * @param \ArrayAccess $container
+     * @param Application $app
      * @param string $structureKey
      * @param string $thesaurusKey
      */
-    public function __construct(PropertyAccess $conf, RecordHelper $recordHelper, ElasticsearchOptions $options, \ArrayAccess $container, $structureKey, $thesaurusKey)
+    public function __construct(PropertyAccess $conf, RecordHelper $recordHelper, ElasticsearchOptions $options, Application $app, $structureKey, $thesaurusKey)
     {
         $this->conf         = $conf;
         $this->recordHelper = $recordHelper;
         $this->options      = $options;
-        $this->container    = $container;
+        $this->app          = $app;
         $this->structureKey = $structureKey;
         $this->thesaurusKey = $thesaurusKey;
     }
@@ -82,7 +83,7 @@ class DataboxFetcherFactory
                 new MetadataHydrator($this->conf, $connection, $this->getStructure(), $this->recordHelper),
                 new FlagHydrator($this->getStructure(), $databox),
                 new ThesaurusHydrator($this->getStructure(), $this->getThesaurus(), $candidateTerms),
-                new SubDefinitionHydrator($databox)
+                new SubDefinitionHydrator($this->app, $databox)
             ],
             $fetcherDelegate
         );
@@ -100,7 +101,7 @@ class DataboxFetcherFactory
      */
     private function getStructure()
     {
-        return $this->container[$this->structureKey];
+        return $this->app[$this->structureKey];
     }
 
     /**
@@ -108,6 +109,6 @@ class DataboxFetcherFactory
      */
     private function getThesaurus()
     {
-        return $this->container[$this->thesaurusKey];
+        return $this->app[$this->thesaurusKey];
     }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
@@ -46,6 +46,9 @@ class DataboxFetcherFactory
     /** @var  ElasticsearchOptions */
     private $options;
 
+    /** @var  bool */
+    private $populatePermalinks;
+
     /**
      * @param PropertyAccess $conf
      * @param RecordHelper $recordHelper
@@ -62,6 +65,7 @@ class DataboxFetcherFactory
         $this->app          = $app;
         $this->structureKey = $structureKey;
         $this->thesaurusKey = $thesaurusKey;
+        $this->populatePermalinks = $conf->get(['main', 'search-engine', 'options', 'populate_permalinks'], false) ;
     }
 
     /**
@@ -83,7 +87,7 @@ class DataboxFetcherFactory
                 new MetadataHydrator($this->conf, $connection, $this->getStructure(), $this->recordHelper),
                 new FlagHydrator($this->getStructure(), $databox),
                 new ThesaurusHydrator($this->getStructure(), $this->getThesaurus(), $candidateTerms),
-                new SubDefinitionHydrator($this->app, $databox)
+                new SubDefinitionHydrator($this->app, $databox, $this->populatePermalinks)
             ],
             $fetcherDelegate
         );

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/DataboxFetcherFactory.php
@@ -46,7 +46,7 @@ class DataboxFetcherFactory
     /** @var  ElasticsearchOptions */
     private $options;
 
-    /** @var  bool */
+    /** @var  boolean */
     private $populatePermalinks;
 
     /**

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
@@ -24,10 +24,10 @@ class SubDefinitionHydrator implements HydratorInterface
     /** @var databox */
     private $databox;
 
-    /** @var  bool */
+    /** @var  boolean */
     private $populatePermalinks;
 
-    public function __construct(Application $app, databox $databox, bool $populatePermalinks)
+    public function __construct(Application $app, databox $databox, boolean $populatePermalinks)
     {
         $this->app = $app;
         $this->databox = $databox;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
@@ -24,10 +24,14 @@ class SubDefinitionHydrator implements HydratorInterface
     /** @var databox */
     private $databox;
 
-    public function __construct(Application $app, databox $databox)
+    /** @var  bool */
+    private $populatePermalinks;
+
+    public function __construct(Application $app, databox $databox, bool $populatePermalinks)
     {
         $this->app = $app;
         $this->databox = $databox;
+        $this->populatePermalinks = $populatePermalinks;
     }
 
     public function hydrateRecords(array &$records)
@@ -35,13 +39,16 @@ class SubDefinitionHydrator implements HydratorInterface
         foreach(array_keys($records) as $rid) {
             try {
                 $subdefs = $this->databox->getRecordRepository()->find($rid)->get_subdefs();
-                $pls = array_map(
+                $pls = [];
+                if ($this->populatePermalinks) {
+                    $pls = array_map(
                     /** media_Permalink_Adapter|null $plink */
-                    function($plink) {
-                        return $plink ? ((string) $plink->get_url()) : null;
-                    },
-                    media_Permalink_Adapter::getMany($this->app, $subdefs, false) // false: don't create missing plinks
-                );
+                        function($plink) {
+                            return $plink ? ((string) $plink->get_url()) : null;
+                        },
+                        media_Permalink_Adapter::getMany($this->app, $subdefs, false) // false: don't create missing plinks
+                    );
+                }
 
                 foreach($subdefs as $subdef) {
                     $name = $subdef->get_name();

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
@@ -27,7 +27,7 @@ class SubDefinitionHydrator implements HydratorInterface
     /** @var  boolean */
     private $populatePermalinks;
 
-    public function __construct(Application $app, databox $databox, boolean $populatePermalinks)
+    public function __construct(Application $app, databox $databox, $populatePermalinks)
     {
         $this->app = $app;
         $this->databox = $databox;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/SubDefinitionHydrator.php
@@ -76,7 +76,7 @@ SQL;
 
             $name = $subdef['name'];
             $records[$subdef['record_id']]['subdefs'][$name] = array(
-                // 'path' => $subdef['path'],
+                'path' => $subdef['path'],
                 'width' => $subdef['width'],
                 'height' => $subdef['height'],
                 'permalink' => array_key_exists($name, $pls) ? $pls[$name] : null

--- a/lib/classes/media/Permalink/Adapter.php
+++ b/lib/classes/media/Permalink/Adapter.php
@@ -276,7 +276,7 @@ class media_Permalink_Adapter implements cache_cacheableInterface
      * @param media_subdef[] $subdefs
      * @return media_Permalink_Adapter[]
      */
-    public static function getMany(Application $app, $subdefs)
+    public static function getMany(Application $app, $subdefs, $createIfMissing = true)
     {
         Assertion::allIsInstanceOf($subdefs, media_subdef::class);
 
@@ -303,18 +303,20 @@ class media_Permalink_Adapter implements cache_cacheableInterface
 
             $missing = array_diff_key($media_subdefs, $data);
 
-            if ($missing) {
+            if($missing && $createIfMissing) {
                 self::createMany($app, $databox, $missing);
                 $data = array_replace($data, self::fetchData($databox, array_diff_key($subdefIds, $data)));
             }
 
             foreach ($media_subdefs as $index => $subdef) {
-                if (!isset($data[$index])) {
+                if ($createIfMissing && !isset($data[$index])) {
                     throw new \RuntimeException('Could not fetch some data. Should never happen');
                 }
-
-                $permalinks[$index] = new self($app, $databox, $subdef, $data[$index]);
+                if(isset($data[$index])) {
+                    $permalinks[$index] = new self($app, $databox, $subdef, $data[$index]);
+                }
             }
+
         }
 
         return $permalinks;

--- a/lib/conf.d/configuration.yml
+++ b/lib/conf.d/configuration.yml
@@ -37,6 +37,7 @@ main:
             maxResultWindow: 500000
             populate_order: RECORD_ID
             populate_direction: DESC
+            populate_permalinks: false
             activeTab: '#elastic-search'
             facets:
                 _base:


### PR DESCRIPTION
## Changelog
The subdefintion's Permalinks are now injected in Elasticsearch index when the new option  "populate_permalinks" is set to "True".
This option is define in configuration.yml, "search-engine" section.
If property is missing the value is false.
With this feature, "api/v3/searchraw" can serve subdefinition's permalinks.
Warning, when populate_permalinks:true, duration and memory consumption during the Populate are increase, this factor is depending of  "databox's" structure.

### Adds
  - PHRAS-3279 : permalinks  in Elasticsearch index.