### PR TITLE
PHRAS-3389_use-only-conceptpaths-from-selected-dbs_MASTER

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -4,7 +4,7 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryHelper;
-use Alchemy\Phrasea\SearchEngine\Elastic\Structure\ValueChecker;
+use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Term;
 
 class TextNode extends AbstractTermNode implements ContextAbleInterface
@@ -39,14 +39,19 @@ class TextNode extends AbstractTermNode implements ContextAbleInterface
     public function buildQuery(QueryContext $context)
     {
         $query_builder = function (array $fields) use ($context) {
+            /** @var Field[] $fields */
             // Full text
             $index_fields = [];
-            foreach (ValueChecker::filterByValueCompatibility($fields, $this->text) as $field) {
+            $th_fields = [];
+            foreach ($fields as $field) {
                 foreach ($context->localizeField($field) as $f) {
                     $index_fields[] = $f;
                 }
                 foreach ($context->truncationField($field) as $f) {
                     $index_fields[] = $f;
+                }
+                if($field->hasConceptInference()) {
+                    $th_fields[] = $field;
                 }
             }
             if (!$index_fields) {
@@ -62,7 +67,7 @@ class TextNode extends AbstractTermNode implements ContextAbleInterface
                 ]
             ];
             // Thesaurus
-            $concept_queries = $this->buildConceptQueries($fields);
+            $concept_queries = $this->buildConceptQueries($th_fields);
             foreach ($concept_queries as $concept_query) {
                 $query = QueryHelper::applyBooleanClause($query, 'should', $concept_query);
             }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -11,29 +11,27 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic;
 
-use Alchemy\Phrasea\Collection\Reference\CollectionReference;
+use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Exception\LogicException;
+use Alchemy\Phrasea\Exception\RuntimeException;
+use Alchemy\Phrasea\Model\Entities\FeedEntry;
 use Alchemy\Phrasea\SearchEngine\Elastic\Indexer\RecordIndexer;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\AggregationHelper;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\FacetsResponse;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryCompiler;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContextFactory;
-use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field AS ESField;
+use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field as ESField;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Flag;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Structure;
 use Alchemy\Phrasea\SearchEngine\SearchEngineInterface;
 use Alchemy\Phrasea\SearchEngine\SearchEngineOptions;
 use Alchemy\Phrasea\SearchEngine\SearchEngineResult;
-use Alchemy\Phrasea\Exception\RuntimeException;
-use Alchemy\Phrasea\SearchEngine\SearchEngineStructure;
 use Alchemy\Phrasea\Utilities\Stopwatch;
 use Closure;
-use Doctrine\Common\Collections\ArrayCollection;
-use Alchemy\Phrasea\Model\Entities\FeedEntry;
-use Alchemy\Phrasea\Application;
 use databox_field;
+use Doctrine\Common\Collections\ArrayCollection;
 use Elasticsearch\Client;
 
 class ElasticSearchEngine implements SearchEngineInterface
@@ -284,9 +282,8 @@ class ElasticSearchEngine implements SearchEngineInterface
     /**
      * {@inheritdoc}
      */
-    public function query($queryText, SearchEngineOptions $options = null)
+    public function query($queryText, SearchEngineOptions $options)
     {
-        $options = $options ?: new SearchEngineOptions();
         $context = $this->context_factory->createContext($options);
 
         /** @var QueryCompiler $query_compiler */

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/ThesaurusHydrator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/ThesaurusHydrator.php
@@ -94,7 +94,7 @@ class ThesaurusHydrator implements HydratorInterface
         if(empty($terms)) {
             return;
         }
-        $bulk = $this->thesaurus->findConceptsBulk($terms, [$sbid], null, $filters, true);
+        $bulk = $this->thesaurus->findConceptsBulk($terms, null, $filters, true);
 
         foreach ($bulk as $offset => $item_concepts) {
             $name = $field_names[$offset];

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/ThesaurusHydrator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/Record/Hydrator/ThesaurusHydrator.php
@@ -12,15 +12,12 @@
 namespace Alchemy\Phrasea\SearchEngine\Elastic\Indexer\Record\Hydrator;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Exception\Exception;
-use Alchemy\Phrasea\SearchEngine\Elastic\RecordHelper;
+use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\CandidateTerms;
-use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Filter;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Term;
-use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Structure;
-use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 
 class ThesaurusHydrator implements HydratorInterface
 {
@@ -64,12 +61,14 @@ class ThesaurusHydrator implements HydratorInterface
             throw new Exception('Expected a record with the "databox_id" key set.');
         }
 
+        $sbid = $record['databox_id'];
+
         $values = array();
         $terms = array();
         $filters = array();
         $field_names = array();
         /** @var Field[] $dbFields */
-        $dbFields = $this->structure->getAllFieldsByDatabox($record['databox_id']);
+        $dbFields = $this->structure->getAllFieldsByDatabox($sbid);
         foreach ($fields as $name => $field) {
             if(!array_key_exists($name, $dbFields) || !$dbFields[$name]->get_generate_cterms()) {
                 continue;
@@ -82,8 +81,8 @@ class ThesaurusHydrator implements HydratorInterface
                 // Concepts are databox's specific, but when no root concepts are
                 // given we need to make sure we only match in the right databox.
                 $filter = $root_concepts
-                    ? Filter::childOfConcepts($record['databox_id'], $root_concepts)
-                    : Filter::byDatabox($record['databox_id']);
+                    ? Filter::childOfConcepts($sbid, $root_concepts)
+                    : Filter::byDatabox($sbid);
                 foreach ($field_values as $value) {
                     $values[] = $value;
                     $terms[] = Term::parse($value);
@@ -95,7 +94,7 @@ class ThesaurusHydrator implements HydratorInterface
         if(empty($terms)) {
             return;
         }
-        $bulk = $this->thesaurus->findConceptsBulk($terms, null, $filters, true);
+        $bulk = $this->thesaurus->findConceptsBulk($terms, [$sbid], null, $filters, true);
 
         foreach ($bulk as $offset => $item_concepts) {
             $name = $field_names[$offset];

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryCompiler.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryCompiler.php
@@ -46,7 +46,8 @@ class QueryCompiler
         // TODO We must restrict thesaurus matching for IN queries, and only
         // search in each field's root concepts.
         $nodes = $query->getTermNodes();
-        $concepts = $this->thesaurus->findConceptsBulk($nodes, $context->getDataboxes());
+        $filter = Thesaurus\Filter::byDataboxes($context->getDataboxes());
+        $concepts = $this->thesaurus->findConceptsBulk($nodes, null, $filter, false);
 
         foreach ($concepts as $index => $termConcepts) {
             $node = $nodes[$index];

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryCompiler.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryCompiler.php
@@ -32,17 +32,21 @@ class QueryCompiler
     public function compile($string, QueryContext $context)
     {
         $query = $this->parse($string);
-        $this->injectThesaurusConcepts($query);
+        $this->injectThesaurusConcepts($query, $context);
 
         return $query->build($context);
     }
 
-    private function injectThesaurusConcepts(Query $query)
+    /**
+     * @param Query $query
+     * @param QueryContext $context
+     */
+    private function injectThesaurusConcepts(Query $query, $context)
     {
         // TODO We must restrict thesaurus matching for IN queries, and only
         // search in each field's root concepts.
         $nodes = $query->getTermNodes();
-        $concepts = $this->thesaurus->findConceptsBulk($nodes);
+        $concepts = $this->thesaurus->findConceptsBulk($nodes, $context->getDataboxes());
 
         foreach ($concepts as $index => $termConcepts) {
             $node = $nodes[$index];

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryContext.php
@@ -2,12 +2,11 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic\Search;
 
-use Alchemy\Phrasea\SearchEngine\Elastic\Exception\QueryException;
-use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Field as ASTField;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Flag;
+use Alchemy\Phrasea\SearchEngine\Elastic\Exception\QueryException;
+use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
+use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Structure;
 use Alchemy\Phrasea\SearchEngine\SearchEngineOptions;
 
@@ -41,6 +40,11 @@ class QueryContext
         $this->queryLocale = $queryLocale;
         $this->fields = $fields;
         $this->options = $options;
+    }
+
+    public function getDataboxes()
+    {
+        return $this->structure->getDataboxes();
     }
 
     public function narrowToFields(array $fields)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Field.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Field.php
@@ -49,6 +49,8 @@ class Field implements Typed
 
     private $used_by_collections;
 
+    private $used_by_databoxes;
+
     public static function createFromLegacyField(databox_field $field)
     {
         $type = self::getTypeFromLegacy($field);
@@ -75,7 +77,8 @@ class Field implements Typed
             'facet' => $facet,
             'thesaurus_roots' => $roots,
             'generate_cterms' => $field->get_generate_cterms(),
-            'used_by_collections' => $databox->get_collection_unique_ids()
+            'used_by_collections' => $databox->get_collection_unique_ids(),
+            'used_by_databoxes' => [$databox->get_sbas_id()]
         ]);
     }
 
@@ -107,6 +110,7 @@ class Field implements Typed
             $this->thesaurus_roots = \igorw\get_in($options, ['thesaurus_roots'], null);
             $this->generate_cterms = \igorw\get_in($options, ['generate_cterms'], false);
             $this->used_by_collections = \igorw\get_in($options, ['used_by_collections'], []);
+            $this->used_by_databoxes = \igorw\get_in($options, ['used_by_databoxes'], []);
         }
         else {
             // todo: this is faster code, but need to fix unit-tests to pass all options
@@ -117,6 +121,7 @@ class Field implements Typed
             $this->thesaurus_roots = $options['thesaurus_roots'];
             $this->generate_cterms = $options['generate_cterms'];
             $this->used_by_collections = $options['used_by_collections'];
+            $this->used_by_databoxes = $options['used_by_databoxes'];
         }
     }
 
@@ -129,7 +134,8 @@ class Field implements Typed
             'facet' => $this->facet,
             'thesaurus_roots' => $this->thesaurus_roots,
             'generate_cterms' => $this->generate_cterms,
-            'used_by_collections' => $this->used_by_collections
+            'used_by_collections' => $this->used_by_collections,
+            'used_by_databoxes' => $this->used_by_databoxes
         ]);
     }
 
@@ -166,6 +172,11 @@ class Field implements Typed
     public function getDependantCollections()
     {
         return $this->used_by_collections;
+    }
+
+    public function getDependantDataboxes()
+    {
+        return $this->used_by_databoxes;
     }
 
     public function isSearchable()
@@ -255,9 +266,20 @@ class Field implements Typed
             )
         );
 
+        $used_by_databoxes = array_values(
+            array_unique(
+                array_merge(
+                    $this->used_by_databoxes,
+                    $other->used_by_databoxes
+                ),
+                SORT_REGULAR
+            )
+        );
+
         return $this->withOptions([
             'thesaurus_roots' => $thesaurus_roots,
-            'used_by_collections' => $used_by_collections
+            'used_by_collections' => $used_by_collections,
+            'used_by_databoxes' => $used_by_databoxes
         ]);
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/GlobalStructure.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/GlobalStructure.php
@@ -98,6 +98,11 @@ final class GlobalStructure implements Structure
         }
     }
 
+    public function getDataboxes()
+    {
+        return array_keys($this->fieldsByDatabox);
+    }
+
     /**
      * @return Field[]
      */

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/LimitedStructure.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/LimitedStructure.php
@@ -32,6 +32,11 @@ final class LimitedStructure implements Structure
         $this->search_options = $search_options;
     }
 
+    public function getDataboxes()
+    {
+        return array_keys($this->search_options->getCollectionsReferencesByDatabox());
+    }
+
     public function getAllFields()
     {
         return $this->limit($this->structure->getAllFields());
@@ -39,7 +44,8 @@ final class LimitedStructure implements Structure
 
     public function getUnrestrictedFields()
     {
-        return $this->structure->getUnrestrictedFields();
+        // return $this->structure->getUnrestrictedFields();
+        return $this->limit($this->structure->getUnrestrictedFields());
     }
 
     public function getPrivateFields()
@@ -93,7 +99,7 @@ final class LimitedStructure implements Structure
         return $this->structure->getMetadataTagByName($name);
     }
 
-    private function limit(array $fields)
+    private function old_limit(array $fields)
     {
         $allowed_collections = $this->allowedCollections();
         // Filter private field collections (base_id) on which access is restricted.
@@ -101,6 +107,27 @@ final class LimitedStructure implements Structure
         foreach ($fields as $name => $field) {
             if ($field->isPrivate()) {
                 $field = $this->limitField($field, $allowed_collections);
+                // Private fields without collections can't be ever visible, we skip them
+                if (!$field->getDependantCollections()) {
+                    continue;
+                }
+            }
+            $limited_fields[$name] = $field;
+        }
+        return $limited_fields;
+    }
+
+    private function limit(array $fields)
+    {
+        $allowed_collections = $this->allowedCollections();
+        // Filter private field collections (base_id) on which access is restricted.
+        $limited_fields = [];
+        foreach ($fields as $name => $field) {
+            $field = $this->limitField($field, $allowed_collections);
+            if(empty($field->getDependantCollections())) {
+                continue;
+            }
+            if ($field->isPrivate()) {
                 // Private fields without collections can't be ever visible, we skip them
                 if (!$field->getDependantCollections()) {
                     continue;

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Structure.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Structure/Structure.php
@@ -13,6 +13,11 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\Structure;
 interface Structure
 {
     /**
+     * @return mixed
+     */
+    public function getDataboxes();
+
+    /**
      * @return Field[]
      */
     public function getAllFields();

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus.php
@@ -45,7 +45,7 @@ class Thesaurus
      * @param  boolean              $strict Strict mode matching
      * @return Concept[][]                  List of matching concepts for each term
      */
-    public function findConceptsBulk(array $terms, $lang = null, $filter = null, $strict = false)
+    public function findConceptsBulk(array $terms, array $databoxIds, $lang = null, $filter = null, $strict = false)
     {
         $this->logger->debug(sprintf('Finding linked concepts in bulk for %d terms', count($terms)));
 
@@ -61,7 +61,7 @@ class Thesaurus
         $concepts = array();
         foreach ($terms as $index => $term) {
             $strict |= ($term instanceof AST\TermNode);      // a "term" node is [strict group of words]
-            $concepts[] = $this->findConcepts($term, $lang, $filters[$index], $strict);
+            $concepts[] = $this->findConcepts($term, $databoxIds, $lang, $filters[$index], $strict);
         }
 
         return $concepts;
@@ -79,16 +79,16 @@ class Thesaurus
      * @param  boolean     $strict Whether to enable strict search or not
      * @return Concept[]           Matching concepts
      */
-    public function findConcepts($term, $lang = null, Filter $filter = null, $strict = false)
+    public function findConcepts($term, array $databoxIds, $lang = null, Filter $filter = null, $strict = false)
     {
         return $strict ?
-            $this->findConceptsStrict($term, $lang, $filter)
+            $this->findConceptsStrict($term, $databoxIds, $lang, $filter)
             :
-            $this->findConceptsFuzzy($term, $lang, $filter)
+            $this->findConceptsFuzzy($term, $databoxIds, $lang, $filter)
             ;
     }
 
-    private function findConceptsStrict($term, $lang = null, Filter $filter = null)
+    private function findConceptsStrict($term, array $databoxIds, $lang = null, Filter $filter = null)
     {
         if (!($term instanceof TermInterface)) {
             $term = new Term($term);
@@ -126,6 +126,24 @@ class Thesaurus
                 ]
             ];
         }
+
+        if(count($databoxIds) > 0) {
+            if(count($databoxIds) == 1) {
+                $filters[] = [
+                    'term' => [
+                        'databox_id' => $databoxIds[0]
+                    ]
+                ];
+            }
+            else {
+                $filters[] = [
+                    'terms' => [
+                        'databox_id' => $databoxIds
+                    ]
+                ];
+            }
+        }
+
         if ($lang) {
             $filters[] = [
                 'term' => [
@@ -133,6 +151,7 @@ class Thesaurus
                 ]
             ];
         }
+
         if ($filter) {
             $filters = array_merge($filters, $filter->getQueryFilters());
         }
@@ -184,12 +203,18 @@ class Thesaurus
 
         // Extract concept paths from response
         $concepts = array();
-        $buckets = \igorw\get_in($response, ['aggregations', 'dedup', 'buckets'], []);
+        $db_buckets = \igorw\get_in($response, ['aggregations', 'db', 'buckets'], []);
         $keys = array();
-        foreach ($buckets as $bucket) {
-            if (isset($bucket['key'])) {
-                $keys[] = $bucket['key'];
-                $concepts[] = new Concept($bucket['key']);
+        foreach ($db_buckets as $db_bucket) {
+            if (isset($db_bucket['key'])) {
+                $db = $db_bucket['key'];
+                $cp_buckets = \igorw\get_in($db_bucket, ['cp', 'buckets'], []);
+                foreach ($cp_buckets as $cp_bucket) {
+                    if (isset($cp_bucket['key'])) {
+                        $keys[] = $cp_bucket['key'];
+                        $concepts[] = new Concept($db, $cp_bucket['key']);
+                    }
+                }
             }
         }
 
@@ -200,7 +225,7 @@ class Thesaurus
         return $concepts;
     }
 
-    private function findConceptsFuzzy($term, $lang = null, Filter $filter = null)
+    private function findConceptsFuzzy($term, array $databoxIds, $lang = null, Filter $filter = null)
     {
         if (!($term instanceof TermInterface)) {
             $term = new Term($term);
@@ -236,6 +261,29 @@ class Thesaurus
             $query['bool']['must'][1] = $context_query;
         }
 
+        if(count($databoxIds) > 0) {
+            if(count($databoxIds) == 1) {
+                $query = self::applyQueryFilter(
+                    $query,
+                    [
+                        'term' => [
+                            'databox_id' => $databoxIds[0]
+                        ]
+                    ]
+                );
+            }
+            else {
+                $query = self::applyQueryFilter(
+                    $query,
+                    [
+                        'terms' => [
+                            'databox_id' => $databoxIds
+                        ]
+                    ]
+                );
+            }
+        }
+
         if ($lang) {
             $lang_filter = array();
             $lang_filter['term']['lang'] = $lang;
@@ -246,36 +294,55 @@ class Thesaurus
             $this->logger->debug('Using filter', array('filter' => Filter::dump($filter)));
             $query = self::applyQueryFilter($query, $filter->getQueryFilter());
         }
+        $params = [
+            'index' => $this->options->getIndexName(),
+            'type'  => TermIndexer::TYPE_NAME,
+            'body'  => [
+                'query' => $query,
+                'aggs'  => [
+                    // Path deduplication
+                    'db' => [                           // databox_id
+                        'terms' => [
+                            'field' => 'databox_id'
+                        ],
+                        'aggs'  => [
+                            // Path deduplication
+                            'cp' => [                   // concept_path
+                                'terms' => [
+                                    'field' => 'path.raw'
+                                ]
+                            ]
+                        ],
 
-        // Path deduplication
-        $aggs = array();
-        $aggs['dedup']['terms']['field'] = 'path.raw';
-
-        // Search request
-        $params = array();
-        $params['index'] = $this->options->getIndexName();
-        $params['type'] = TermIndexer::TYPE_NAME;
-        $params['body']['query'] = $query;
-        $params['body']['aggs'] = $aggs;
-        // Arbitrary score low limit, we need find a more granular way to remove
-        // inexact concepts.
-        // We also need to disable TF/IDF on terms, and try to boost score only
-        // when the search match nearly all tokens of term's value field.
-        $params['body']['min_score'] = $this->options->getMinScore();
-        // No need to get any hits since we extract data from aggs
-        $params['body']['size'] = 0;
+                    ]
+                ],
+                // Arbitrary score low limit, we need find a more granular way to remove
+                // inexact concepts.
+                // We also need to disable TF/IDF on terms, and try to boost score only
+                // when the search match nearly all tokens of term's value field.
+                'min_score' => $this->options->getMinScore(),
+                // No need to get any hits since we extract data from aggs
+                'size' => 0
+            ]
+        ];
 
         $this->logger->debug('Sending search', $params['body']);
         $response = $this->client->search($params);
 
         // Extract concept paths from response
-        $concepts = array();
-        $buckets = \igorw\get_in($response, ['aggregations', 'dedup', 'buckets'], []);
+        $concepts = [];
+        $db_buckets = \igorw\get_in($response, ['aggregations', 'db', 'buckets'], []);
         $keys = array();
-        foreach ($buckets as $bucket) {
-            if (isset($bucket['key'])) {
-                $keys[] = $bucket['key'];
-                $concepts[] = new Concept($bucket['key']);
+        foreach ($db_buckets as $db_bucket) {
+            if (isset($db_bucket['key'])) {
+                $db = $db_bucket['key'];
+                $cp_buckets = \igorw\get_in($db_bucket, ['cp', 'buckets'], []);
+                foreach ($cp_buckets as $cp_bucket) {
+                    if (isset($cp_bucket['key'])) {
+                        $keys[] = $cp_bucket['key'];
+                        $concepts[] = new Concept($db, $cp_bucket['key']);
+                    }
+                }
             }
         }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Concept.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Concept.php
@@ -13,11 +13,18 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus;
 
 class Concept
 {
+    private $databox_id;
     private $path;
 
-    public function __construct($path)
+    public function __construct($databox_id, $path)
     {
+        $this->databox_id = $databox_id;
         $this->path = (string) $path;
+    }
+
+    public function getDataboxId()
+    {
+        return $this->databox_id;
     }
 
     public function getPath()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Filter.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Filter.php
@@ -13,17 +13,22 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus;
 
 class Filter
 {
-    private $databox_id;
+    private $databox_ids;
     private $paths;
 
     public static function childOfConcepts($databox_id, array $concepts)
     {
-        return new self($databox_id, Concept::toPathArray($concepts));
+        return new self([$databox_id], Concept::toPathArray($concepts));
     }
 
     public static function byDatabox($databox_id)
     {
-        return new self($databox_id, []);
+        return new self([$databox_id], []);
+    }
+
+    public static function byDataboxes($databox_ids)
+    {
+        return new self($databox_ids, []);
     }
 
     public static function dump(Filter $filter)
@@ -31,15 +36,19 @@ class Filter
         return $filter->getQueryFilter();   // perfect as an array
     }
 
-    private function __construct($databox_id, array $paths)
+    private function __construct($databox_ids, array $paths)
     {
-        $this->databox_id = $databox_id;
+        $this->databox_ids = $databox_ids;
         $this->paths = $paths;
     }
 
     public function getQueryFilter()
     {
-        $filter = ['terms'=>['databox_id'=>[$this->databox_id]]];
+        $filter = [
+            'terms' => [
+                'databox_id' => $this->databox_ids
+            ]
+        ];
         if(count($this->paths) > 0) {
             $filter['terms']['path'] = $this->paths;
         }
@@ -51,8 +60,8 @@ class Filter
     {
         $filters = [
             [
-                'term' => [
-                    'databox_id' => $this->databox_id
+                'terms' => [
+                    'databox_id' => $this->databox_ids
                 ]
             ]
         ];

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Helper.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Helper.php
@@ -33,52 +33,27 @@ class Helper
 
         /** @var DOMElement $node */
         foreach ($nodes as $node) {
-            if(1) {
-                $me_and_parents = array_merge([$node], self::getElementAncestors($node));
+            $me_and_parents = array_merge([$node], self::getElementAncestors($node));
 
-                $path_segments = [];
+            $path_segments = [];
 
-                foreach ($me_and_parents as $me_or_parent) {
-                    if (!Navigator::isConcept($me_or_parent)) {
-                        // Silently skips invalid targeted nodes
-                        break;
-                    }
-
-                    $path_segments[] = self::conceptPathSegment($me_or_parent);
+            foreach ($me_and_parents as $me_or_parent) {
+                if (!Navigator::isConcept($me_or_parent)) {
+                    // Silently skips invalid targeted nodes
+                    break;
                 }
 
-                // Concept paths are have databox identifier at root level
-                $concepts[] = new Concept(sprintf(
+                $path_segments[] = self::conceptPathSegment($me_or_parent);
+            }
+
+            // Concept paths are have databox identifier at root level
+            $concepts[] = new Concept(
+                $databox->get_sbas_id(),
+                sprintf(
                     '/%d/%s',
                     $databox->get_sbas_id(),
                     implode('/', array_reverse($path_segments))
                 ));
-            }
-            else {
-                $path = '';
-                // go up thru parents
-                while ($node) {
-                    $v = null;
-                    for ($n = $node->firstChild; $n; $n = $n->nextSibling) {
-                        if ($n->nodeType === XML_ELEMENT_NODE && $n->nodeName === 'sy') {
-                            if ($v === null) {
-                                $v = $n->getAttribute('v');
-                                continue;
-                            }
-                            if ($n->getAttribute('lng') === 'en') {
-                                $v = $n->getAttribute('v');
-                                break;
-                            }
-                        }
-                    }
-                    if ($v !== null) {
-                        $path = '/' . $v . $path;
-                    }
-                    $node = $node->parentNode;
-                }
-                $path = '/' . $databox->get_sbas_id() . $path;
-                $concepts[] = new Concept($path);
-            }
         }
 
         return $concepts;

--- a/lib/Alchemy/Phrasea/SearchEngine/SearchEngineInterface.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/SearchEngineInterface.php
@@ -167,7 +167,7 @@ interface SearchEngineInterface
      *
      * @return SearchEngineResult
      */
-    public function query($query, SearchEngineOptions $options = null);
+    public function query($query, SearchEngineOptions $options);
 
     /**
      * Return an array of suggestions corresponding to the last word of the

--- a/lib/Alchemy/Phrasea/SearchEngine/SearchEngineOptions.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/SearchEngineOptions.php
@@ -14,13 +14,12 @@ namespace Alchemy\Phrasea\SearchEngine;
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Authentication\ACLProvider;
 use Alchemy\Phrasea\Authentication\Authenticator;
-use Alchemy\Phrasea\Collection\CollectionRepository;
 use Alchemy\Phrasea\Collection\Reference\CollectionReference;
-use Alchemy\Phrasea\Collection\Reference\DbalCollectionReferenceRepository;
+use Alchemy\Phrasea\Collection\Reference\CollectionReferenceRepository;
 use Assert\Assertion;
+use databox_descriptionStructure;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use databox_descriptionStructure;
 
 class SearchEngineOptions
 {
@@ -41,7 +40,7 @@ class SearchEngineOptions
     const SORT_MODE_ASC = 'asc';
     const SORT_MODE_DESC = 'desc';
 
-    /** @var DbalCollectionReferenceRepository $dbalCollectionReferenceRepository */
+    /** @var CollectionReferenceRepository */
     private $collectionReferenceRepository;
 
     /** @var string */
@@ -455,6 +454,11 @@ class SearchEngineOptions
         return $this->date_fields;
     }
 
+    public function __construct(CollectionReferenceRepository $collectionReferenceRepository)
+    {
+        $this->collectionReferenceRepository = $collectionReferenceRepository;
+    }
+
     /**
      * Creates options based on a Symfony Request object
      *
@@ -469,9 +473,7 @@ class SearchEngineOptions
         $authenticator = $app->getAuthenticator();
         $isAuthenticated = $authenticator->isAuthenticated();
 
-        $options = new static();
-
-        $options->collectionReferenceRepository = $app['repo.collection-references'];
+        $options = new static($app['repo.collection-references']);
 
         $options->disallowBusinessFields();
         $options->setLocale($app['locale']);
@@ -713,7 +715,7 @@ class SearchEngineOptions
             throw new \InvalidArgumentException('SearchEngineOptions data are corrupted');
         }
 
-        $options = new static();
+        $options = new static($app['repo.collection-references']);
         $options->disallowBusinessFields();
 
         $methods = self::getHydrateMethods($app);

--- a/lib/classes/record/preview.php
+++ b/lib/classes/record/preview.php
@@ -93,7 +93,7 @@ class record_preview extends record_adapter
                     throw new \LogicException('Search Engine should be provided');
                 }
                 if (!$options) {
-                    $options = new SearchEngineOptions();
+                    $options = new SearchEngineOptions($app['repo.collection-references']);
                 }
                 $options->setFirstResult($pos);
                 $options->setMaxResults(1);
@@ -197,7 +197,7 @@ class record_preview extends record_adapter
 
         switch ($this->env) {
             case 'RESULT':
-                $options = $this->options ?: new SearchEngineOptions();
+                $options = $this->options ?: new SearchEngineOptions($this->app['repo.collection-references']);
                 $options->setFirstResult(($this->pos - 3) < 0 ? 0 : ($this->pos - 3));
                 $options->setMaxResults(56);
 

--- a/tests/Alchemy/Tests/Phrasea/Controller/Prod/QueryTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Prod/QueryTest.php
@@ -3,7 +3,6 @@
 namespace Alchemy\Tests\Phrasea\Controller\Prod;
 
 use Alchemy\Phrasea\SearchEngine\SearchEngineOptions;
-use Prophecy\Argument;
 
 /**
  * @group functional
@@ -47,7 +46,7 @@ class QueryTest extends \PhraseanetAuthenticatedWebTestCase
         $app = $this->mockElasticsearchResult(self::$DI['record_2']);
         $this->authenticate($app);
 
-        $options = new SearchEngineOptions();
+        $options = new SearchEngineOptions(self::$DI['app']['repo.collection-references']);
         $searchableBasesIds = $app->getAclForUser($app->getAuthenticatedUser())->getSearchableBasesIds();
         $options->onBasesIds($searchableBasesIds);
         $serializedOptions = $options->serialize();

--- a/tests/Alchemy/Tests/Phrasea/Controller/Prod/RecordsTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Prod/RecordsTest.php
@@ -3,9 +3,9 @@
 namespace Alchemy\Tests\Phrasea\Controller\Prod;
 
 use Alchemy\Phrasea\Border\File;
-use Alchemy\Phrasea\SearchEngine\SearchEngineOptions;
 use Alchemy\Phrasea\Model\Entities\Basket;
 use Alchemy\Phrasea\Model\Entities\BasketElement;
+use Alchemy\Phrasea\SearchEngine\SearchEngineOptions;
 
 /**
  * @group functional
@@ -101,7 +101,7 @@ class RecordsTest extends \PhraseanetAuthenticatedWebTestCase
         $app = $this->mockElasticsearchResult(self::$DI['record_1']);
         $this->authenticate($app);
 
-        $options = new SearchEngineOptions();
+        $options = new SearchEngineOptions(self::$DI['app']['repo.collection-references']);
         $acl = $app->getAclForUser($app->getAuthenticatedUser());
         $searchableBasesIds = $acl->getSearchableBasesIds();
         $options->onBasesIds($searchableBasesIds);

--- a/tests/Alchemy/Tests/Phrasea/Controller/Prod/TooltipTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Controller/Prod/TooltipTest.php
@@ -84,7 +84,7 @@ class TooltipTest extends \PhraseanetAuthenticatedWebTestCase
         ];
 
         foreach ($routes as $route) {
-            $option = new SearchEngineOptions();
+            $option = new SearchEngineOptions(self::$DI['app']['repo.collection-references']);
             $crawler = self::$DI['client']->request('POST', $route, ['options_serial' => $option->serialize()]);
 
             $this->assertTrue(self::$DI['client']->getResponse()->isOk());

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/QuotedTextNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/QuotedTextNodeTest.php
@@ -52,7 +52,8 @@ class QuotedTextNodeTest extends \PHPUnit_Framework_TestCase
         ]);
         $private_field = new Field('bar', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2, 3]
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [1]
         ]);
 
         $query_context = $this->prophesize(QueryContext::class);
@@ -96,9 +97,7 @@ class QuotedTextNodeTest extends \PHPUnit_Framework_TestCase
                                 "type": "phrase",
                                 "fields": [
                                     "private_caption.bar.fr",
-                                    "private_caption.bar.en",
-                                    "foo.fr",
-                                    "foo.en"
+                                    "private_caption.bar.en"
                                 ],
                                 "query": "baz",
                                 "lenient": true

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TermNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TermNodeTest.php
@@ -27,7 +27,13 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuild()
     {
-        $field = new Field('foo', FieldMapping::TYPE_STRING, ['private' => false]);
+        $field = new Field(
+            'foo',
+            FieldMapping::TYPE_STRING,
+            [
+                'private' => false,
+                'used_by_databoxes' => [1, 2]
+            ]);
         $query_context = $this->prophesize(QueryContext::class);
         $query_context
             ->getUnrestrictedFields()
@@ -81,10 +87,14 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuildWithPrivateFields()
     {
-        $public_field = new Field('foo', FieldMapping::TYPE_STRING, ['private' => false]);
+        $public_field = new Field('foo', FieldMapping::TYPE_STRING, [
+            'private' => false,
+             'used_by_databoxes' => [1, 2]
+       ]);
         $private_field = new Field('bar', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2, 3]
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [1, 2]
         ]);
 
         $query_context = $this->prophesize(QueryContext::class);
@@ -126,16 +136,14 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
                                 "should": [{
                                     "multi_match": {
                                         "fields": [
-                                            "concept_path.bar",
-                                            "concept_path.foo"
+                                            "concept_path.bar"
                                         ],
                                         "query": "/baz"
                                     }
                                 }, {
                                     "multi_match": {
                                         "fields": [
-                                            "concept_path.bar",
-                                            "concept_path.foo"
+                                            "concept_path.bar"
                                         ],
                                         "query": "/qux"
                                     }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TermNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TermNodeTest.php
@@ -5,7 +5,6 @@ namespace Alchemy\Tests\Phrasea\SearchEngine\AST;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Context;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\TermNode;
 use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
@@ -39,8 +38,8 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
 
         $node = new TermNode('bar');
         $node->setConcepts([
-            new Concept('/baz'),
-            new Concept('/qux'),
+            new Concept(1, '/baz'),
+            new Concept(2, '/qux'),
         ]);
         $query = $node->buildQuery($query_context->reveal());
 
@@ -98,8 +97,8 @@ class TermNodeTest extends \PHPUnit_Framework_TestCase
 
         $node = new TermNode('baz');
         $node->setConcepts([
-            new Concept('/baz'),
-            new Concept('/qux'),
+            new Concept(1, '/baz'),
+            new Concept(2, '/qux'),
         ]);
         $query = $node->buildQuery($query_context->reveal());
 

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
@@ -67,10 +67,14 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuildWithPrivateFields()
     {
-        $public_field = new Field('foo', FieldMapping::TYPE_STRING, ['private' => false]);
+        $public_field = new Field('foo', FieldMapping::TYPE_STRING, [
+            'private' => false,
+            'used_by_databoxes' => [1]
+        ]);
         $private_field = new Field('bar', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2, 3]
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [1]
         ]);
 
         $query_context = $this->prophesize(QueryContext::class);
@@ -117,9 +121,7 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
                             "multi_match": {
                                 "fields": [
                                     "private_caption.bar.fr",
-                                    "private_caption.bar.en",
-                                    "foo.fr",
-                                    "foo.en"
+                                    "private_caption.bar.en"
                                 ],
                                 "query": "baz",
                                 "type": "cross_fields",
@@ -137,7 +139,11 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuildWithConcepts()
     {
-        $field = new Field('foo', FieldMapping::TYPE_STRING, ['private' => false]);
+        $field = new Field('foo', FieldMapping::TYPE_STRING, [
+            'private' => false ,
+            'thesaurus_roots' => "/thesaurus/te[@id='T1']",
+            'used_by_databoxes' => [2]
+        ]);
         $query_context = $this->prophesize(QueryContext::class);
         $query_context->getUnrestrictedFields()->willReturn([$field]);
         $query_context->getPrivateFields()->willReturn([]);
@@ -177,7 +183,8 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
         $public_field = new Field('foo', FieldMapping::TYPE_STRING, ['private' => false]);
         $private_field = new Field('bar', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2, 3]
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [2]
         ]);
 
         $query_context = $this->prophesize(QueryContext::class);

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
@@ -5,7 +5,6 @@ namespace Alchemy\Tests\Phrasea\SearchEngine\AST;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\Context;
 use Alchemy\Phrasea\SearchEngine\Elastic\AST\TextNode;
 use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
@@ -147,7 +146,7 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
         $node = new TextNode('bar');
         $node->setConcepts([
-            new Concept('/qux'),
+            new Concept(2, '/qux'),
         ]);
         $query = $node->buildQuery($query_context->reveal());
 
@@ -203,7 +202,7 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
         $node = new TextNode('baz');
         $node->setConcepts([
-            new Concept('/qux'),
+            new Concept(2, '/qux'),
         ]);
         $query = $node->buildQuery($query_context->reveal());
 

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/AST/TextNodeTest.php
@@ -180,12 +180,17 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
     public function testQueryBuildWithPrivateFieldAndConcept()
     {
-        $public_field = new Field('foo', FieldMapping::TYPE_STRING, ['private' => false]);
+        $public_field = new Field('foo', FieldMapping::TYPE_STRING, [
+            'private' => false,
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [1],
+        ]);
         $private_field = new Field('bar', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2, 3],
-            'used_by_databoxes' => [2]
-        ]);
+            'used_by_collections' => [4, 5, 6],
+            'used_by_databoxes' => [2],
+            'thesaurus_roots' => "/thesaurus/te[@id='T1']",
+       ]);
 
         $query_context = $this->prophesize(QueryContext::class);
         $query_context
@@ -209,7 +214,7 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
 
         $node = new TextNode('baz');
         $node->setConcepts([
-            new Concept(2, '/qux'),
+            new Concept(2, '/2/qux'),
         ]);
         $query = $node->buildQuery($query_context->reveal());
 
@@ -224,17 +229,10 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
                         "lenient": true
                     }
                 }, {
-                    "multi_match": {
-                        "fields": [
-                            "concept_path.foo"
-                        ],
-                        "query": "\/qux"
-                    }
-                }, {
                     "filtered": {
                         "filter": {
                             "terms": {
-                                "base_id": [1, 2, 3]
+                                "base_id": [4, 5, 6]
                             }
                         },
                         "query": {
@@ -243,9 +241,7 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
                                     "multi_match": {
                                         "fields": [
                                             "private_caption.bar.fr",
-                                            "private_caption.bar.en",
-                                            "foo.fr",
-                                            "foo.en"
+                                            "private_caption.bar.en"
                                         ],
                                         "query": "baz",
                                         "type": "cross_fields",
@@ -255,10 +251,9 @@ class TextNodeTest extends \PHPUnit_Framework_TestCase
                                 }, {
                                     "multi_match": {
                                         "fields": [
-                                            "concept_path.bar",
-                                            "concept_path.foo"
+                                            "concept_path.bar"
                                         ],
-                                        "query": "/qux"
+                                        "query": "/2/qux"
                                     }
                                 }]
                             }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Search/AggregationHelperTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Search/AggregationHelperTest.php
@@ -17,7 +17,8 @@ class AggregationHelperTest extends \PHPUnit_Framework_TestCase
     {
         $field = new Field('foo', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2, 3]
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [1]
         ]);
         $agg = [
             'terms' => 'bar'

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineOptionsTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineOptionsTest.php
@@ -23,7 +23,7 @@ class SearchEngineOptionsTest extends \PhraseanetTestCase
         /** @var \collection $collection */
         $collection = $this->getCollection();
 
-        $options = new SearchEngineOptions($app);
+        $options = new SearchEngineOptions(self::$DI['app']['repo.collection-references']);
         $options->onBasesIds([$collection->get_base_id()]);
         $options->setRecordType(SearchEngineOptions::TYPE_ALL);
         $options->setSearchType(SearchEngineOptions::RECORD_RECORD);

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineResultTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/SearchEngineResultTest.php
@@ -3,9 +3,9 @@
 namespace Alchemy\Tests\Phrasea\SearchEngine;
 
 use Alchemy\Phrasea\SearchEngine\SearchEngineOptions;
-use Doctrine\Common\Collections\ArrayCollection;
 use Alchemy\Phrasea\SearchEngine\SearchEngineResult;
 use Alchemy\Phrasea\SearchEngine\SearchEngineSuggestion;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @group functional
@@ -18,7 +18,7 @@ class SearchEngineResultTest extends \PhraseanetTestCase
      */
     public function testBasic()
     {
-        $options = new SearchEngineOptions();
+        $options = new SearchEngineOptions(self::$DI['app']['repo.collection-references']);
         $results = new ArrayCollection([
                     self::$DI['record_2']
                 ]);
@@ -82,7 +82,7 @@ class SearchEngineResultTest extends \PhraseanetTestCase
 
     public function testWithOffsetStartAtZero()
     {
-        $options = new SearchEngineOptions();
+        $options = new SearchEngineOptions(self::$DI['app']['repo.collection-references']);
         $results = new ArrayCollection([
                     self::$DI['record_2']
                 ]);

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/FieldTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/FieldTest.php
@@ -3,9 +3,8 @@
 namespace Alchemy\Tests\Phrasea\SearchEngine\Structure;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
 
 /**
  * @group unit
@@ -87,8 +86,8 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 
     public function testMergeWithThesaurusRoots()
     {
-        $foo = new Concept('/foo');
-        $bar = new Concept('/bar');
+        $foo = new Concept(1, '/foo');
+        $bar = new Concept(2, '/bar');
         $field = new Field('foo', FieldMapping::TYPE_STRING);
         $other = new Field('foo', FieldMapping::TYPE_STRING, [
             'thesaurus_roots' => [$foo, $bar]
@@ -96,8 +95,8 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $merged = $field->mergeWith($other);
         $this->assertEquals([$foo, $bar], $merged->getThesaurusRoots());
 
-        $foo = new Concept('/foo');
-        $bar = new Concept('/bar');
+        $foo = new Concept(1, '/foo');
+        $bar = new Concept(2, '/bar');
         $field = new Field('foo', FieldMapping::TYPE_STRING, [
             'thesaurus_roots' => [$foo]
         ]);

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/FieldTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/FieldTest.php
@@ -14,8 +14,10 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 {
     public function testBasicMerge()
     {
-        $field = new Field('foo', FieldMapping::TYPE_STRING, ['used_by_collections' => ['1', '2']]);
-        $other = new Field('foo', FieldMapping::TYPE_STRING, ['used_by_collections' => ['3', '4']]);
+        $field = new Field('foo', FieldMapping::TYPE_STRING, ['used_by_collections' => ['1', '2'],
+                                                              'used_by_databoxes' => [1]]);
+        $other = new Field('foo', FieldMapping::TYPE_STRING, ['used_by_collections' => ['3', '4'],
+                                                              'used_by_databoxes' => [1]]);
         $merged = $field->mergeWith($other);
         $this->assertInstanceOf(Field::class, $merged);
         $this->assertNotSame($field, $merged);
@@ -110,10 +112,12 @@ class FieldTest extends \PHPUnit_Framework_TestCase
     public function testMergeWithDependantCollections()
     {
         $field = new Field('foo', FieldMapping::TYPE_STRING, [
-            'used_by_collections' => [1, 2]
+            'used_by_collections' => [1, 2],
+            'used_by_databoxes' => [1]
         ]);
         $other = new Field('foo', FieldMapping::TYPE_STRING, [
-            'used_by_collections' => [2, 3]
+            'used_by_collections' => [2, 3],
+            'used_by_databoxes' => [1]
         ]);
         $merged = $field->mergeWith($other);
         $this->assertEquals([1, 2, 3], $merged->getDependantCollections());

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/LimitedStructureTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/LimitedStructureTest.php
@@ -3,7 +3,6 @@
 namespace Alchemy\Tests\Phrasea\SearchEngine\Structure;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\LimitedStructure;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Structure;
@@ -17,36 +16,53 @@ class LimitedStructureTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetUnrestrictedFields()
     {
-        $field = new Field('foo', FieldMapping::TYPE_STRING);
+        $field = new Field('foo', FieldMapping::TYPE_STRING, [
+            'used_by_collections' => [1, 2, 3],
+            'used_by_databoxes' => [1],
+        ]);
         $wrapped = $this->prophesize(Structure::class);
         $wrapped
             ->getUnrestrictedFields()
             ->shouldBeCalled()
             ->willReturn(['foo' => $field]);
+
         $options = $this->prophesize(SearchEngineOptions::class);
+        $options
+            ->getBasesIds()
+            ->willReturn([1, 2, 3]);
+        $options
+            ->getBusinessFieldsOn()
+            ->willReturn([]);
+
         $structure = new LimitedStructure($wrapped->reveal(), $options->reveal());
 
         $s = $structure->getUnrestrictedFields();
 
-        $this->assertEquals(['foo' => $field], $structure->getUnrestrictedFields());
+        $this->assertEquals(['foo' => $field], $s);
     }
 
     public function testGet()
     {
         $wrapped = $this->prophesize(Structure::class);
-        $options = $this->prophesize(SearchEngineOptions::class);
-        $options->getBusinessFieldsOn()->willReturn([2]);
-        $structure = new LimitedStructure($wrapped->reveal(), $options->reveal());
-
         $wrapped->get('foo')
             ->shouldBeCalled()
             ->willReturn(
                 new Field('foo', FieldMapping::TYPE_STRING, [
+                    'private' => false,
                     'used_by_collections' => [1, 2, 3],
                     'used_by_databoxes' => [1]
                 ])
-            )
-        ;
+            );
+
+        $options = $this->prophesize(SearchEngineOptions::class);
+        $options
+            ->getBasesIds()
+            ->willReturn([2]);
+        $options
+            ->getBusinessFieldsOn()->willReturn([2]);
+
+        $structure = new LimitedStructure($wrapped->reveal(), $options->reveal());
+
         $this->assertEquals(
             new Field('foo', FieldMapping::TYPE_STRING, [
                 'used_by_collections' => [2],
@@ -62,7 +78,13 @@ class LimitedStructureTest extends \PHPUnit_Framework_TestCase
     public function testGetAllFields()
     {
         $options = $this->prophesize(SearchEngineOptions::class);
-        $options->getBusinessFieldsOn()->willReturn([1, 3]);
+        $options
+            ->getBasesIds()
+            ->willReturn([2]);
+        $options
+            ->getBusinessFieldsOn()
+            ->willReturn([1, 3]);
+
         $wrapped = $this->prophesize(Structure::class);
         $structure = new LimitedStructure($wrapped->reveal(), $options->reveal());
 
@@ -81,7 +103,7 @@ class LimitedStructureTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'foo' => new Field('foo', FieldMapping::TYPE_STRING, [
                 'private' => false,
-                'used_by_collections' => [1, 2, 3],
+                'used_by_collections' => [2],
                 'used_by_databoxes' => [1]
             ]),
             'bar' => new Field('bar', FieldMapping::TYPE_STRING, [

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/LimitedStructureTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/LimitedStructureTest.php
@@ -26,6 +26,8 @@ class LimitedStructureTest extends \PHPUnit_Framework_TestCase
         $options = $this->prophesize(SearchEngineOptions::class);
         $structure = new LimitedStructure($wrapped->reveal(), $options->reveal());
 
+        $s = $structure->getUnrestrictedFields();
+
         $this->assertEquals(['foo' => $field], $structure->getUnrestrictedFields());
     }
 
@@ -40,13 +42,15 @@ class LimitedStructureTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled()
             ->willReturn(
                 new Field('foo', FieldMapping::TYPE_STRING, [
-                    'used_by_collections' => [1, 2, 3]
+                    'used_by_collections' => [1, 2, 3],
+                    'used_by_databoxes' => [1]
                 ])
             )
         ;
         $this->assertEquals(
             new Field('foo', FieldMapping::TYPE_STRING, [
-                'used_by_collections' => [2]
+                'used_by_collections' => [2],
+                'used_by_databoxes' => [1]
             ]),
             $structure->get('foo')
         );
@@ -65,21 +69,25 @@ class LimitedStructureTest extends \PHPUnit_Framework_TestCase
         $wrapped->getAllFields()->willReturn([
             'foo' => new Field('foo', FieldMapping::TYPE_STRING, [
                 'private' => false,
-                'used_by_collections' => [1, 2, 3]
+                'used_by_collections' => [1, 2, 3],
+                'used_by_databoxes' => [1]
             ]),
             'bar' => new Field('bar', FieldMapping::TYPE_STRING, [
                 'private' => true,
-                'used_by_collections' => [1, 2, 3]
+                'used_by_collections' => [1, 2, 3],
+                'used_by_databoxes' => [1]
             ])
         ]);
         $this->assertEquals([
             'foo' => new Field('foo', FieldMapping::TYPE_STRING, [
                 'private' => false,
-                'used_by_collections' => [1, 2, 3]
+                'used_by_collections' => [1, 2, 3],
+                'used_by_databoxes' => [1]
             ]),
             'bar' => new Field('bar', FieldMapping::TYPE_STRING, [
                 'private' => true,
-                'used_by_collections' => [1, 3]
+                'used_by_collections' => [1, 3],
+                'used_by_databoxes' => [1]
             ])
         ], $structure->getAllFields());
     }

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
@@ -3,10 +3,9 @@
 namespace Alchemy\Tests\Phrasea\SearchEngine\Structure;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\FieldMapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Mapping;
-use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\Field;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure as Structure;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
 
 /**
  * @group unit
@@ -113,7 +112,7 @@ class StructureTest extends \PHPUnit_Framework_TestCase
             'thesaurus_roots' => null
         ]);
         $enabled = new Field('bar', FieldMapping::TYPE_STRING, [
-            'thesaurus_roots' => [new Concept('/foo')]
+            'thesaurus_roots' => [new Concept(1, '/foo')]
         ]);
         $structure = new Structure();
         $structure->add($not_enabled);

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Structure/StructureTest.php
@@ -167,15 +167,18 @@ class StructureTest extends \PHPUnit_Framework_TestCase
         $structure = new Structure();
         $structure->add($foo = (new Field('foo', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [1, 2]
+            'used_by_collections' => [1, 2],
+            'used_by_databoxes' => [1]
         ])));
         $structure->add(new Field('foo', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [2, 3]
+            'used_by_collections' => [2, 3],
+            'used_by_databoxes' => [1]
         ]));
         $structure->add(new Field('bar', FieldMapping::TYPE_STRING, [
             'private' => true,
-            'used_by_collections' => [2, 3]
+            'used_by_collections' => [2, 3],
+            'used_by_databoxes' => [1]
         ]));
         $structure->add(new Field('baz', FieldMapping::TYPE_STRING, ['private' => false]));
         $this->assertEquals([1, 2], $foo->getDependantCollections());

--- a/tests/Alchemy/Tests/Phrasea/SearchEngine/Thesaurus/ConceptTest.php
+++ b/tests/Alchemy/Tests/Phrasea/SearchEngine/Thesaurus/ConceptTest.php
@@ -12,34 +12,34 @@ class ConceptTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetPath()
     {
-        $concept = new Concept('/foo/bar');
+        $concept = new Concept(1, '/foo/bar');
         $this->assertEquals('/foo/bar', $concept->getPath());
     }
 
     public function testNarrowCheck()
     {
-        $parent = new Concept('/foo');
-        $child = new Concept('/foo/bar');
+        $parent = new Concept(1, '/foo');
+        $child = new Concept(1, '/foo/bar');
         $this->assertFalse($parent->isNarrowerThan($child));
         $this->assertTrue($child->isNarrowerThan($parent));
-        $other = new Concept('/other/bar');
+        $other = new Concept(1, '/other/bar');
         $this->assertFalse($other->isNarrowerThan($child));
     }
 
     public function testNarrowConceptPruning()
     {
         $concepts = [
-            new Concept('/foo'),
-            new Concept('/fooo'),
-            new Concept('/foo/baz'),
-            new Concept('/bar/baz'),
-            new Concept('/bar'),
+            new Concept(1, '/foo'),
+            new Concept(1, '/fooo'),
+            new Concept(1, '/foo/baz'),
+            new Concept(1, '/bar/baz'),
+            new Concept(1, '/bar'),
         ];
         $pruned = Concept::pruneNarrowConcepts($concepts);
         $expected = [
-            new Concept('/bar'),
-            new Concept('/foo'),
-            new Concept('/fooo'),
+            new Concept(1, '/bar'),
+            new Concept(1, '/foo'),
+            new Concept(1, '/fooo'),
         ];
         $this->assertEquals($expected, $pruned);
     }

--- a/tests/classes/PhraseanetAuthenticatedWebTestCase.php
+++ b/tests/classes/PhraseanetAuthenticatedWebTestCase.php
@@ -212,7 +212,7 @@ abstract class PhraseanetAuthenticatedWebTestCase extends \PhraseanetAuthenticat
         $queryESLib = '{index:"test", match:{""}}';    // fake, real is really more complex
 
         $result = new SearchEngineResult(
-            new SearchEngineOptions(),
+            new SearchEngineOptions(self::$DI['app']['repo.collection-references']),
             new ArrayCollection([$elasticsearchRecord]), // Records
             $queryText,    // the query as typed by the user
             $queryAST,


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3389: search only concept-paths from the relevant thesaurus
  - Search only fields from the relevant databoxes (collections)
