### PR TITLE
PHRAS-3350 Password renewal and creation - link send by email - token TTL - token table of applicationBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Phraseanet is licensed under GPL-v3 license.
 
 https://docs.phraseanet.com/
 
-For development with Phraseanet API see https://docs.phraseanet.com/4.0/en/Devel/index.html
+For development with Phraseanet API see https://docs.phraseanet.com/4.1/en/Devel/index.html
 
 # Installation :
 
@@ -26,7 +26,7 @@ You can download a packaged version here: :
 
 https://www.phraseanet.com/download/
 
-And follow the install steps described at https://docs.phraseanet.com/4.0/en/Admin/Install.html
+And follow the install steps described at https://docs.phraseanet.com/4.1/en/Admin/Install.html
 
 # Phraseanet with Docker:
 

--- a/lib/Alchemy/Phrasea/Authentication/RecoveryService.php
+++ b/lib/Alchemy/Phrasea/Authentication/RecoveryService.php
@@ -128,7 +128,7 @@ class RecoveryService
             $mail = MailRequestPasswordUpdate::create($this->application, $receiver);
             $mail->setLogin($user->getLogin());
             $mail->setButtonUrl($url);
-            $mail->setExpiration(new \DateTime('+1 day'));
+            $mail->setExpiration($token->getExpiration());
 
             $this->mailer->deliver($mail);
         }

--- a/lib/Alchemy/Phrasea/Model/Manipulator/TokenManipulator.php
+++ b/lib/Alchemy/Phrasea/Model/Manipulator/TokenManipulator.php
@@ -220,7 +220,7 @@ class TokenManipulator implements ManipulatorInterface
      */
     public function createResetPasswordToken(User $user)
     {
-        return $this->create($user, self::TYPE_PASSWORD, new DateTime('+1 day'));
+        return $this->create($user, self::TYPE_PASSWORD, new DateTime('+3 day'));
     }
 
     /**

--- a/tests/Alchemy/Tests/Phrasea/Model/Manipulator/TokenManipulatorTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Model/Manipulator/TokenManipulatorTest.php
@@ -146,7 +146,7 @@ class TokenManipulatorTest extends \PhraseanetTestCase
         $this->assertNull($token->getData());
         $this->assertSame(self::$DI['user'], $token->getUser());
         $this->assertSame(TokenManipulator::TYPE_PASSWORD, $token->getType());
-        $this->assertDateNear('+1 day', $token->getExpiration());
+        $this->assertDateNear('+3 day', $token->getExpiration());
     }
 
     public function testUpdate()


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3350: Password renewal and creation - link send by email - token TTL - token table of applicationBox
  - default renewal ttl to 72 hours
