### PR TITLE
PHRAS-3364 explode compose file

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,7 @@
 
+# For dev purpose COMPOSE_FILE=docker-compose.yml:docker-compose.db.yml:docker-compose.mailhog.yml:docker-compose.override.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.db.yml:docker-compose.mailhog.yml
+
 # Registry from where you pull Docker images
 PHRASEANET_DOCKER_REGISTRY=local
 

--- a/.env
+++ b/.env
@@ -49,6 +49,7 @@ SERVER_NAME=phraseanet-docker
 
 # Mysql max allowed packet
 MYSQL_MAX_ALLOWED_PACKET=16M
+COMPOSE_FILE=docker-compose.yml:docker-compose.db.yml:docker-compose.mailhog.yml
 
 # --------------- PHRASEANET CONFIGURATION --------------------
 

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,12 @@
+version: "3.4"
+
+services: 
+  db:
+    image: $PHRASEANET_DOCKER_REGISTRY/phraseanet-db:$PHRASEANET_DOCKER_TAG
+    build: ./docker/db
+    restart: on-failure
+    environment:
+    - MYSQL_ROOT_PASSWORD
+    - MYSQL_MAX_ALLOWED_PACKET
+    volumes:
+    - ${PHRASEANET_DB_DIR}:/var/lib/mysql

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -10,3 +10,5 @@ services:
     - MYSQL_MAX_ALLOWED_PACKET
     volumes:
     - ${PHRASEANET_DB_DIR}:/var/lib/mysql
+    networks:
+      - internal

--- a/docker-compose.mailhog.yml
+++ b/docker-compose.mailhog.yml
@@ -1,0 +1,8 @@
+version: "3.4"
+
+services:
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+    - 1025:1025
+    - 8025:8025

--- a/docker-compose.mailhog.yml
+++ b/docker-compose.mailhog.yml
@@ -1,8 +1,10 @@
 version: "3.4"
 
 services:
-  mailhog:
+   mailhog:
     image: mailhog/mailhog
     ports:
     - 1025:1025
     - 8025:8025
+    networks:
+      - internal


### PR DESCRIPTION
## Changelog
### Changed
  - MariaDb and Mailhog container are moved in severals docker-compose file.
  - You can compose your stack by dealing with COMPOSE_FILE env
 
eg :
 For dev purpose 
```
COMPOSE_FILE=docker-compose.yml:docker-compose.db.yml:docker-compose.mailhog.yml:docker- 
 compose.override.yml
```
 For test

`COMPOSE_FILE=docker-compose.yml:docker-compose.db.yml:docker-compose.mailhog.yml`

Down your actual stack before using this pr. 