### PR TITLE
PHRAS-3129 Docker - Worker - if rabbitMQ is not up, worker need to exit with 1

### DIFF
--- a/lib/Alchemy/Phrasea/WorkerManager/Command/WorkerExecuteCommand.php
+++ b/lib/Alchemy/Phrasea/WorkerManager/Command/WorkerExecuteCommand.php
@@ -45,7 +45,7 @@ class WorkerExecuteCommand extends Command
         if ($channel == null) {
             $output->writeln("Can't connect to rabbit, check configuration!");
 
-            return;
+            return 1;
         }
 
         $serverConnection->declareExchange();
@@ -56,7 +56,7 @@ class WorkerExecuteCommand extends Command
         if ($input->getOption('max-processes') != null && $maxProcesses == 0) {
             $output->writeln('<error>Invalid max-processes option.Need an integer</error>');
 
-            return;
+            return 1;
         } elseif($maxProcesses) {
             $workerInvoker->setMaxProcessPoolValue($maxProcesses);
         }


### PR DESCRIPTION
## Changelog
### Changed
  -  If rabbitMQ is not up, worker exit with code 1 
  
### Fixes
  - PHRAS-3129 : Docker - Worker - if rabbitMQ is not up, worker need to exit with 1

