### PR TITLE
PHRAS-3426_translations-ignored_MASTER

### DIFF
--- a/lib/Alchemy/Phrasea/Command/Developer/Utils/HelpMessageExtractor.php
+++ b/lib/Alchemy/Phrasea/Command/Developer/Utils/HelpMessageExtractor.php
@@ -11,16 +11,17 @@
 
 namespace Alchemy\Phrasea\Command\Developer\Utils;
 
+use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Annotation\Desc;
+use JMS\TranslationBundle\Annotation\Ignore;
+use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Annotation\Meaning;
-use JMS\TranslationBundle\Annotation\Desc;
-use JMS\TranslationBundle\Annotation\Ignore;
-use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use PhpParser\Comment\Doc;
 use PHPParser\Node;
 use PHPParser\Node\Expr\Array_;
 use PHPParser\Node\Scalar\String_;
@@ -94,7 +95,8 @@ class HelpMessageExtractor implements FileVisitorInterface, NodeVisitor, LoggerA
         $docComment = $item->key->getDocComment();
         $docComment = $docComment ? $docComment : $item->value->getDocComment();
         if ($docComment) {
-            foreach ($this->docParser->parse($docComment, 'file '.$this->file.' near line '.$item->value->getLine()) as $annot) {
+            /** @var Doc $docComment */
+            foreach ($this->docParser->parse($docComment->getText(), 'file '.$this->file.' near line '.$item->value->getLine()) as $annot) {
                 if ($annot instanceof Ignore) {
                     $ignore = true;
                 } elseif ($annot instanceof Desc) {

--- a/lib/Alchemy/Phrasea/Form/Configuration/APIClientsFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/APIClientsFormType.php
@@ -11,29 +11,40 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class APIClientsFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('api-enabled', 'checkbox', [
+        $builder->add('api-enabled', CheckboxType::class, [
             'label' => 'Enable Phraseanet Web API',
-            'help_message' => 'The Phraseanet Web API allows other web application to rely on this instance'
+            'help_message' => /** @Ignore */ $this->translator->trans('The Phraseanet Web API allows other web application to rely on this instance')
         ]);
 
-        $builder->add('navigator-enabled', 'checkbox', [
+        $builder->add('navigator-enabled', CheckboxType::class, [
             'label'        => 'Authorize *Phraseanet Navigator*',
-            'help_message' => '*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance',
+            'help_message' => /** @Ignore */ $this->translator->trans('*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance'),
         ]);
 
-        $builder->add('office-enabled', 'checkbox', [
-            'label'        => 'Authorize Microsoft Office Plugin to connect.',
+        $builder->add('office-enabled', CheckboxType::class, [
+            'label'        => /** @Ignore */ $this->translator->trans('Authorize Microsoft Office Plugin to connect.'),
         ]);
 
-        $builder->add('adobe_cc-enabled', 'checkbox', [
-            'label'        => 'Authorize Adobe cc Plugin to connect.',
+        $builder->add('adobe_cc-enabled', CheckboxType::class, [
+            'label'        => /** @Ignore */ $this->translator->trans('Authorize Adobe cc Plugin to connect.'),
         ]);
     }
 

--- a/lib/Alchemy/Phrasea/Form/Configuration/ActionsFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/ActionsFormType.php
@@ -11,53 +11,66 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ActionsFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('download-max-size', 'integer', [
+        $builder->add('download-max-size', IntegerType::class, [
             'label'        => 'Maximum megabytes allowed for download',
-            'help_message' => 'If request is bigger, then mail is still available',
+            'help_message' => /** @Ignore */ $this->translator->trans('If request is bigger, then mail is still available'),
         ]);
-        $builder->add('validation-reminder-time-left-percent', 'integer', [
+        $builder->add('validation-reminder-time-left-percent', IntegerType::class, [
             'label'       => 'Percent of the time left before the end of the validation to send a reminder email',
         ]);
-        $builder->add('validation-expiration-days', 'integer', [
+        $builder->add('validation-expiration-days', IntegerType::class, [
             'label'        => 'Default validation links duration',
-            'help_message' => 'If set to 0, duration is permanent',
+            'help_message' => /** @Ignore */ $this->translator->trans('If set to 0, duration is permanent'),
         ]);
-        $builder->add('auth-required-for-export', 'checkbox', [
+        $builder->add('auth-required-for-export', CheckboxType::class, [
             'label'        => 'Require authentication to download documents',
-            'help_message' => 'Used for guest account',
+            'help_message' => /** @Ignore */ $this->translator->trans('Used for guest account'),
         ]);
-        $builder->add('tou-validation-required-for-export', 'checkbox', [
+        $builder->add('tou-validation-required-for-export', CheckboxType::class, [
             'label'        => 'Users must accept Terms of Use for each export',
         ]);
-        $builder->add('export-title-choice', 'checkbox', [
+        $builder->add('export-title-choice', CheckboxType::class, [
             'label'        => 'Choose the title of the document to export',
         ]);
-        $builder->add('default-export-title', 'choice', [
+        $builder->add('default-export-title', ChoiceType::class, [
             'label'        => 'Default export title',
             'choices'      => ['title' => 'Document title', 'original' => 'Original name'],
         ]);
-        $builder->add('social-tools', 'choice', [
+        $builder->add('social-tools', ChoiceType::class, [
             'label'        => 'Enable this setting to share on Facebook and Twitter',
             'choices'      => ['none' => 'Disabled', 'publishers' => 'Publishers', 'all' => 'Enabled'],
         ]);
-        $builder->add('enable-push-authentication', 'checkbox', [
+        $builder->add('enable-push-authentication', CheckboxType::class, [
             'label'        => 'Enable Forcing authentication to see push content',
-            'help_message' => 'Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.',
+            'help_message' => /** @Ignore */ $this->translator->trans('Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.'),
         ]);
-        $builder->add('force-push-authentication', 'checkbox', [
+        $builder->add('force-push-authentication', CheckboxType::class, [
             'label'        => 'Disallow the possibility for the end user to disable push authentication',
         ]);
-        $builder->add('enable-feed-notification', 'checkbox', [
+        $builder->add('enable-feed-notification', CheckboxType::class, [
             'label'        => 'Enable possibility to notify users when publishing a new feed entry',
         ]);
-        $builder->add('download-link-validity', 'integer', [
+        $builder->add('download-link-validity', IntegerType::class, [
             'label'        => 'Validity period of the download links',
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Configuration/CustomLinkFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/CustomLinkFormType.php
@@ -11,13 +11,18 @@
 namespace Alchemy\Phrasea\Form\Configuration;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class CustomLinkFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('linkName', 'text', [
+        $builder->add('linkName', TextType::class, [
             'label' => false,
             'attr'  => [
                 'placeholder' => 'setup::custom-link:name-link',
@@ -25,7 +30,7 @@ class CustomLinkFormType extends AbstractType
                 'maxlength'   => "30"
             ]
         ]);
-        $builder->add('linkLanguage', 'choice', [
+        $builder->add('linkLanguage', ChoiceType::class, [
             'label'   => false,
             'attr'    => [
                 'required' => true
@@ -41,14 +46,14 @@ class CustomLinkFormType extends AbstractType
                 'du'  => 'DU'
             ]
         ]);
-        $builder->add('linkUrl', 'url', [
+        $builder->add('linkUrl', UrlType::class, [
             'label' => false,
             'attr'  => [
                 'placeholder' => 'setup::custom-link:placeholder-link-url',
                 'required'    => true
             ]
         ]);
-        $builder->add('linkLocation', 'choice', [
+        $builder->add('linkLocation', ChoiceType::class, [
             'label'   => false,
             'attr'    => [
                 'required' => true
@@ -59,13 +64,13 @@ class CustomLinkFormType extends AbstractType
                 'navigation-bar' => 'setup::custom-link:navigation-bar',
             ]
         ]);
-        $builder->add('linkOrder', 'integer', [
+        $builder->add('linkOrder', IntegerType::class, [
             'label' => false,
         ]);
-        $builder->add('linkBold', 'checkbox', [
+        $builder->add('linkBold', CheckboxType::class, [
             'label' => false,
         ]);
-        $builder->add('linkColor', 'choice', [
+        $builder->add('linkColor', ChoiceType::class, [
             'label'   => false,
             'choices' => [
                 ''        => '#ad0800',

--- a/lib/Alchemy/Phrasea/Form/Configuration/EmailFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/EmailFormType.php
@@ -12,44 +12,48 @@
 namespace Alchemy\Phrasea\Form\Configuration;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class EmailFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('emitter-email', 'text', [
+        $builder->add('emitter-email', TextType::class, [
             'label'        => 'Default mail sender address',
         ]);
-        $builder->add('prefix', 'text', [
+        $builder->add('prefix', TextType::class, [
             'label'        => 'Prefix for notification emails',
         ]);
-        $builder->add('smtp-enabled', 'checkbox', [
+        $builder->add('smtp-enabled', CheckboxType::class, [
             'label'        => 'Use a SMTP server',
         ]);
-        $builder->add('smtp-auth-enabled', 'checkbox', [
+        $builder->add('smtp-auth-enabled', CheckboxType::class, [
             'label'        => 'Enable SMTP authentication',
         ]);
-        $builder->add('smtp-host', 'text', [
+        $builder->add('smtp-host', TextType::class, [
             'label'        => 'SMTP host',
         ]);
-        $builder->add('smtp-port', 'text', [
+        $builder->add('smtp-port', TextType::class, [
             'label'        => 'SMTP port',
         ]);
-        $builder->add('smtp-secure-mode', 'choice', [
+        $builder->add('smtp-secure-mode', ChoiceType::class, [
             'label'        => 'SMTP encryption',
             'choices'      => ['none' => 'None', 'ssl' => 'SSL', 'tls' => 'TLS'],
         ]);
-        $builder->add('smtp-user', 'text', [
+        $builder->add('smtp-user', TextType::class, [
             'label'        => 'SMTP user',
         ]);
-        $builder->add('hidden-password', 'password', [
+        $builder->add('hidden-password', PasswordType::class, [
             'label' => '',
             'attr' =>  [
                 'style' => 'display:none'
             ]
         ]);
-        $builder->add('smtp-password', 'password', [
+        $builder->add('smtp-password', PasswordType::class, [
             'label'        => 'SMTP password',
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Configuration/ExecutablesFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/ExecutablesFormType.php
@@ -11,12 +11,18 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ExecutablesFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
     private $translator;
 
     public function __construct(TranslatorInterface $translator)
@@ -26,38 +32,37 @@ class ExecutablesFormType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('h264-streaming-enabled', 'checkbox', [
+        $builder->add('h264-streaming-enabled', CheckboxType::class, [
             'label'        => 'Enable H264 stream mode',
-            'help_message' => 'Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token',
+            'help_message' => /** @Ignore */ $this->translator->trans('Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token'),
         ]);
-        $builder->add('auth-token-directory', 'text', [
+        $builder->add('auth-token-directory', TextType::class, [
             'label'        => 'Auth_token mount point',
         ]);
-        $builder->add('auth-token-directory-path', 'text', [
+        $builder->add('auth-token-directory-path', TextType::class, [
             'label'        => 'Auth_token directory path',
         ]);
-        $builder->add('auth-token-passphrase', 'text', [
+        $builder->add('auth-token-passphrase', TextType::class, [
             'label'        => 'Auth_token passphrase',
-            'help_message' => 'Defined in Apache configuration',
+            'help_message' => /** @Ignore */ $this->translator->trans('Defined in Apache configuration'),
         ]);
-        $builder->add('php-conf-path', 'text', [
+        $builder->add('php-conf-path', TextType::class, [
             'label'        => 'php.ini path',
-            'help_message' => 'Empty if not used',
+            'help_message' => /** @Ignore */ $this->translator->trans('Empty if not used'),
         ]);
 
         $imagineDoc = '<a href="http://imagine.readthedocs.org/en/latest/usage/introduction.html">http://imagine.readthedocs.org/en/latest/usage/introduction.html</a>';
 
-        $builder->add('imagine-driver', 'choice', [
-            'label'        => $this->translator->trans('Imagine driver'),
+        $builder->add('imagine-driver', ChoiceType::class, [
+            'label'        => 'Imagine driver',
             'help_message' => /** @Ignore */ $this->translator->trans('See documentation at %url%', ['%url%' => $imagineDoc]),
             'choices'      => ['' => 'Auto', 'gmagick' => 'GraphicsMagick', 'imagick' => 'ImageMagick', 'gd' => 'GD'],
-            'translation_domain' => false
         ]);
 
-        $builder->add('ffmpeg-threads', 'integer', [
+        $builder->add('ffmpeg-threads', IntegerType::class, [
             'label'        => 'Number of threads to use for FFMpeg',
         ]);
-        $builder->add('pdf-max-pages', 'integer', [
+        $builder->add('pdf-max-pages', IntegerType::class, [
             'label'        => 'Maximum number of pages to be extracted from PDF',
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Configuration/FtpExportFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/FtpExportFormType.php
@@ -11,20 +11,31 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FtpExportFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('ftp-enabled', 'checkbox', [
+        $builder->add('ftp-enabled', CheckboxType::class, [
             'label'        => 'Enable FTP export',
-            'help_message' => 'Available in multi-export tab',
+            'help_message' => /** @Ignore */ $this->translator->trans('Available in multi-export tab'),
         ]);
-        $builder->add('ftp-user-access', 'checkbox', [
+        $builder->add('ftp-user-access', CheckboxType::class, [
             'label'        => 'Enable FTP for users',
-            'help_message' => 'By default it is available for admins',
+            'help_message' => /** @Ignore */ $this->translator->trans('By default it is available for admins'),
         ]);
     }
 

--- a/lib/Alchemy/Phrasea/Form/Configuration/GeneralFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/GeneralFormType.php
@@ -12,6 +12,11 @@
 namespace Alchemy\Phrasea\Form\Configuration;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 
@@ -26,28 +31,28 @@ class GeneralFormType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('title', 'text', [
+        $builder->add('title', TextType::class, [
             'label'         => 'Application title',
         ]);
-        $builder->add('keywords', 'text', [
+        $builder->add('keywords', TextType::class, [
             'label'         => 'Keywords used for indexing purposes by search engines robots',
         ]);
-        $builder->add('description', 'textarea', [
+        $builder->add('description', TextareaType::class, [
             'label'         => 'Application description',
         ]);
-        $builder->add('analytics', 'text', [
+        $builder->add('analytics', TextType::class, [
             'label'         => 'Google Analytics identifier',
         ]);
-        $builder->add('matomo-analytics-url', 'text', [
+        $builder->add('matomo-analytics-url', TextType::class, [
             'label'         => 'Matomo Analytics url',
         ]);
-        $builder->add('matomo-analytics-id', 'text', [
+        $builder->add('matomo-analytics-id', TextType::class, [
             'label'         => 'Matomo Analytics identifier',
         ]);
-        $builder->add('allow-indexation', 'checkbox', [
+        $builder->add('allow-indexation', CheckboxType::class, [
             'label'         => 'Allow the website to be indexed by search engines like Google',
         ]);
-        $builder->add('home-presentation-mode', 'choice', [
+        $builder->add('home-presentation-mode', ChoiceType::class, [
             'label'         => 'Homepage slideshow',
             'choices'       => [
                 'DISPLAYx1' => 'Single image',
@@ -57,7 +62,7 @@ class GeneralFormType extends AbstractType
                 'GALLERIA'  => 'Gallery',
             ],
         ]);
-        $builder->add('default-subdef-url-ttl', 'integer', [
+        $builder->add('default-subdef-url-ttl', IntegerType::class, [
             'label'       => 'Default TTL in seconds of sub-definition url',
             'attr'        => ['min' => -1],
             'constraints' => new GreaterThanOrEqual(['value' => -1]),

--- a/lib/Alchemy/Phrasea/Form/Configuration/MainConfigurationFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/MainConfigurationFormType.php
@@ -12,10 +12,10 @@
 namespace Alchemy\Phrasea\Form\Configuration;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
 class MainConfigurationFormType extends AbstractType
 {
@@ -33,22 +33,22 @@ class MainConfigurationFormType extends AbstractType
         $builder->add('general', new GeneralFormType($this->languages), [
             'label'    => 'General configuration',
         ]);
-        $builder->add('modules', new ModulesFormType(), [
+        $builder->add('modules', new ModulesFormType($this->translator), [
             'label' => 'Additionnal modules',
         ]);
-        $builder->add('actions', new ActionsFormType(), [
+        $builder->add('actions', new ActionsFormType($this->translator), [
             'label' => 'Push configuration',
         ]);
-        $builder->add('ftp', new FtpExportFormType(), [
+        $builder->add('ftp', new FtpExportFormType($this->translator), [
             'label' => 'FTP Export',
         ]);
-        $builder->add('registration', new RegistrationFormType(), [
+        $builder->add('registration', new RegistrationFormType($this->translator), [
             'label' => 'Registration',
         ]);
         $builder->add('maintenance', new MaintenanceFormType(), [
             'label' => 'Maintenance state',
         ]);
-        $builder->add('api-clients', new APIClientsFormType(), [
+        $builder->add('api-clients', new APIClientsFormType($this->translator), [
             'label' => 'Phraseanet client API',
         ]);
         $builder->add('webservices', new WebservicesFormType($this->translator), [
@@ -57,7 +57,7 @@ class MainConfigurationFormType extends AbstractType
         $builder->add('executables', new ExecutablesFormType($this->translator), [
             'label' => 'Executables settings',
         ]);
-        $builder->add('searchengine', new SearchEngineFormType(), [
+        $builder->add('searchengine', new SearchEngineFormType($this->translator), [
             'label' => 'Search engine',
         ]);
         $builder->add('email', new EmailFormType(), [

--- a/lib/Alchemy/Phrasea/Form/Configuration/MaintenanceFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/MaintenanceFormType.php
@@ -12,16 +12,18 @@
 namespace Alchemy\Phrasea\Form\Configuration;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class MaintenanceFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('message', 'text', [
+        $builder->add('message', TextType::class, [
             'label'       => 'Maintenance message',
         ]);
-        $builder->add('enabled', 'checkbox', [
+        $builder->add('enabled', CheckboxType::class, [
             'label'       => 'Enable maintenance message broadcast',
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Configuration/ModulesFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/ModulesFormType.php
@@ -11,28 +11,39 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ModulesFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('thesaurus', 'checkbox', [
+        $builder->add('thesaurus', CheckboxType::class, [
             'label'        => 'Enable thesaurus',
         ]);
-        $builder->add('stories', 'checkbox', [
+        $builder->add('stories', CheckboxType::class, [
             'label'        => 'Enable multi-doc mode',
         ]);
-        $builder->add('doc-substitution', 'checkbox', [
+        $builder->add('doc-substitution', CheckboxType::class, [
             'label'        => 'Enable HD substitution',
         ]);
-        $builder->add('thumb-substitution', 'checkbox', [
+        $builder->add('thumb-substitution', CheckboxType::class, [
             'label'        => 'Enable thumbnail substitution',
         ]);
-        $builder->add('anonymous-report', 'checkbox', [
+        $builder->add('anonymous-report', CheckboxType::class, [
             'label'        => 'Anonymous report',
-            'help_message' => 'Hide information about users',
+            'help_message' => /** @Ignore */ $this->translator->trans('Hide information about users'),
         ]);
     }
 

--- a/lib/Alchemy/Phrasea/Form/Configuration/PersonalisationLogoFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/PersonalisationLogoFormType.php
@@ -11,13 +11,16 @@
 namespace Alchemy\Phrasea\Form\Configuration;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class PersonalisationLogoFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('logoChoice', 'choice', [
+        $builder->add('logoChoice', ChoiceType::class, [
             'label'    => false,
             'choices'  => [
                 'original' => 'original logo',
@@ -28,15 +31,15 @@ class PersonalisationLogoFormType extends AbstractType
 
         ]);
 
-        $builder->add('personalizeLogoInput', 'file', [
+        $builder->add('personalizeLogoInput', FileType::class, [
             'label' => false,
         ]);
 
-        $builder->add('personalizeFile', 'hidden', [
+        $builder->add('personalizeFile', HiddenType::class, [
             'label' => false,
         ]);
 
-        $builder->add('fileType', 'hidden', [
+        $builder->add('fileType', HiddenType::class, [
             'label' => false,
         ]);
 

--- a/lib/Alchemy/Phrasea/Form/Configuration/RegistrationFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/RegistrationFormType.php
@@ -11,18 +11,29 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class RegistrationFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('auto-select-collections', 'checkbox', [
+        $builder->add('auto-select-collections', CheckboxType::class, [
             'label'        => 'Auto select databases',
-            'help_message' => 'This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases.',
+            'help_message' => /** @Ignore */ $this->translator->trans('This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases.'),
         ]);
-        $builder->add('auto-register-enabled', 'checkbox', [
+        $builder->add('auto-register-enabled', CheckboxType::class, [
             'label'        => 'Enable auto registration',
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Configuration/SearchEngineFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/SearchEngineFormType.php
@@ -11,23 +11,36 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class SearchEngineFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('min-letters-truncation', 'integer', [
+        $builder->add('min-letters-truncation', IntegerType::class, [
             'label'        => 'Minimum number of letters before truncation',
-            'help_message' => 'Used in search engine',
+            'help_message' => /** @Ignore */ $this->translator->trans('Used in search engine'),
         ]);
-        $builder->add('default-query', 'text', [
+        $builder->add('default-query', TextType::class, [
             'label'        => 'Default query',
         ]);
-        $builder->add('default-query-type', 'choice', [
+        $builder->add('default-query-type', ChoiceType::class, [
             'label'        => 'Default searched type',
-            'help_message' => 'Used when opening the application',
+            'help_message' => /** @Ignore */ $this->translator->trans('Used when opening the application'),
             'choices'      => ['0' => 'Documents', '1' => 'Stories'],
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Configuration/WebservicesFormType.php
+++ b/lib/Alchemy/Phrasea/Form/Configuration/WebservicesFormType.php
@@ -11,12 +11,16 @@
 
 namespace Alchemy\Phrasea\Form\Configuration;
 
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class WebservicesFormType extends AbstractType
 {
+    /** @var TranslatorInterface  */
     private $translator;
 
     public function __construct(TranslatorInterface $translator)
@@ -28,22 +32,22 @@ class WebservicesFormType extends AbstractType
     {
         $recaptchaDoc = '<a href="http://www.google.com/recaptcha">http://www.google.com/recaptcha</a>';
 
-        $builder->add('google-charts-enabled', 'checkbox', [
+        $builder->add('google-charts-enabled', CheckboxType::class, [
             'label'        => 'Use Google Chart API',
         ]);
-        $builder->add('geonames-server', 'text', [
+        $builder->add('geonames-server', TextType::class, [
             'label'       => 'Geonames server address',
         ]);
 
-        $builder->add('captchas-enabled', 'checkbox', [
-            'label'        => 'Use recaptcha API',
-            'help_message' => /** @Ignore */ $this->translator->trans('See documentation at %url%', ['%url%' => $recaptchaDoc]),
+        $builder->add('captchas-enabled', CheckboxType::class, [
+            'label'        => $this->translator->trans('Use recaptcha API'),
+            'help_message' => /** @Ignore */$this->translator->trans('See documentation at %url%', ['%url%' => $recaptchaDoc]),
             'translation_domain' => false
         ]);
-        $builder->add('recaptcha-public-key', 'text', [
+        $builder->add('recaptcha-public-key', TextType::class, [
             'label'       => 'Recaptcha public key',
         ]);
-        $builder->add('recaptcha-private-key', 'text', [
+        $builder->add('recaptcha-private-key', TextType::class, [
             'label'       => 'Recaptcha private key',
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Login/PhraseaAuthenticationForm.php
+++ b/lib/Alchemy/Phrasea/Form/Login/PhraseaAuthenticationForm.php
@@ -11,11 +11,15 @@
 
 namespace Alchemy\Phrasea\Form\Login;
 
-use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Silex\Application;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class PhraseaAuthenticationForm extends AbstractType
 {
@@ -28,7 +32,7 @@ class PhraseaAuthenticationForm extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('login', 'text', [
+        $builder->add('login', TextType::class, [
             'label'       => 'Login',
             'required'    => true,
             'disabled'    => $options['disabled'],
@@ -37,7 +41,7 @@ class PhraseaAuthenticationForm extends AbstractType
             ],
         ]);
 
-        $builder->add('password', 'password', [
+        $builder->add('password', PasswordType::class, [
             'label'       => 'Password',
             'required'    => true,
             'disabled'    => $options['disabled'],
@@ -47,7 +51,7 @@ class PhraseaAuthenticationForm extends AbstractType
         ]);
 
         if ($this->app['phraseanet.configuration']['session']['idle'] < 1) {
-            $builder->add('remember-me', 'checkbox' , [
+            $builder->add('remember-me', CheckboxType::class, [
                 'label'    =>  'Remember me',
                 'mapped'   => false,
                 'required' => false,
@@ -56,14 +60,14 @@ class PhraseaAuthenticationForm extends AbstractType
                 ]
             ]);
         } else {
-            $builder->add('remember-me', 'hidden' , [
+            $builder->add('remember-me', HiddenType::class, [
                 'label'    =>  '',
                 'mapped'   => false,
                 'required' => false
             ]);
         }
 
-        $builder->add('redirect', 'hidden', [
+        $builder->add('redirect', HiddenType::class, [
             'required' => false,
         ]);
     }

--- a/lib/Alchemy/Phrasea/Form/Login/PhraseaForgotPasswordForm.php
+++ b/lib/Alchemy/Phrasea/Form/Login/PhraseaForgotPasswordForm.php
@@ -12,6 +12,7 @@
 namespace Alchemy\Phrasea\Form\Login;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -19,7 +20,7 @@ class PhraseaForgotPasswordForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('email', 'email', [
+        $builder->add('email', EmailType::class, [
             'label' => 'E-mail',
             'required' => true,
             'constraints' => [

--- a/lib/Alchemy/Phrasea/Form/Login/PhraseaRecoverPasswordForm.php
+++ b/lib/Alchemy/Phrasea/Form/Login/PhraseaRecoverPasswordForm.php
@@ -14,6 +14,8 @@ namespace Alchemy\Phrasea\Form\Login;
 use Alchemy\Phrasea\Form\Constraint\PasswordToken;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -31,14 +33,14 @@ class PhraseaRecoverPasswordForm extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('token', 'hidden', [
+        $builder->add('token', HiddenType::class, [
             'required'      => true,
             'constraints'   => [
                 new PasswordToken($this->repository)
             ]
         ]);
 
-        $builder->add('password', 'repeated', [
+        $builder->add('password', RepeatedType::class, [
             'type'              => 'password',
             'required'          => true,
             'invalid_message'   => 'Please provide the same passwords.',

--- a/lib/Alchemy/Phrasea/Form/Login/PhraseaRegisterForm.php
+++ b/lib/Alchemy/Phrasea/Form/Login/PhraseaRegisterForm.php
@@ -12,17 +12,26 @@
 namespace Alchemy\Phrasea\Form\Login;
 
 use Alchemy\Phrasea\Application;
+use Alchemy\Phrasea\Exception\InvalidArgumentException;
 use Alchemy\Phrasea\Form\Constraint\NewEmail;
 use Alchemy\Phrasea\Utilities\StringHelper;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Alchemy\Phrasea\Exception\InvalidArgumentException;
 
 class PhraseaRegisterForm extends AbstractType
 {
     private $available;
     private $params;
+    /**
+     * @var Application
+     */
+    private $app;
 
     public function __construct(Application $app, array $available, array $params = [])
     {
@@ -33,7 +42,7 @@ class PhraseaRegisterForm extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('email', 'email', [
+        $builder->add('email', EmailType::class, [
             'label'       => 'E-mail',
             'required'    => true,
             'constraints' => [
@@ -43,7 +52,7 @@ class PhraseaRegisterForm extends AbstractType
             ],
         ]);
 
-        $builder->add('password', 'repeated', [
+        $builder->add('password', RepeatedType::class, [
             'type'              => 'password',
             'required'          => true,
             'invalid_message'   => 'Please provide the same passwords.',
@@ -58,7 +67,7 @@ class PhraseaRegisterForm extends AbstractType
         ]);
 
         if ($this->app->hasTermsOfUse()) {
-            $builder->add('accept-tou', 'checkbox', [
+            $builder->add('accept-tou', CheckboxType::class, [
                 'label'         => 'Terms of Use',
                 'mapped'        => false,
                 "constraints"   => [
@@ -68,7 +77,7 @@ class PhraseaRegisterForm extends AbstractType
             ]);
         }
 
-        $builder->add('provider-id', 'hidden');
+        $builder->add('provider-id', HiddenType::class);
 
         $choices = $baseIds = [];
 
@@ -84,7 +93,7 @@ class PhraseaRegisterForm extends AbstractType
         }
 
         if (!$this->app['conf']->get(['registry', 'registration', 'auto-select-collections'])) {
-            $builder->add('collections', 'choice', [
+            $builder->add('collections', ChoiceType::class, [
                 'choices'     => $choices,
                 'multiple'    => true,
                 'expanded'    => false,

--- a/lib/Alchemy/Phrasea/Form/Login/PhraseaRenewPasswordForm.php
+++ b/lib/Alchemy/Phrasea/Form/Login/PhraseaRenewPasswordForm.php
@@ -12,6 +12,8 @@
 namespace Alchemy\Phrasea\Form\Login;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -22,7 +24,7 @@ class PhraseaRenewPasswordForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('oldPassword', 'password', [
+        $builder->add('oldPassword', PasswordType::class, [
             'label'         => 'Current password',
             'required'      => true,
             'constraints'   => [
@@ -30,7 +32,7 @@ class PhraseaRenewPasswordForm extends AbstractType
             ]
         ]);
 
-        $builder->add('password', 'repeated', [
+        $builder->add('password', RepeatedType::class, [
             'type'              => 'password',
             'required'          => true,
             'invalid_message'   => 'Please provide the same passwords.',

--- a/lib/Alchemy/Phrasea/Form/TaskForm.php
+++ b/lib/Alchemy/Phrasea/Form/TaskForm.php
@@ -13,22 +13,26 @@ namespace Alchemy\Phrasea\Form;
 
 use Alchemy\Phrasea\Model\Entities\Task;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class TaskForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text', [
+        $builder->add('name', TextType::class, [
             'label'       => 'Task name',
             'required'    => true,
             'constraints' => [
                 new Assert\NotBlank(),
             ],
         ]);
-        $builder->add('period', 'integer', [
+        $builder->add('period', IntegerType::class, [
             'label'       => 'Task period (in seconds)',
             'required'    => true,
             'constraints' => [
@@ -36,14 +40,14 @@ class TaskForm extends AbstractType
                 new Assert\GreaterThan(['value' => 0]),
             ],
         ]);
-        $builder->add('status', 'choice', [
+        $builder->add('status', ChoiceType::class, [
             'label'       => 'The task status',
             'choices'   => [
                 Task::STATUS_STARTED   => 'Started',
                 Task::STATUS_STOPPED   => 'Stopped',
             ],
         ]);
-        $builder->add('settings', 'hidden');
+        $builder->add('settings', HiddenType::class);
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
@@ -12,7 +12,13 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic;
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
 use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -38,64 +44,64 @@ class ElasticsearchSettingsFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('host', 'text', [
+            ->add('host', TextType::class, [
                 'label' => 'ElasticSearch server host',
             ])
-            ->add('port', 'integer', [
+            ->add('port', IntegerType::class, [
                 'label' => 'ElasticSearch service port',
                 'constraints' => new Range(['min' => 1, 'max' => 65535]),
             ])
-            ->add('indexName', 'text', [
+            ->add('indexName', TextType::class, [
                 'label' => 'ElasticSearch index name',
                 'constraints' => new NotBlank(),
                 'attr' =>['data-class'=>'inline']
             ])
-            ->add('esSettingsDropIndexButton', 'button', [
+            ->add('esSettingsDropIndexButton', ButtonType::class, [
                 'label' => "Drop index",
                 'attr' => [
                     'data-id' => 'esSettingsDropIndexButton',
                     'class' => 'btn btn-danger'
                 ]
             ])
-            ->add('esSettingsCreateIndexButton', 'button', [
+            ->add('esSettingsCreateIndexButton', ButtonType::class, [
                 'label' => "Create index",
                 'attr' => ['data-id' => "esSettingsCreateIndexButton",
                            'class' => 'btn btn-success'
                 ]
             ])
-            ->add('shards', 'integer', [
+            ->add('shards', IntegerType::class, [
                 'label' => 'Number of shards',
                 'constraints' => new Range(['min' => 1]),
             ])
-            ->add('replicas', 'integer', [
+            ->add('replicas', IntegerType::class, [
                 'label' => 'Number of replicas',
                 'constraints' => new Range(['min' => 0]),
             ])
-            ->add('minScore', 'integer', [
+            ->add('minScore', IntegerType::class, [
                 'label' => 'Thesaurus Min score',
                 'constraints' => new Range(['min' => 0]),
             ])
-            ->add('highlight', 'checkbox', [
+            ->add('highlight', CheckboxType::class, [
                 'label' => 'Activate highlight',
                 'required' => false
             ])
             //                ->add('save', 'submit', [
             //                    'attr' => ['class' => 'btn btn-primary']
             //                ])
-            ->add('esSettingFromIndex', 'button', [
+            ->add('esSettingFromIndex', ButtonType::class, [
                 'label' => 'Get setting form index',
                 'attr' => [
                     'onClick' => 'esSettingFromIndex()',
                     'class' => 'btn'
                 ]
             ])
-            ->add('dumpField', 'textarea', [
+            ->add('dumpField', TextareaType::class, [
                 'label' => false,
                 'required' => false,
                 'mapped' => false,
                 'attr' => ['class' => 'dumpfield hide']
             ])
-            ->add('activeTab', 'hidden');
+            ->add('activeTab', HiddenType::class);
 
         // keep aggregates in configuration order with this intermediate array
         $aggs = [];
@@ -127,7 +133,7 @@ class ElasticsearchSettingsFormType extends AbstractType
         // all fields fron conf
         foreach($this->esSettings->getAggregableFields() as $k=>$f) {
             // default value will be replaced by hardcoded tech fields & all databoxes fields
-            $addAgg($k, "/?\\ " . $k, $this->translator->trans("This field does not exists in current databoxes."), true);
+            $addAgg($k, "/?\\ " . $k, $this->translator->trans("admin:searchengine:aggregates:This field does not exists in current databoxes."), true);
         }
 
         // add or replace hardcoded tech fields
@@ -137,7 +143,7 @@ class ElasticsearchSettingsFormType extends AbstractType
             $label = '#' . $k;
             if(!array_key_exists($k, $aggs)) {
                 $label = "/!\\ " . $label;
-                $help = $this->translator->trans("New field, please confirm setting.");
+                $help = $this->translator->trans("admin:searchengine:aggregates:New field, please confirm setting.");
             }
             $addAgg($k, $label, $help, false, $choices);
         }
@@ -148,7 +154,7 @@ class ElasticsearchSettingsFormType extends AbstractType
             $help = null;
             if(!array_key_exists($field->getName(), $aggs)) {
                 $label = "/!\\ " . $label;
-                $help = $this->translator->trans("New field, please confirm setting.");
+                $help = $this->translator->trans("admin:searchengine:aggregates:New field, please confirm setting.");
             }
             $addAgg($k, $label, $help);     // default choices
         }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticsearchSettingsFormType.php
@@ -10,6 +10,7 @@
 namespace Alchemy\Phrasea\SearchEngine\Elastic;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Structure\GlobalStructure;
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -31,6 +32,7 @@ class ElasticsearchSettingsFormType extends AbstractType
     {
         $this->globalStructure = $g;
         $this->esSettings = $settings;
+        $this->translator = $translator;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -110,14 +112,14 @@ class ElasticsearchSettingsFormType extends AbstractType
             }
             $choices = array_merge(["not aggregated" => 0], $choices);  //  add this option always as first choice
             $aggs[$k] = [   // default value will be replaced by hardcoded tech fields & all databoxes fields
-                'label'              =>  /** @Ignore */ $label,
+                'label'              => $label,
                 'choices_as_values'  => true,
                 'choices' => $choices,
                 'attr'               => [
                     'class' => 'aggregate'
                 ],
                 'disabled'           => $disabled,
-                'help_message'       =>  /** @Ignore */ $this->translator->trans($help),     // todo : not displayed ?
+                'help_message'       => /** @Ignore */ $help,     // todo : not displayed ?
                 'translation_domain' => false
             ];
         };
@@ -125,7 +127,7 @@ class ElasticsearchSettingsFormType extends AbstractType
         // all fields fron conf
         foreach($this->esSettings->getAggregableFields() as $k=>$f) {
             // default value will be replaced by hardcoded tech fields & all databoxes fields
-            $addAgg($k, "/?\\ " . $k, "This field does not exists in current databoxes.", true);
+            $addAgg($k, "/?\\ " . $k, $this->translator->trans("This field does not exists in current databoxes."), true);
         }
 
         // add or replace hardcoded tech fields
@@ -135,7 +137,7 @@ class ElasticsearchSettingsFormType extends AbstractType
             $label = '#' . $k;
             if(!array_key_exists($k, $aggs)) {
                 $label = "/!\\ " . $label;
-                $help = "New field, please confirm setting.";
+                $help = $this->translator->trans("New field, please confirm setting.");
             }
             $addAgg($k, $label, $help, false, $choices);
         }
@@ -146,7 +148,7 @@ class ElasticsearchSettingsFormType extends AbstractType
             $help = null;
             if(!array_key_exists($field->getName(), $aggs)) {
                 $label = "/!\\ " . $label;
-                $help = "New field, please confirm setting.";
+                $help = $this->translator->trans("New field, please confirm setting.");
             }
             $addAgg($k, $label, $help);     // default choices
         }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/FacetsResponse.php
@@ -56,7 +56,7 @@ class FacetsResponse
                     if($response['aggregations'][$name . '#empty']['doc_count'] > 0) {  // don't add a facet for 0 results
                         $aggregation['buckets'][] = [
                             'key'       => '_empty_',
-                            'value'     => sprintf($this->translator->trans('prod:workzone:facetstab:unset_field_facet_label_(%s)'), $name),   // special homemade prop to display a human value instead of the key
+                            'value'     => $this->translator->trans('prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)', ['%fieldname%' =>$name]),   // special homemade prop to display a human value instead of the key
                             'doc_count' => $response['aggregations'][$name . '#empty']['doc_count']
                         ];
                     }

--- a/resources/locales/messages.de.xlf
+++ b/resources/locales/messages.de.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:30:52Z" source-language="en" target-language="de" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:11Z" source-language="en" target-language="de" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,8 +9,8 @@
       <trans-unit id="da39a3ee5e6b4b0d3255bfef95601890afd80709" resname="">
         <source></source>
         <target state="new"></target>
-        <jms:reference-file line="47">Form/Configuration/EmailFormType.php</jms:reference-file>
-        <jms:reference-file line="60">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c03e9a1b443b7d9ac9a84e4d2cf55ebc016a9c5b" resname="                                Add" approved="yes">
         <source>                                Add</source>
@@ -20,73 +20,73 @@
       <trans-unit id="17b36ba11b9598e1ca72638a17637c71db031f8b" resname="#3567c6" approved="yes">
         <source>#3567c6</source>
         <target state="translated">#3567c6</target>
-        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="86">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c18097cf04c5f24e6b201e44603c26f000cbf266" resname="#4497d5" approved="yes">
         <source>#4497d5</source>
         <target state="translated">#4497d5</target>
-        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="654b7f2144322b13150ca53f8eb712644275fbbb" resname="#5aa53b" approved="yes">
         <source>#5aa53b</source>
         <target state="translated">#5aa53b</target>
-        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="81184afa6b2fb59a54a368a94c5af314882f4379" resname="#a1d0d0" approved="yes">
         <source>#a1d0d0</source>
         <target state="translated">#a1d0d0</target>
-        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="69760e828adabd5e543638f8b396d108e4e1c7f6" resname="#ad0800" approved="yes">
         <source>#ad0800</source>
         <target state="translated">#ad0800</target>
-        <jms:reference-file line="71">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
-        <jms:reference-file line="72">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8868030f047d29838dccd3ebd90a8cbcf5cf97b9" resname="#b151ee" approved="yes">
         <source>#b151ee</source>
         <target state="translated">#b151ee</target>
-        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="87">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df800d7d3f6bec2f0c48d7b18ad0f7515b4ed8a4" resname="#b8d84e" approved="yes">
         <source>#b8d84e</source>
         <target state="translated">#b8d84e</target>
-        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d3505d50f73a3440832d861060fc212eb2d929a" resname="#c875ea" approved="yes">
         <source>#c875ea</source>
         <target state="translated">#c875ea</target>
-        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="88">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cdd9fb48ed6b38bdf4cd732d30851062312f64b3" resname="#e46990" approved="yes">
         <source>#e46990</source>
         <target state="translated">#e46990</target>
-        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="89">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="22a0112b6eafc281d17f1b98fb8405847d01f04b" resname="#f06006" approved="yes">
         <source>#f06006</source>
         <target state="translated">#f06006</target>
-        <jms:reference-file line="73">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db6ca79114142b612eebf0ca5f80b94c80cbf453" resname="#f4ea5b" approved="yes">
         <source>#f4ea5b</source>
         <target state="translated">#f4ea5b</target>
-        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc4fad5f043fc9875dcdc532a296ec359a6c39e1" resname="#f5842b" approved="yes">
         <source>#f5842b</source>
         <target state="translated">#f5842b</target>
-        <jms:reference-file line="74">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="590b78bf59d578b0efdd1a7b1a385e8004fa88e8" resname="#ffc322" approved="yes">
         <source>#ffc322</source>
         <target state="translated">#ffc322</target>
-        <jms:reference-file line="75">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0cc996e2ae03790c84ef6edc0601ba0245d7cf1c" resname="#ffccd7" approved="yes">
         <source>#ffccd7</source>
         <target state="translated">#ffccd7</target>
-        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="90">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9378053eb7743587671aa830ffd2c9f1b13ad1a" resname="%ElementsCount% records" approved="yes">
         <source>%ElementsCount% records</source>
@@ -177,28 +177,28 @@
       <trans-unit id="24c43d6925295b9738f6fe69e4fb3dc7a2030f0f" resname="%nb_records% records" approved="yes">
         <source>%nb_records% records</source>
         <target state="translated">%nb_records% Datensätze</target>
-        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Tooltip/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="107">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e39dc3a90b0674916ef22f19912638564f33e518" resname="%nb_view% vue" approved="yes">
         <source>%nb_view% vue</source>
         <target state="translated">%nb_view% Ansicht</target>
-        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae7480d89dfd1ca0d1732014aee13f9958836bf8" resname="%nb_view% vues" approved="yes">
         <source>%nb_view% vues</source>
         <target state="translated">%nb_view% Ansichten</target>
-        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="7">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de0804eb70c10b14d71df74292e45c6daa13d672" resname="%number% documents&lt;br/&gt;selectionnes" approved="yes">
         <source><![CDATA[%number% documents<br/>selectionnes]]></source>
         <target state="translated"><![CDATA[%number% Dokumente<br/> ausgewählt]]></target>
-        <jms:reference-file line="268">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="263">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac5c6fe2979cfa2496c95dcb218f135fd916040d" resname="%quantity% Stories attached to the WorkZone" approved="yes">
         <source>%quantity% Stories attached to the WorkZone</source>
@@ -279,7 +279,7 @@
       <trans-unit id="f9b19aa0c7cf7aab245692450b473acff6a077e4" resname="%total% reponses" approved="yes">
         <source>%total% reponses</source>
         <target state="translated">%total% Ergebnisse</target>
-        <jms:reference-file line="316">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="311">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="99d2e1a7e8d0ba4a7132282b53b15e503b91c2cb" resname="%user% a envoye son rapport de validation de %title%" approved="yes">
         <source>%user% a envoye son rapport de validation de %title%</source>
@@ -384,7 +384,7 @@
       <trans-unit id="4412a659c3e1ca169796ab2f540a932ea7cbe2a4" resname="*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance" approved="yes">
         <source>*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance</source>
         <target state="translated">*Phraseanet Navigator* ist eine Smartphone Anwendung, die dem Benutzer ermöglicht, sich auf diese Instanz zu verbinden.</target>
-        <jms:reference-file line="28">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="356a192b7913b04c54574d18c28d46e6395428ab" resname="1" approved="yes">
         <source>1</source>
@@ -526,7 +526,7 @@
       <trans-unit id="62a3ad0fef668c4e2a220f6982de94942fbf1d1e" resname="AR" approved="yes">
         <source>AR</source>
         <target state="translated">AR</target>
-        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8887b473975b3b740e5afe559123403a6c219524" resname="About Roles :" approved="yes">
         <source>About Roles :</source>
@@ -625,17 +625,17 @@
       <trans-unit id="c3cd636a585b20c40ac2df5ffb403e83cb2eef51" resname="Actions" approved="yes">
         <source>Actions</source>
         <target state="translated">Aktionen</target>
-        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="26">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4a4f00323184bd750ee72b5c05e6e17d1584bfd" resname="Activate highlight" approved="yes">
         <source>Activate highlight</source>
         <target state="translated">Highlight aktivieren</target>
-        <jms:reference-file line="74">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="85">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="682">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a733b809d2f1233496ab516eed0f3ef75cf3791a" resname="Active" approved="yes">
@@ -668,10 +668,10 @@
       <trans-unit id="61cc55aa0453184734c3fa0b621eda6fa874bd83" resname="Add" approved="yes">
         <source>Add</source>
         <target state="translated">Hinzufügen</target>
-        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="514">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="515">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
+        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="983c5aed52d2f74bf36e97dc34dbce97fdd43f5b" resname="Add a&#10;                    new field" approved="yes">
         <source>Add a
@@ -733,7 +733,7 @@
       <trans-unit id="74ab95a4dbfaecbcd1fd586b71d97066ab7431c2" resname="Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only." approved="yes">
         <source>Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.</source>
         <target state="translated">Fügt eine Option im Push Registrierungsformular hinzu, um Push Zugriff nur für die Phraseanet Benutzer zu erlauben.</target>
-        <jms:reference-file line="52">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="65">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e7afebcfbae000b22c7c85e5560f89a2a0280b4" resname="Admin" approved="yes">
         <source>Admin</source>
@@ -779,22 +779,22 @@
       <trans-unit id="a810fdb68ba89818cce5c607021256e40cf14170" resname="Afficher la fiche descriptive" approved="yes">
         <source>Afficher la fiche descriptive</source>
         <target state="translated">das beschriftliche Blatt anzeigen</target>
-        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="946bf37a064ede9145bd8e3c7ce50e8608885518" resname="Afficher le titre" approved="yes">
         <source>Afficher le titre</source>
         <target state="translated">den Titel anzeigen</target>
-        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee793299aa2f135a4330889d59d362d1652fa577" resname="Afficher le type" approved="yes">
         <source>Afficher le type</source>
         <target state="translated">Typ anzeigen</target>
-        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1041">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7627cf7574df870b584ab3bd8a67d62d7ab4a18b" resname="Afficher les status" approved="yes">
         <source>Afficher les status</source>
         <target state="translated">die Status anzeigen</target>
-        <jms:reference-file line="1005">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="47743dc906e82db1978c23daf01e4d5e727702bd" resname="Afficher une icone" approved="yes">
         <source>Afficher une icone</source>
@@ -829,16 +829,16 @@
       <trans-unit id="5e8a35671080dba23a7f84416dcf97fd975a33e6" resname="Ajouter a" approved="yes">
         <source>Ajouter a</source>
         <target state="translated">Hinzufügen zu</target>
-        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6be348e8c91127640dc04e94dca7d5503ddb6c7d" resname="Ajouter ma selection courrante" approved="yes">
         <source>Ajouter ma selection courrante</source>
         <target state="translated">Meine aktuelle Auswahl hinzufügen</target>
+        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
         <jms:reference-file line="15">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/orders/order_item.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d391a678bc6acf01f3f67c57b07853c5a588171" resname="Ajouter un nouvel utilisateur" approved="yes">
         <source>Ajouter un nouvel utilisateur</source>
@@ -858,7 +858,7 @@
       <trans-unit id="6a72085653e4c5be8c7640c868ef787cbcf063d1" resname="All" approved="yes">
         <source>All</source>
         <target state="translated">Alle</target>
-        <jms:reference-file line="35">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="189">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="199">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="209">actions/Feedback/list.html.twig</jms:reference-file>
@@ -882,7 +882,7 @@
       <trans-unit id="619eebecff3aef2d53d82536ebc2604fb07900e2" resname="Allow the website to be indexed by search engines like Google" approved="yes">
         <source>Allow the website to be indexed by search engines like Google</source>
         <target state="translated">Die Website ermöglichen, von Suchmaschinen (wie Google) indexiert zu werden.</target>
-        <jms:reference-file line="48">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77c7b4909d393bbb0e9e72d3dd008972625771b3" resname="Allowed" approved="yes">
         <source>Allowed</source>
@@ -955,13 +955,11 @@
       <trans-unit id="f0cf9a47c6b420dda55c973a12840600fc19b7fb" resname="An error occured" approved="yes">
         <source>An error occured</source>
         <target state="translated">Ein Fehler ist aufgetreten</target>
-        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="164">Controller/Prod/MoveCollectionController.php</jms:reference-file>
-        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="251">Controller/Prod/BasketController.php</jms:reference-file>
-        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="218">Controller/Prod/StoryController.php</jms:reference-file>
+        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="71">Controller/Admin/DataboxesController.php</jms:reference-file>
         <jms:reference-file line="86">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="159">Controller/Admin/DataboxController.php</jms:reference-file>
@@ -983,12 +981,14 @@
         <jms:reference-file line="667">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="700">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="808">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="23">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="194">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
         <jms:reference-file line="19">admin/databox/databox.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a16a3255c311eccbe2471bfc5b5cd92f3b907654" resname="An error occured when wanting to change status!" approved="yes">
         <source>An error occured when wanting to change status!</source>
@@ -1029,13 +1029,13 @@
       <trans-unit id="98a5e115c36d45b5c1cb4ed3537f847a5210d1e7" resname="An error occurred" approved="yes">
         <source>An error occurred</source>
         <target state="translated">Ein Fehler ist aufgetreten</target>
-        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
-        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="2081">Controller/Api/V1Controller.php</jms:reference-file>
         <jms:reference-file line="2527">Controller/Api/V1Controller.php</jms:reference-file>
-        <jms:reference-file line="135">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="531">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="126">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="136">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
         <jms:reference-file line="81">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e861f79c8744b5cb0b59ce4f0100603952751b1" resname="An error occurred reading this file" approved="yes">
@@ -1056,7 +1056,7 @@
       <trans-unit id="3ad56f9f5a406f1c69267d4ac341168e3affa3e7" resname="Anonymous report" approved="yes">
         <source>Anonymous report</source>
         <target state="translated">anonymer Bericht</target>
-        <jms:reference-file line="34">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d7854118cda9d187ac6091c889576577aab8a36b" resname="Any time" approved="yes">
         <source>Any time</source>
@@ -1092,7 +1092,7 @@
       <trans-unit id="498778131fed5b01b06132a7c29c2d29829410c4" resname="Application description" approved="yes">
         <source>Application description</source>
         <target state="translated">Anwendung Bezeichnung</target>
-        <jms:reference-file line="36">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9ec030ab77d85f2493f1ebc5ab78e62e83fc383" resname="Application desktop" approved="yes">
         <source>Application desktop</source>
@@ -1102,7 +1102,7 @@
       <trans-unit id="ee3ac8b2def14068e5827dcd2499e831cb89712c" resname="Application title" approved="yes">
         <source>Application title</source>
         <target state="translated">Anwendung Titel</target>
-        <jms:reference-file line="30">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="866fef154cc77e6c30d7c9e97387dae0fb72dd08" resname="Application web" approved="yes">
         <source>Application web</source>
@@ -1133,8 +1133,8 @@
       <trans-unit id="b8fb717785e899f8e3bacfd74a395da7a434af9e" resname="Apply changes" approved="yes">
         <source>Apply changes</source>
         <target state="translated">Änderungen anwenden</target>
-        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="112">actions/Property/index.html.twig</jms:reference-file>
+        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e585e139fb6fc86d30e02ba78bdbb4dff6ac6b9" resname="Apply status on story children." approved="yes">
         <source>Apply status on story children.</source>
@@ -1274,8 +1274,8 @@
       <trans-unit id="d6caeca6303e9c722c929fbb58744a013a7ba7db" resname="Audio Codec" approved="yes">
         <source>Audio Codec</source>
         <target state="translated">Audio Codec</target>
-        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="37">Media/Subdef/Audio.php</jms:reference-file>
+        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a80232c45008d73666e95544f7c9c8c0896536af" resname="Audio Samplerate" approved="yes">
         <source>Audio Samplerate</source>
@@ -1300,17 +1300,17 @@
       <trans-unit id="9e761dfcff90efcb07867accd3e8b109762fc596" resname="Auth_token directory path" approved="yes">
         <source>Auth_token directory path</source>
         <target state="translated">Auth_token Verzeichnispfad</target>
-        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77277d274230409567d5eaa8a27e1a1b8f08cef6" resname="Auth_token mount point" approved="yes">
         <source>Auth_token mount point</source>
         <target state="translated">Auth_token Mount-Punkt</target>
-        <jms:reference-file line="34">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ef5e08e2db8aa52ae7a50b9d9f0bd6920b69a37" resname="Auth_token passphrase" approved="yes">
         <source>Auth_token passphrase</source>
         <target state="translated">Auth_token Passphrase</target>
-        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb7b626329225c9775b113922aa0d1662b5901a2" resname="Authoriser l'access" approved="yes">
         <source>Authoriser l'access</source>
@@ -1336,27 +1336,27 @@
       <trans-unit id="d5f364d5d9a0a95fdba37f29a65a9ba61d6329ef" resname="Authorize *Phraseanet Navigator*" approved="yes">
         <source>Authorize *Phraseanet Navigator*</source>
         <target state="translated">*Phraseanet Navigator* aktivieren</target>
-        <jms:reference-file line="27">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b85de40822e66ce4309b94ccad5bb731f2a89373" resname="Authorize Adobe cc Plugin to connect." approved="yes">
         <source>Authorize Adobe cc Plugin to connect.</source>
         <target state="translated">Adobe cc Plugin Verbindung erlauben</target>
-        <jms:reference-file line="36">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e1ead524b95ba3b45281df7ba45d2addbbf1a79" resname="Authorize Microsoft Office Plugin to connect." approved="yes">
         <source>Authorize Microsoft Office Plugin to connect.</source>
         <target state="translated">Verbindung mit Microsoft Office Plugin erlauben</target>
-        <jms:reference-file line="32">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c614ba7c453cdcd4d21b20e8286c6266c891e0c6" resname="Auto" approved="yes">
         <source>Auto</source>
         <target state="translated">Auto</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e57297a1b1a46f4190603240a211144dde456ffe" resname="Auto select databases" approved="yes">
         <source>Auto select databases</source>
         <target state="translated">automatische Wahl von Datenbanken</target>
-        <jms:reference-file line="22">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7c91a8c4806cffc223b40523b3233bd23412ad4" resname="AutoRegister information" approved="yes">
         <source>AutoRegister information</source>
@@ -1384,7 +1384,7 @@
       <trans-unit id="45fc87c2d0ade465c57c00f7aa434a4d0bebe106" resname="Available in multi-export tab" approved="yes">
         <source>Available in multi-export tab</source>
         <target state="translated">In der Mehrfachexport Registerkarte verfügbar</target>
-        <jms:reference-file line="23">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="37940d53912d9cc9ab0441c09c3754d6e83c438b" resname="Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes." approved="yes">
         <source>Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes.</source>
@@ -1394,11 +1394,11 @@
       <trans-unit id="b52b36b7269fbfc58ec24bb724691951a3decbe8" resname="Back" approved="yes">
         <source>Back</source>
         <target state="translated">Zurück</target>
-        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
         <jms:reference-file line="69">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="92">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="134">mobile/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="738444fb7badaeb28467562ed8af8e1311e42eac" resname="Back to Feedback" approved="yes">
         <source>Back to Feedback</source>
@@ -1419,9 +1419,9 @@
         <source>Bad request format, only JSON is allowed</source>
         <target state="translated">Bad Request Format, nur JSON wird erlaubt</target>
         <jms:reference-file line="191">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="61">Controller/Admin/RootController.php</jms:reference-file>
         <jms:reference-file line="223">Controller/Admin/RootController.php</jms:reference-file>
-        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa0d7d2cb29f1ca72b4108bfaa0bf5686d3910ff" resname="Bad request, please contact an admin" approved="yes">
         <source>Bad request, please contact an admin</source>
@@ -1530,7 +1530,7 @@
       <trans-unit id="54a2cf5e634dbba0be2bf8a55f79252f5c790bdb" resname="Browser" approved="yes">
         <source>Browser</source>
         <target state="translated">Webbrowser</target>
-        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d90cbe9431fb9e8d6013b651c2fb46a598de9eb" resname="Business Fields" approved="yes">
         <source>Business Fields</source>
@@ -1548,7 +1548,7 @@
       <trans-unit id="4a9b7a5a8f68ffe693f4205fc0d2916e373e4b64" resname="By default it is available for admins" approved="yes">
         <source>By default it is available for admins</source>
         <target state="translated">Standardmässig ist es für die Administratoren verfügbar</target>
-        <jms:reference-file line="27">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a8e6c2695279fb4760d299974903123f751b3bf" resname="By field" approved="yes">
         <source>By field</source>
@@ -1576,12 +1576,12 @@
         <target state="translated">Abbrechen</target>
         <jms:reference-file line="131">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="28">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
-        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="114">actions/Property/index.html.twig</jms:reference-file>
-        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
+        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
+        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
         <jms:reference-file line="68">admin/fields/templates.html.twig</jms:reference-file>
         <jms:reference-file line="42">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae1f9ef7dc1cee4760e7f208f36c225e3ab1aa1f" resname="Cancel all" approved="yes">
         <source>Cancel all</source>
@@ -1602,14 +1602,14 @@
       <trans-unit id="f1f842e1950136f97e6b449b2ee8ee2a88c9d214" resname="Carousel" approved="yes">
         <source>Carousel</source>
         <target state="translated">Karussell</target>
-        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="790d9876f3745353f60eb4d5232b26bb597ca5a3" resname="Categorie" approved="yes">
         <source>Categorie</source>
         <target state="translated">Kategorie</target>
-        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="38">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bf1584669680e7841bf069b9495ea2f012bff60b" resname="Ce champ est decrit comme element du %DublinCoreElementSet%" approved="yes">
         <source>Ce champ est decrit comme element du %DublinCoreElementSet%</source>
@@ -1639,14 +1639,14 @@
       <trans-unit id="17061b6a22c3d9f7255c7f6208394911623ea1cd" resname="Ce champ est obligatoire" approved="yes">
         <source>Ce champ est obligatoire</source>
         <target state="translated">Dieses Feld ist ein Pflichtfeld</target>
-        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="798">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="823">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="691">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="713">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e821f6f0c9613624f82ae880c01573ab0c0a0eac" resname="Ce champ est relie a une branche de thesaurus" approved="yes">
         <source>Ce champ est relie a une branche de thesaurus</source>
@@ -1667,12 +1667,12 @@
       <trans-unit id="9fb36da9009b1be61fc35e5de8ef5ea79ceca1c1" resname="Ce champ est trop long %length% caracteres max" approved="yes">
         <source>Ce champ est trop long %length% caracteres max</source>
         <target state="translated">Dieses Feld ist zu lang, maximal %length% Zeichen</target>
-        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="801">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="826">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="694">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="716">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a436b2b01f08a63284006c23ac3b38c9a699cbd" resname="Ce champ est utilise en titre a l'affichage" approved="yes">
         <source>Ce champ est utilise en titre a l'affichage</source>
@@ -1748,8 +1748,8 @@
       <trans-unit id="b030d590c21c95efe2ba71da1d0f1198a7e655b4" resname="Choisir" approved="yes">
         <source>Choisir</source>
         <target state="translated">wählen</target>
-        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="150">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="168">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="368">web/admin/subdefs.html.twig</jms:reference-file>
@@ -1761,13 +1761,13 @@
       <trans-unit id="3f657f29e68346624be98bea3924a6748900a66c" resname="Choose a new password" approved="yes">
         <source>Choose a new password</source>
         <target state="translated">Wählen Sie ein neues Passwort aus</target>
-        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="15">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ad9476afb3cde04fd01e41ab85a0180eabfdb1c" resname="Choose the title of the document to export" approved="yes">
         <source>Choose the title of the document to export</source>
         <target state="translated">Wählen Sie den Titel des Dokuments zu exportieren</target>
-        <jms:reference-file line="40">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0506773f181511d306efe57b7d20af4ea44fa1b3" resname="Civility" approved="yes">
         <source>Civility</source>
@@ -1777,8 +1777,8 @@
       <trans-unit id="719ea396ad92e01b4757ec2b93bb1e5f270f771d" resname="Clear" approved="yes">
         <source>Clear</source>
         <target state="translated">Klar</target>
-        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/log_scheduler.html.twig</jms:reference-file>
+        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7135ee5eaed0e404c4fcf48d6eb7d2808f8e55f2" resname="Clear list" approved="yes">
         <source>Clear list</source>
@@ -1825,8 +1825,8 @@
       <trans-unit id="30c54a96f8011b39819ba18bcb53fcbb092d650d" resname="Collection" approved="yes">
         <source>Collection</source>
         <target state="translated">Kollektion</target>
-        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="446">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/databox/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="814cd4d896d0d93eac2f4d71dc24c91a46cd5e28" resname="Collection %collection%" approved="yes">
@@ -1896,10 +1896,10 @@
       <trans-unit id="f7853f027e327a9ddf52dd60f8d1719ae6904333" resname="Confidentialite" approved="yes">
         <source>Confidentialite</source>
         <target state="translated">Vertraulichkeit</target>
-        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="56">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e9445beaddb548587c6f275e49da38e9fc7b785" resname="Confidentialite : privee" approved="yes">
         <source>Confidentialite : privee</source>
@@ -1990,7 +1990,7 @@
       <trans-unit id="da54a34bad5b32178cd5a344200f3beb72b8b214" resname="Cooliris" approved="yes">
         <source>Cooliris</source>
         <target state="translated">Cooliris</target>
-        <jms:reference-file line="55">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a1757945390259d3dbb7c551d01c23638463d39" resname="Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :" approved="yes">
         <source>Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :</source>
@@ -2046,7 +2046,7 @@
       <trans-unit id="26a9831600fb0e895035038bcac30cc389b393e0" resname="Create index" approved="yes">
         <source>Create index</source>
         <target state="translated">Index erstellen</target>
-        <jms:reference-file line="56">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="67">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c175379b0389b2d6057b0b7db996720f1fb92fc7" resname="Creation date" approved="yes">
         <source>Creation date</source>
@@ -2066,9 +2066,9 @@
       <trans-unit id="2bd00521d39c34d7b8a4a42573e1cf42fb319036" resname="Creer" approved="yes">
         <source>Creer</source>
         <target state="translated">erstellen</target>
-        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e0c179a64761a8abdbd1a1ef499e6aa7fd41b516" resname="Creer la tache d'ecriture des metadonnees" approved="yes">
         <source>Creer la tache d'ecriture des metadonnees</source>
@@ -2113,8 +2113,8 @@
       <trans-unit id="6a2b9fb6f6a60bde44a1bbe5e058c013cb1004ea" resname="Creer une playlist" approved="yes">
         <source>Creer une playlist</source>
         <target state="translated">einen neuen Playlist erstellen</target>
-        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c26eb5f5ded79caa39c9dd44376bf3556f6466" resname="Creez une application pour commencer a utiliser l'API Phraseanet" approved="yes">
         <source>Creez une application pour commencer a utiliser l'API Phraseanet</source>
@@ -2145,12 +2145,12 @@
       <trans-unit id="19dff4dad0a7214ece14624f8c4c9fb206a1cfdd" resname="Current password" approved="yes">
         <source>Current password</source>
         <target state="translated">aktuelles Passwort</target>
-        <jms:reference-file line="26">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e8ae2dcb43aa1748c5f5facbb8bcc2b52a627059" resname="Current session" approved="yes">
         <source>Current session</source>
         <target state="translated">Aktuelle Sitzung</target>
-        <jms:reference-file line="43">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="46">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="081ae3fdc403609cf6e760849ebb14117b7a50cb" resname="Custom" approved="yes">
         <source>Custom</source>
@@ -2166,12 +2166,12 @@
       <trans-unit id="ce3e4bed2954adbf05f8edfaf1a4c0cc0cea70e9" resname="DE" approved="yes">
         <source>DE</source>
         <target state="translated">DE</target>
-        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="129bcdb9bbdbd9bba49b7e1eb1ec49698604f0b0" resname="DU" approved="yes">
         <source>DU</source>
         <target state="translated">DU</target>
-        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e2dc4518235e7567a3d68c45cb6165ec116fa3c" resname="Danger zone !" approved="yes">
         <source>Danger zone !</source>
@@ -2253,13 +2253,13 @@
       <trans-unit id="910c2f8e114bda3eef68b7f17eee5e864be52dc4" resname="Date de connexion" approved="yes">
         <source>Date de connexion</source>
         <target state="translated">Verbindungsdatum</target>
-        <jms:reference-file line="22">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d5e8d1af5f3c137fb998b7afa347eeea683a7229" resname="Date de création" approved="yes">
         <source>Date de création</source>
         <target state="translated">Erstellungsdatum</target>
-        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a13dfa9c55746372090d1ffbd465703786b7f90" resname="Date de demande" approved="yes">
         <source>Date de demande</source>
@@ -2271,8 +2271,8 @@
       <trans-unit id="c004345fde85bded2c74513e29c8cd58d74b594f" resname="Date de modification" approved="yes">
         <source>Date de modification</source>
         <target state="translated">Änderungsdatum</target>
-        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="11">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce084029e351b4bfa9f425ae70e8aaa14a8904e5" resname="Date(s) from field(s)" approved="yes">
         <source>Date(s) from field(s)</source>
@@ -2315,7 +2315,7 @@
       <trans-unit id="7f4c92d36ad39747b7393498e20a21e3898d5ea6" resname="Default TTL in seconds of sub-definition url" approved="yes">
         <source>Default TTL in seconds of sub-definition url</source>
         <target state="translated">Standard-TTL in Sekunden, von URL Unterauflösung</target>
-        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="21cec17f6cd9c992f10804a71ea6d286a56c456a" resname="Default basket" approved="yes">
         <source>Default basket</source>
@@ -2325,27 +2325,27 @@
       <trans-unit id="1747ef3d688685c5844db2dc7c98aafd78ce3893" resname="Default export title" approved="yes">
         <source>Default export title</source>
         <target state="translated">Standard Export Titel</target>
-        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0865e6ae43db7711e100ad36595c2b38742f0b9f" resname="Default mail sender address" approved="yes">
         <source>Default mail sender address</source>
         <target state="translated">Standard E-Mail Absenderadresse</target>
-        <jms:reference-file line="22">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1ad516bc09a2a902e2bf2d738bed0236b5a61c5e" resname="Default query" approved="yes">
         <source>Default query</source>
         <target state="translated">Standardsuche</target>
-        <jms:reference-file line="26">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27cbd98bc854aa8480d4c436e762e9f30a00474e" resname="Default searched type" approved="yes">
         <source>Default searched type</source>
         <target state="translated">Standard Suchoptionen</target>
-        <jms:reference-file line="29">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ccd20794e5c5f8f28ac9b0b2f57b29bcd31ddfc6" resname="Default validation links duration" approved="yes">
         <source>Default validation links duration</source>
         <target state="translated">Standarddauer für die Validierungslinke</target>
-        <jms:reference-file line="29">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="332c9d57e19e2419cf5246fc9283f182eb316b8d" resname="Define a webhook URL" approved="yes">
         <source>Define a webhook URL</source>
@@ -2360,7 +2360,7 @@
       <trans-unit id="3b6bf506a535e9bf22431eace58b8f2f704dbd2a" resname="Defined in Apache configuration" approved="yes">
         <source>Defined in Apache configuration</source>
         <target state="translated">in der Apache Konfiguration definiert</target>
-        <jms:reference-file line="41">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a147677ac3ad9bbeaa766ccee9b2f2d3c7e1d59" resname="Delai depasse lors du contact avec le serveur WEB" approved="yes">
         <source>Delai depasse lors du contact avec le serveur WEB</source>
@@ -2430,20 +2430,20 @@
       <trans-unit id="57ec2e2addbd6a4117f16c1fff5f491fe3c5642c" resname="Deplacement %n_element% elements" approved="yes">
         <source>Deplacement %n_element% elements</source>
         <target state="translated">Bewegung von %n_element% Elemente</target>
-        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17c91ee147631da4f5aacabed0e198eb02955790" resname="Dernier access" approved="yes">
         <source>Dernier access</source>
         <target state="translated">Letzter Zugriff</target>
-        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="821ed4c906c76220f9dc83eba5e0b861e22baa04" resname="Derniere mise a jour le %updated_on%" approved="yes">
         <source>Derniere mise a jour le %updated_on%</source>
         <target state="translated">letztes Update am %updated_on%</target>
-        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="45">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dcce9368ad626fe4addfa719b7a16807d464aa9b" resname="Derniers envois" approved="yes">
         <source>Derniers envois</source>
@@ -2459,29 +2459,29 @@
       <trans-unit id="55f8ebc805e65b5b71ddafdae390e3be2bcd69af" resname="Description" approved="yes">
         <source>Description</source>
         <target state="translated">Beschreibung</target>
-        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/Tooltip/DCESFieldInfo.html.twig</jms:reference-file>
-        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="31">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85cce1e14782f67cb830f74002ebe5603783c674" resname="Deselect all" approved="yes">
         <source>Deselect all</source>
         <target state="translated">Alle abwählen</target>
-        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="60">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="225">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd281ce85e6f98a7dad0aa31a2e493a85ef178ca" resname="Design of personalization logo section" approved="yes">
         <source>Design of personalization logo section</source>
         <target state="translated">Logo Anpassung</target>
-        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac930a136ebd04a19bc5f2ce1769fc065efb7bdf" resname="Detailed view URL" approved="yes">
         <source>Detailed view URL</source>
@@ -2507,8 +2507,8 @@
       <trans-unit id="45e147abd920eeb1aca320340e18cf67b4c77252" resname="Dimension" approved="yes">
         <source>Dimension</source>
         <target state="translated">Grösse</target>
-        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Unknown.php</jms:reference-file>
+        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Image.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8b6613d50c2d8718fd7cab023e1530ce11650736" resname="Disable document type sharing" approved="yes">
@@ -2519,12 +2519,12 @@
       <trans-unit id="f4f4473df8cb59f0a369aebee3d1509adc0151c6" resname="Disabled" approved="yes">
         <source>Disabled</source>
         <target state="translated">Deaktiviert</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e304849daf61291daab688ef3154c851694909e6" resname="Disallow the possibility for the end user to disable push authentication" approved="yes">
         <source>Disallow the possibility for the end user to disable push authentication</source>
         <target state="translated">Möglichkeit verweigern, die Push Authentifizierung für die EndBenutzer zu deaktivieren</target>
-        <jms:reference-file line="55">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="68">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa9fd169cd55f0433c6e7a4b5d758f90d0847411" resname="Display &amp; action settings" approved="yes">
         <source><![CDATA[Display & action settings]]></source>
@@ -2564,7 +2564,7 @@
       <trans-unit id="1dc1290f2dcd49c014e5cae4004924885fbd68ed" resname="Do you really want to end the activity of this session?" approved="yes">
         <source>Do you really want to end the activity of this session?</source>
         <target state="translated">Möchten Sie wirklich, die Aktivität von dieser Sitzung beenden?</target>
-        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="017fd7aedf39f509d51ce202368e4f0ea943de4e" resname="Do you want to send your report ?" approved="yes">
         <source>Do you want to send your report ?</source>
@@ -2600,12 +2600,12 @@
       <trans-unit id="3859bdaa8c6ffa767307d2ebc130439c543819c8" resname="Document title" approved="yes">
         <source>Document title</source>
         <target state="translated">Titel des Dokuments</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="687c82861c956e47456186f6522cfc8dbadb8ef6" resname="Documents" approved="yes">
         <source>Documents</source>
         <target state="translated">Dokumente</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1096d02ee2e62ae8ea5873c92b391094d9f9516e" resname="Documents indisponibles" approved="yes">
         <source>Documents indisponibles</source>
@@ -2643,7 +2643,7 @@
       <trans-unit id="4e4528018d1a0aa11f7dc17b5425174a7436d334" resname="Drop index" approved="yes">
         <source>Drop index</source>
         <target state="translated">Drop index</target>
-        <jms:reference-file line="49">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a9c043f68c147a7c8d8c2fa14ddfaba6e05da62" resname="Duree" approved="yes">
         <source>Duree</source>
@@ -2658,8 +2658,8 @@
       <trans-unit id="0d01e2e86669e98441ab4dce5520696c318b7098" resname="E-mail" approved="yes">
         <source>E-mail</source>
         <target state="translated">E-Mail Adresse</target>
-        <jms:reference-file line="23">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="37">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9cf2896f8b2e9e6a28f9b151e8be31f220a5d256" resname="E-mail domain" approved="yes">
         <source>E-mail domain</source>
@@ -2669,7 +2669,7 @@
       <trans-unit id="734a78cd06d0929c433f487754d18bf073e43bf6" resname="EN" approved="yes">
         <source>EN</source>
         <target state="translated">EN</target>
-        <jms:reference-file line="37">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a908567d2c0292366061394efd6d40b139e033c5" resname="ERREUR : La classe de subdef est necessaire et egal a &quot;thumbnail&quot;,&quot;preview&quot; ou &quot;document&quot;" approved="yes">
         <source>ERREUR : La classe de subdef est necessaire et egal a "thumbnail","preview" ou "document"</source>
@@ -2689,7 +2689,7 @@
       <trans-unit id="9debabbaa01a190fabe8324c5e6e2f2808052099" resname="ES" approved="yes">
         <source>ES</source>
         <target state="translated">ES</target>
-        <jms:reference-file line="38">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5301648dcf6b53cefc9ed52999aaa92d4603cae0" resname="Edit" approved="yes">
         <source>Edit</source>
@@ -2714,9 +2714,9 @@
       <trans-unit id="5184ecbec7829b91dda100c703ea3fa284c7f5e8" resname="Edition de 1 element" approved="yes">
         <source>Edition de 1 element</source>
         <target state="translated">Bearbeitung von 1 Element</target>
-        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="10">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99ead0eb32b2089a9933db5ccc262e2fc35fd0a6" resname="Edition des droits de %display_name%" approved="yes">
         <source>Edition des droits de %display_name%</source>
@@ -2751,19 +2751,19 @@
       <trans-unit id="201b9ab150a2ab3e5641814c373f8db1949199d0" resname="ElasticSearch index name" approved="yes">
         <source>ElasticSearch index name</source>
         <target state="translated">ElasticSearch Index Name</target>
-        <jms:reference-file line="44">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="55">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="666">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b89586db0b00163ce75ae7426f06aa2e2a57b223" resname="ElasticSearch server host" approved="yes">
         <source>ElasticSearch server host</source>
         <target state="translated">ElasticSearch Server Host</target>
-        <jms:reference-file line="37">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="48">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="654">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18fd7d0c79d71cd9317190ae98dccdb1f7cf8b76" resname="ElasticSearch service port" approved="yes">
         <source>ElasticSearch service port</source>
         <target state="translated">ElasticSearch Service Schnittstelle</target>
-        <jms:reference-file line="40">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="51">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="658">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="84add5b2952787581cb9a8851eef63d1ec75d22b" resname="Email" approved="yes">
@@ -2844,7 +2844,7 @@
       <trans-unit id="16edbca430dbc855d01b65c634474ae1648e1890" resname="Empty if not used" approved="yes">
         <source>Empty if not used</source>
         <target state="translated">leer, wenn nicht benutzt</target>
-        <jms:reference-file line="45">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c90ec9c48fe61ec12eff0a4e00b6d74780aa38" resname="Empty quarantine" approved="yes">
         <source>Empty quarantine</source>
@@ -2876,8 +2876,8 @@
       <trans-unit id="0413c20ae2fd31e0a1eef73e7768c8e1c68558d9" resname="En cours d'encodage" approved="yes">
         <source>En cours d'encodage</source>
         <target state="translated">Kodierung läuft</target>
-        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="531">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="56">actions/Bridge/records_list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="43494e363213dc176e0699b914ccf966ccbd994d" resname="En cours d'envoi" approved="yes">
@@ -2888,42 +2888,42 @@
       <trans-unit id="4b4a90ee07557c5f8d1a9aedaed0fafacc4cc58f" resname="Enable FTP export" approved="yes">
         <source>Enable FTP export</source>
         <target state="translated">FTP Export aktivieren</target>
-        <jms:reference-file line="22">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4f48c8f3f90677271cd196305954c1bc820a420" resname="Enable FTP for users" approved="yes">
         <source>Enable FTP for users</source>
         <target state="translated">FTP für die Benutzer aktivieren</target>
-        <jms:reference-file line="26">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="25b38d3df5918f72187522a9cf74625c729ac6ad" resname="Enable Forcing authentication to see push content" approved="yes">
         <source>Enable Forcing authentication to see push content</source>
         <target state="translated">Aufzwingende Authentifizierung aktivieren, um den Push Inhalt anzuschauen</target>
-        <jms:reference-file line="51">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e2edcbbb1c6aa26ccce6fbf04bec121c904dcec" resname="Enable H264 stream mode" approved="yes">
         <source>Enable H264 stream mode</source>
         <target state="translated">H264 Stream Modus aktivieren</target>
-        <jms:reference-file line="30">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc15a5aec96be87d7fec6a07972f8ac99693b265" resname="Enable HD substitution" approved="yes">
         <source>Enable HD substitution</source>
         <target state="translated">HD Ersetzung aktivieren</target>
-        <jms:reference-file line="28">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="344fc3edd6987653de543b2ecd2d31aec2f3cca0" resname="Enable Phraseanet Web API" approved="yes">
         <source>Enable Phraseanet Web API</source>
         <target state="translated">Phraseanet Web API aktivieren</target>
-        <jms:reference-file line="22">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee98e71194d6f532c3c777fa20a957c3ba490089" resname="Enable SMTP authentication" approved="yes">
         <source>Enable SMTP authentication</source>
         <target state="translated">SMTP Authentifizierung aktivieren</target>
-        <jms:reference-file line="31">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1abba66821d3efad3698297ceac2c3fc0e985faf" resname="Enable auto registration" approved="yes">
         <source>Enable auto registration</source>
         <target state="translated">Automatische Anmeldung aktivieren</target>
-        <jms:reference-file line="26">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84aa616ef0b3e29513430631bf82c50c9cde7406" resname="Enable document type sharing" approved="yes">
         <source>Enable document type sharing</source>
@@ -2933,43 +2933,43 @@
       <trans-unit id="af559a0c4023968d8723bcdfe3337ce72eca48eb" resname="Enable maintenance message broadcast" approved="yes">
         <source>Enable maintenance message broadcast</source>
         <target state="translated">Aussendung von Wartungsmeldungen aktivieren</target>
-        <jms:reference-file line="25">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2b8f6db16b5583a7d9ef39a74fe471390d73bd74" resname="Enable multi-doc mode" approved="yes">
         <source>Enable multi-doc mode</source>
         <target state="translated">MultiDoc modus aktivieren</target>
-        <jms:reference-file line="25">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="af54ffee479b01e950445015c81b8e68c1347a66" resname="Enable possibility to notify users when publishing a new feed entry" approved="yes">
         <source>Enable possibility to notify users when publishing a new feed entry</source>
         <target state="translated">Ermöglichen, Benutzern zu benachritigen, als sie eine neue Eingabe veröffentlichen</target>
-        <jms:reference-file line="58">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="35a2e4d551405a7ce8cdf754de5a47c8922b52d7" resname="Enable thesaurus" approved="yes">
         <source>Enable thesaurus</source>
         <target state="translated">Thesaurus aktivieren</target>
-        <jms:reference-file line="22">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="56848224e379e98e9a4cbcad0b51a0e99f7980f0" resname="Enable this setting to share on Facebook and Twitter" approved="yes">
         <source>Enable this setting to share on Facebook and Twitter</source>
         <target state="translated">Aktivieren Sie diese Einstellung, um Dateien auf Facebook und Twitter zu teilen</target>
-        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8c91cee722569eccd85bf170aff83c6b8e3b4d1" resname="Enable thumbnail substitution" approved="yes">
         <source>Enable thumbnail substitution</source>
         <target state="translated">Miniaturansicht Ersetzung aktivieren</target>
-        <jms:reference-file line="31">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df174a3f2faa31814e06540acda7af8825403fac" resname="Enabled" approved="yes">
         <source>Enabled</source>
         <target state="translated">Aktiviert</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c2951dce186cc543b533d553a40cd64c767c6d7b" resname="End Activity" approved="yes">
         <source>End Activity</source>
         <target state="translated">Aktivität beenden</target>
         <jms:reference-file line="13">web/account/sessions.html.twig</jms:reference-file>
-        <jms:reference-file line="41">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61983e17f966924dc25febd5756e710e2102d38f" resname="End Range" approved="yes">
         <source>End Range</source>
@@ -2979,7 +2979,7 @@
       <trans-unit id="b5d90b80b452e4c8e3f1840c23372475d8861803" resname="End session activity" approved="yes">
         <source>End session activity</source>
         <target state="translated">Sitzung Aktivität beenden</target>
-        <jms:reference-file line="69">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="42f2df94366ecaac40f51500a7583ecc8c6d424b" resname="Enter your e-mail address to retrieve your password" approved="yes">
         <source>Enter your e-mail address to retrieve your password</source>
@@ -3124,8 +3124,8 @@
       <trans-unit id="40019ae278d51a265b82e37738989bf1b22157b7" resname="Etendue de la publication" approved="yes">
         <source>Etendue de la publication</source>
         <target state="translated">Erweiterung der Veröffentlichung</target>
-        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="255f8b2705b27e25acc23428730bfd7a32d9a0db" resname="Etes vous sur de supprimer %number% photos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% photos ?</source>
@@ -3140,14 +3140,14 @@
       <trans-unit id="e7f864e2cef6464cd4342b0a0b607c6b53fd8263" resname="Etes vous sur de supprimer %number% playlists ?" approved="yes">
         <source>Etes vous sur de supprimer %number% playlists ?</source>
         <target state="translated">Sind Sie sicher, %number% Playlisten zu löschen?</target>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0181b1da6f09b84ae46efce781899eb57ec74b8" resname="Etes vous sur de supprimer %number% videos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% videos ?</source>
         <target state="translated">Sind Sie sicher, %number%  Videos zu löschen?</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46a1884f7b083976b0fd0678f10b8f00ee93cde9" resname="Ex : Paris, bleu, montagne" approved="yes">
         <source>Ex : Paris, bleu, montagne</source>
@@ -3172,9 +3172,9 @@
       <trans-unit id="f3e4fadb9e370a1e2c0c622c01fc8c77daf93a2c" resname="Export" approved="yes">
         <source>Export</source>
         <target state="translated">Exportieren</target>
+        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="75">Controller/Prod/DoDownloadController.php</jms:reference-file>
         <jms:reference-file line="76">Controller/Prod/DoDownloadController.php</jms:reference-file>
-        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c26d273867dffc55d40f46e6a163067c75969f5" resname="Export ranges" approved="yes">
         <source>Export ranges</source>
@@ -3189,7 +3189,7 @@
       <trans-unit id="6d2830b1e76dc7300fce6745176601827d233de8" resname="FR" approved="yes">
         <source>FR</source>
         <target state="translated">FR</target>
-        <jms:reference-file line="36">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="acb28212fba0272ee990cebd571ebe09b463312e" resname="FTP" approved="yes">
         <source>FTP</source>
@@ -3215,10 +3215,10 @@
         <source>Feedback</source>
         <target state="translated">Feedback</target>
         <jms:reference-file line="122">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="54">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="90d95d818c456d269d000b3d82579506f6e34c5f" resname="Feedback:: Requested by %initiator% on %createdDate%" approved="yes">
         <source>Feedback:: Requested by %initiator% on %createdDate%</source>
@@ -3278,11 +3278,11 @@
       <trans-unit id="aadf78d4b7c7c7341aa891adca70897c4f978cb6" resname="File is not present in quarantine anymore, please refresh" approved="yes">
         <source>File is not present in quarantine anymore, please refresh</source>
         <target state="translated">Datei befindet sich nicht mehr in der Quarantäne, bitte aktualisieren</target>
+        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="56">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="136">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="157">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
-        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3491d2e44dd1896af3411bb1a048847c13647feb" resname="File is too big : 64k max" approved="yes">
         <source>File is too big : 64k max</source>
@@ -3427,7 +3427,7 @@
       <trans-unit id="a5ec616668f5ea6fa47eec00bbe6e31964599856" resname="GD" approved="yes">
         <source>GD</source>
         <target state="translated">GD-Bibliothek</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a45e2e1fd0f0cb30474f4cfd3d8fbdc9fd7fb9" resname="GOP size" approved="yes">
         <source>GOP size</source>
@@ -3437,7 +3437,7 @@
       <trans-unit id="9c30a3485a5887f1ba5abd2a291d304a01863e55" resname="Gallery" approved="yes">
         <source>Gallery</source>
         <target state="translated">Gallery</target>
-        <jms:reference-file line="57">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="259242b8cd71adbfc416f01eaef816dacc0d8384" resname="General configuration" approved="yes">
         <source>General configuration</source>
@@ -3493,7 +3493,7 @@
       <trans-unit id="efd1f5fd46c31701d2e70555e9ab45efe27b4048" resname="Geonames server address" approved="yes">
         <source>Geonames server address</source>
         <target state="translated">GeoNames Serveradresse</target>
-        <jms:reference-file line="35">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5334c3c15248b80aba72d8a192cb45256f6de263" resname="Get a notification when a mail export fails" approved="yes">
         <source>Get a notification when a mail export fails</source>
@@ -3503,7 +3503,7 @@
       <trans-unit id="05a07cd950e4b273afdde28fa0b591cc75524121" resname="Get setting form index" approved="yes">
         <source>Get setting form index</source>
         <target state="translated">Index Daten erhalten</target>
-        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="92">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee485ef50d127d2c51fe0091051d8c390d03ed59" resname="Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side." approved="yes">
         <source>Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side.</source>
@@ -3538,7 +3538,7 @@
       <trans-unit id="442bee77a51f11ee32ca32751c4e244e80de6e3d" resname="Google Analytics identifier" approved="yes">
         <source>Google Analytics identifier</source>
         <target state="translated">Google Analytics Bezeichner</target>
-        <jms:reference-file line="39">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="362c03cff3bb37904f552194e92e5f13c721882f" resname="Grant rights" approved="yes">
         <source>Grant rights</source>
@@ -3558,7 +3558,7 @@
       <trans-unit id="cd6d6f27b3e16afd7cdd573b85b3cc5bfd22e8db" resname="GraphicsMagick" approved="yes">
         <source>GraphicsMagick</source>
         <target state="translated">GraphicsMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="779f61efcfe62182d0052c9526f3910378764758" resname="Graphiste (preview au rollover)" approved="yes">
         <source>Graphiste (preview au rollover)</source>
@@ -3610,8 +3610,8 @@
       <trans-unit id="d0d3632efe2a20cf1235aead5d817e03308131cc" resname="Hello %username%" approved="yes">
         <source>Hello %username%</source>
         <target state="translated">Hallo %username%</target>
-        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="82">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="62">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c47ae15370cfe1ed2781eedc1dc2547d12d9e972" resname="Help" approved="yes">
@@ -3627,21 +3627,21 @@
       <trans-unit id="78860a4e5b33556e6a8947485d8b042d9e58234e" resname="Hide information about users" approved="yes">
         <source>Hide information about users</source>
         <target state="translated">Informationen über die Benutzer ausblenden</target>
-        <jms:reference-file line="35">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="70f8bb9a8a5393ef080507a89e4b98d139000d65" resname="Home" approved="yes">
         <source>Home</source>
         <target state="translated">Hauptseite</target>
-        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="3">login/include/language-block.html.twig</jms:reference-file>
-        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="49">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99f3b7dca04d6f354a9d2a3b633d9578a9ad8cac" resname="Homepage slideshow" approved="yes">
         <source>Homepage slideshow</source>
         <target state="translated">Homeseite Diashow</target>
-        <jms:reference-file line="51">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8e41286dd8a6f03ef89a5aa958b1dad86ba4211f" resname="Hyperfocal distance" approved="yes">
         <source>Hyperfocal distance</source>
@@ -3651,13 +3651,13 @@
       <trans-unit id="f39bf9043aaeea61e7a0ba3949d854bd3997cb2a" resname="I have read the terms of use" approved="yes">
         <source>I have read the terms of use</source>
         <target state="translated">Ich habe die Nutzungsbedingungen gelesen</target>
-        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
         <jms:reference-file line="68">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ea424d38af72dd1366a08aad1f47eca3e7ec3d24" resname="IP" approved="yes">
         <source>IP</source>
         <target state="translated">IP</target>
-        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f325d995b6d028ccc75771b1679537b623521c4" resname="ISO" approved="yes">
         <source>ISO</source>
@@ -3682,17 +3682,17 @@
       <trans-unit id="447a3b86a8a61425d5c46aed97eb2e7cf0bb769c" resname="If request is bigger, then mail is still available" approved="yes">
         <source>If request is bigger, then mail is still available</source>
         <target state="translated">Wenn die Anfrage ist grösser, können Sie durch E-Mail senden</target>
-        <jms:reference-file line="23">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d9e4315a74579080394bc6a6fdb7f5eccbf41e8" resname="If set to 0, duration is permanent" approved="yes">
         <source>If set to 0, duration is permanent</source>
         <target state="translated">Ist es auf null gestellt, ist die Zeitdauer bleibend</target>
-        <jms:reference-file line="30">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="516e5bc94c0583cb8e632e13c36f77e514e0afc3" resname="If you notice any unfamiliar devices or locations, click on button %button% to end the session." approved="yes">
         <source>If you notice any unfamiliar devices or locations, click on button %button% to end the session.</source>
         <target state="translated">Wenn Sie ungewohnte Geräte oder Orten bemerken, klicken Sie auf %button%, um die Sitzung zu schliessen.</target>
-        <jms:reference-file line="15">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="17">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f91c7b9a3a35352f74a9fb8708e35ddbb36a852b" resname="If you plan to store large files, be sure it will fit in these directories." approved="yes">
         <source>If you plan to store large files, be sure it will fit in these directories.</source>
@@ -3722,7 +3722,7 @@
       <trans-unit id="57a8e563190f921afb876d6489bb40ed74f43a1a" resname="ImageMagick" approved="yes">
         <source>ImageMagick</source>
         <target state="translated">ImageMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3e38a20c1629a473809ea6a14c9cdf4204d3ac3b" resname="Images par secondes" approved="yes">
         <source>Images par secondes</source>
@@ -3738,7 +3738,7 @@
       <trans-unit id="bae76060aa0bb6aaf66ce914cf80b0786f965dc7" resname="Imagine driver" approved="yes">
         <source>Imagine driver</source>
         <target state="translated">Imagine driver</target>
-        <jms:reference-file line="52">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca13920228ea59b30c40b8372f53df3bf4631520" resname="In the answer grid" approved="yes">
         <source>In the answer grid</source>
@@ -3775,9 +3775,9 @@
       <trans-unit id="54937b3a4f8cfa4576692882d3ff7b14c90c4ce5" resname="Informations" approved="yes">
         <source>Informations</source>
         <target state="translated">Informationen</target>
-        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/account/base.html.twig</jms:reference-file>
+        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e1e0586141223b0143df16f7422dae5a43b77103" resname="Informations personnelles" approved="yes">
         <source>Informations personnelles</source>
@@ -3826,8 +3826,8 @@
         <source>Invalid file type, only (%supported_file_types%) file formats are supported</source>
         <target state="translated">ungültiger Dateityp, nur (%supported_file_types%) Dateitypen werden unterstützt</target>
         <jms:reference-file line="60">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
         <jms:reference-file line="199">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="65fd566280b15a384df25c73315b0dcbc6dacb69" resname="Invalid file type, only (%supported_file_types%) file formats are supported'" approved="yes">
         <source>Invalid file type, only (%supported_file_types%) file formats are supported'</source>
@@ -3864,8 +3864,8 @@
       <trans-unit id="8606f0ad87b5f92e01e46416cad301829571b7a7" resname="Inverser" approved="yes">
         <source>Inverser</source>
         <target state="translated">umkehren</target>
-        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3067f6d77794b736024c9a5594c1823612581e07" resname="It is not recommended to install Phraseanet without HTTPS support" approved="yes">
         <source>It is not recommended to install Phraseanet without HTTPS support</source>
@@ -3895,13 +3895,13 @@
       <trans-unit id="aa288d5bdc9be4c044885fa43c6f3758a1087d5a" resname="Keywords used for indexing purposes by search engines robots" approved="yes">
         <source>Keywords used for indexing purposes by search engines robots</source>
         <target state="translated">Schlüsselwörter, die für Indexierung Zwecke von Suchroboter benutzt werden</target>
-        <jms:reference-file line="33">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e9f378dcffe600d99f66ba5fa74cd91d10b2256" resname="L'upload a echoue" approved="yes">
         <source>L'upload a echoue</source>
         <target state="translated">Upload ist fehlgeschlagen</target>
-        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="486">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="94fe10f78d9c8b531bbd609a20f373289599035c" resname="L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%" approved="yes">
         <source>L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%</source>
@@ -3945,20 +3945,20 @@
       <trans-unit id="cfa0120ab592ae2bc3198dbde15a7a87a0c792c4" resname="La taille maximale d'une video est de %duration% minutes." approved="yes">
         <source>La taille maximale d'une video est de %duration% minutes.</source>
         <target state="translated">Maximale Dauer für eine Video ist %duration% Minuten.</target>
-        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="900">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dcfd86b957b9cf12ede165c6c2fa0acf12f3eeb" resname="La video a ete rejetee" approved="yes">
         <source>La video a ete rejetee</source>
         <target state="translated">Das Video wurde abgelehnt</target>
-        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="527">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="653e67f152ecc63ff3ee1014e86cc630a35dfe1a" resname="La video a ete supprimee" approved="yes">
         <source>La video a ete supprimee</source>
         <target state="translated">Das Video wurde gelöscht</target>
-        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="525">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="da1c672d0d761ed5ac292335ed60e14ff3073265" resname="La video est restreinte" approved="yes">
         <source>La video est restreinte</source>
@@ -4054,16 +4054,16 @@
       <trans-unit id="b96ead6ab3add78d8448fcb2d18af281bb2cb278" resname="Le poids maximum d'un fichier est de %size%" approved="yes">
         <source>Le poids maximum d'un fichier est de %size%</source>
         <target state="translated">Maximales Gewicht von Datei ist %size%</target>
-        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="906">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="814">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="13b9d7ef8e81663d7162d25b84cec1c24041e630" resname="Le record n'a pas de fichier physique" approved="yes">
         <source>Le record n'a pas de fichier physique</source>
         <target state="translated">Der Datensatz hat keine physikalische Datei</target>
-        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="896">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="808">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a596c989f20650068f6278338c1a966b7a8693f8" resname="Le token n'a pas encore ete genere" approved="yes">
         <source>Le token n'a pas encore ete genere</source>
@@ -4084,9 +4084,9 @@
       <trans-unit id="e330465da3182b7f6ed1b78217993edb4e22aacb" resname="Les elements ne peuvent etre uploades (problemes de type ou de droit)" approved="yes">
         <source>Les elements ne peuvent etre uploades (problemes de type ou de droit)</source>
         <target state="translated">Die Elemente können nicht hochgeladen werden (Typ oder Rechte Problem).</target>
-        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="15">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="72d3dbec389dce620bfa531d37c5f199ca2ccfda" resname="Les indications donnees ci dessous sont a titre informatif." approved="yes">
         <source>Les indications donnees ci dessous sont a titre informatif.</source>
@@ -4210,7 +4210,7 @@
       <trans-unit id="4e5a2893bdcc7d239c1db72e4c4ffbe4bea73174" resname="Login" approved="yes">
         <source>Login</source>
         <target state="translated">Benutzername</target>
-        <jms:reference-file line="32">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
         <jms:reference-file line="9">login/oauth/login.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/mapping.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/bind.html.twig</jms:reference-file>
@@ -4261,7 +4261,7 @@
       <trans-unit id="ca62571facf94a0b6b601235fa440be30c505b24" resname="Maintenance message" approved="yes">
         <source>Maintenance message</source>
         <target state="translated">Wartungsmeldung</target>
-        <jms:reference-file line="22">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb66e0bf5a145832586ceac41b71a4f95abcbc7e" resname="Maintenance state" approved="yes">
         <source>Maintenance state</source>
@@ -4321,22 +4321,22 @@
       <trans-unit id="bfceb124609fe75ad259082ced98a09429f02d2c" resname="Matomo Analytics identifier" approved="yes">
         <source>Matomo Analytics identifier</source>
         <target state="translated">Matomo Analytics site ID</target>
-        <jms:reference-file line="45">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d17f219ba947499e5a2f9b63a78d54deb821e1f8" resname="Matomo Analytics url" approved="yes">
         <source>Matomo Analytics url</source>
         <target state="translated">Matomo Analytics URL</target>
-        <jms:reference-file line="42">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28736b7711fa32497f69497b45453226c3bea0aa" resname="Maximum megabytes allowed for download" approved="yes">
         <source>Maximum megabytes allowed for download</source>
         <target state="translated">genehmigte Menge in Megabytes für Download</target>
-        <jms:reference-file line="22">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e91bcca4090d4b36db511b03beb7800d72baa230" resname="Maximum number of pages to be extracted from PDF" approved="yes">
         <source>Maximum number of pages to be extracted from PDF</source>
         <target state="translated">Seitenhöchstzahl aus PDF extrahiert</target>
-        <jms:reference-file line="61">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="453c592dee2184bc6fb63b94d517cf1a6354590b" resname="Mes applications" approved="yes">
         <source>Mes applications</source>
@@ -4374,7 +4374,7 @@
       <trans-unit id="cb4f425374af2741715669ed8b541a666078b729" resname="Minimum number of letters before truncation" approved="yes">
         <source>Minimum number of letters before truncation</source>
         <target state="translated">Mindestzeichenzahl vor der Kürzung</target>
-        <jms:reference-file line="22">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="815d1b7d85075463e14c340ff9897a6c4af09ec3" resname="Missing &quot;structure&quot; parameter" approved="yes">
         <source>Missing "structure" parameter</source>
@@ -4544,14 +4544,14 @@
       <trans-unit id="d850ee188c7c55b64bc3624534de5c5051a57dc6" resname="New password" approved="yes">
         <source>New password</source>
         <target state="translated">Neues Passwort</target>
-        <jms:reference-file line="47">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="39">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="49">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="572cfba6707b8e82f8c893b2188bede937e3f662" resname="New password (confirmation)" approved="yes">
         <source>New password (confirmation)</source>
         <target state="translated">Neues Passwort (Bestätigung)</target>
-        <jms:reference-file line="48">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="40">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17b2b838c5ce22c961a36736534a5029d6ba0087" resname="New task" approved="yes">
         <source>New task</source>
@@ -4568,8 +4568,8 @@
       <trans-unit id="816c52fd2bdd94a63cd0944823a6c0aa9384c103" resname="No" approved="yes">
         <source>No</source>
         <target state="translated">Nein</target>
-        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="283">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c123d8ad43d08cc48c3d6a7676e65f71eea59df" resname="No URL available" approved="yes">
         <source>No URL available</source>
@@ -4691,19 +4691,19 @@
       <trans-unit id="22838b9a8bf000656dd4ff96d8ac904c8c33fade" resname="Nom du nouveau panier" approved="yes">
         <source>Nom du nouveau panier</source>
         <target state="translated">Titel</target>
-        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c57d307e10f641b5b496db576d0dcd69d1daf25e" resname="Non-Restreinte (publique)" approved="yes">
         <source>Non-Restreinte (publique)</source>
         <target state="translated">Nicht eingeschränkt (öffentlich)</target>
-        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6eef6648406c333a4035cd5e60d0bf2ecf2606d7" resname="None" approved="yes">
         <source>None</source>
         <target state="translated">Keine</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
         <jms:reference-file line="56">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="260">admin/user/registrations.html.twig</jms:reference-file>
       </trans-unit>
@@ -4735,8 +4735,8 @@
       <trans-unit id="a6633333760410e40ad92a50baade0b83afe8f7f" resname="Not aggregated" approved="yes">
         <source>Not aggregated</source>
         <target state="translated">Nicht aggregiert</target>
-        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="241">admin/fields/templates.html.twig</jms:reference-file>
+        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc451929f50e088ffcff10e90dfe157d2319e753" resname="Notification par email" approved="yes">
         <source>Notification par email</source>
@@ -4797,25 +4797,25 @@
       <trans-unit id="997c69f6571530618bb38ac03f4cf2d236dcc15e" resname="Number of replicas" approved="yes">
         <source>Number of replicas</source>
         <target state="translated">Anzahl von Nachbauten</target>
-        <jms:reference-file line="66">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="77">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="674">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5c2a8aa4e676273c8d8f177856923ed9950e54bb" resname="Number of shards" approved="yes">
         <source>Number of shards</source>
         <target state="translated">Anzahl von Scherben</target>
-        <jms:reference-file line="62">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="73">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="670">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a44db49e9b745fe2a96ae2a2ef3595913e274b33" resname="Number of threads to use for FFMpeg" approved="yes">
         <source>Number of threads to use for FFMpeg</source>
         <target state="translated">Anzahl von Fäden für FFMpeg zu benutzen</target>
-        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ce3bd4224c8c1780db56b4125ecf3f24bf748b7" resname="OK" approved="yes">
         <source>OK</source>
         <target state="translated">OK</target>
-        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="535">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a98216a32426b9e66a4ac1eb6df2e96e1b495c" resname="Ok" approved="yes">
         <source>Ok</source>
@@ -4866,10 +4866,10 @@
       <trans-unit id="94946e4d2391ccf8ff24f984869ae8fcf9ede7c4" resname="Or login with" approved="yes">
         <source>Or login with</source>
         <target state="translated">Oder Anmeldung mit</target>
-        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
         <jms:reference-file line="103">web/login/index.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="91">login/oauth/login.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
+        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d75774c0f96b6ee44eb6643c9fea71b50b90ea8" resname="Order" approved="yes">
         <source>Order</source>
@@ -4909,7 +4909,7 @@
       <trans-unit id="77561f3d48cb738cc40f376dec4616a77da54ee1" resname="Original name" approved="yes">
         <source>Original name</source>
         <target state="translated">ursprünglicher Name</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="672c78971d44f4576ab54c347b873ad9dc98f5f1" resname="Oups ! something went wrong !" approved="yes">
         <source>Oups ! something went wrong !</source>
@@ -4929,9 +4929,9 @@
       <trans-unit id="fb06270f7c212baabc8749ffc36e49dc8f321548" resname="Page" approved="yes">
         <source>Page</source>
         <target state="translated">Seite</target>
-        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="600584c2d5ccb97c0c0c424d9f32d6b102fcb040" resname="Pages" approved="yes">
         <source>Pages</source>
@@ -4941,31 +4941,31 @@
       <trans-unit id="fe42b90acc297644b70123354014701c49384489" resname="Paniers" approved="yes">
         <source>Paniers</source>
         <target state="translated">Sammelkörbe</target>
+        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="127">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="173">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="55">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="142">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="379c70ed96868079feece6d5c6a2b91545c2515b" resname="Par %author%" approved="yes">
         <source>Par %author%</source>
         <target state="translated">Von %author%</target>
-        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="25">mobile/lightbox/feed.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8be3c943b1609fffbfc51aad666d0a04adf83c9d" resname="Password" approved="yes">
         <source>Password</source>
         <target state="translated">Passwort</target>
-        <jms:reference-file line="41">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
-        <jms:reference-file line="52">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="81">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e3c007b7794e8f9fc4381136dfc7cdff5aa788a8" resname="Password (confirmation)" approved="yes">
         <source>Password (confirmation)</source>
         <target state="translated">Passwort (Bestätigung)</target>
-        <jms:reference-file line="53">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e77cc0549ad99a9d3ba5c384f7f329db24d6d0c" resname="Password is empty at line %line%" approved="yes">
         <source>Password is empty at line %line%</source>
@@ -4995,7 +4995,7 @@
       <trans-unit id="102bbf0d1fb0a23cb8d8fb6eb03685b4509176c0" resname="Percent of the time left before the end of the validation to send a reminder email" approved="yes">
         <source>Percent of the time left before the end of the validation to send a reminder email</source>
         <target state="translated">Verbleibende Zeit Prozentsatz vor Ende des Feedbacks, um eine Erinnerungsmail zu senden</target>
-        <jms:reference-file line="26">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3d8de900b56813bb78e97afbf22578720d473219" resname="Periodically fetches an FTP repository content locally" approved="yes">
         <source>Periodically fetches an FTP repository content locally</source>
@@ -5061,14 +5061,14 @@
       <trans-unit id="cd95b41f85ddc0922e3fce8844279c55e9e3cdd9" resname="Playlist" approved="yes">
         <source>Playlist</source>
         <target state="translated">Playlist</target>
-        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77b69f32c8780049ce0eec9782c3b77bb1e52bc3" resname="Playlists" approved="yes">
         <source>Playlists</source>
         <target state="translated">Playlisten</target>
-        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="183">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a79729c3f4563330799d576273950579e1ba3f5" resname="Please accept the terms of use to register." approved="yes">
         <source>Please accept the terms of use to register.</source>
@@ -5197,7 +5197,7 @@
       <trans-unit id="40c963556bf21635f163641ae0bbc354c6f8452c" resname="Prefix for notification emails" approved="yes">
         <source>Prefix for notification emails</source>
         <target state="translated">Präfix für Benachrichtigungs-E-Mails</target>
-        <jms:reference-file line="25">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="29">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="474ae549026692693381925784cc30e5b706f330" resname="Prerequisite and Configuration" approved="yes">
         <source>Prerequisite and Configuration</source>
@@ -5212,7 +5212,7 @@
       <trans-unit id="be11dff872b14e749d330f920d6b159e107f277a" resname="Presentation de vignettes de panier" approved="yes">
         <source>Presentation de vignettes de panier</source>
         <target state="translated">Vorstellung der Voransichten des Sammelkorbes</target>
-        <jms:reference-file line="998">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1007">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e709e76ff5425bd59879423588e80e67d778fa57" resname="Presets" approved="yes">
         <source>Presets</source>
@@ -5278,13 +5278,13 @@
       <trans-unit id="a255047b3f86eb4c0c79377f0725c89ceafe07ae" resname="Publique" approved="yes">
         <source>Publique</source>
         <target state="translated">öffentliche</target>
-        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="40">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107e7fab79b95c8f34990d625dd309e15996acba" resname="Publishers" approved="yes">
         <source>Publishers</source>
         <target state="translated">Veröffentlicher</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f7f57b519fc9bc5683b4808641d3b33f53b6f9d" resname="Push" approved="yes">
         <source>Push</source>
@@ -5471,13 +5471,12 @@
         <source>Re-initialiser</source>
         <target state="translated">Zurücksetzen</target>
         <jms:reference-file line="411">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca2a6abfc98ae1a46c15a6f8bbdc5fac25531462" resname="Re-ordonner" approved="yes">
         <source>Re-ordonner</source>
         <target state="translated">wieder ordnen</target>
-        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="13">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="211">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="212">prod/WorkZone/Macros.html.twig</jms:reference-file>
@@ -5485,6 +5484,7 @@
         <jms:reference-file line="290">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="294">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="295">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9b19a5a212deb29444cc1b420ad81703205848be" resname="Read-only" approved="yes">
         <source>Read-only</source>
@@ -5494,12 +5494,12 @@
       <trans-unit id="8af84354a61a59531041ee67713997b84e7657ee" resname="Recaptcha private key" approved="yes">
         <source>Recaptcha private key</source>
         <target state="translated">geheimer Schlüssel für ReCaptcha</target>
-        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c821a7953fa090cedb78553591582972bd8836e9" resname="Recaptcha public key" approved="yes">
         <source>Recaptcha public key</source>
         <target state="translated">öffentlicher Schlüssel für ReCaptcha</target>
-        <jms:reference-file line="45">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="80f271a01202ec6ae47a6b61ad2bd75e4ccb4845" resname="Receive notification when I receive a push" approved="yes">
         <source>Receive notification when I receive a push</source>
@@ -5636,10 +5636,10 @@
       <trans-unit id="d672995a14650d0e018026b64f297663d8c71c8d" resname="Register" approved="yes">
         <source>Register</source>
         <target state="translated">Registrieren</target>
-        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="10">login/include/register-link-block.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ab985702970c5012a1c1a2db7b65d95926aecaf" resname="Register approbation" approved="yes">
         <source>Register approbation</source>
@@ -5671,7 +5671,7 @@
       <trans-unit id="ced7b308a348567fbf21dd775ee496dd01207f24" resname="Remember me" approved="yes">
         <source>Remember me</source>
         <target state="translated">Angemeldet bleiben</target>
-        <jms:reference-file line="51">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="55">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8005b356e3a4dba94a532df1deec4ebce882d13" resname="Reminder : validate '%title%'" approved="yes">
         <source>Reminder : validate '%title%'</source>
@@ -5708,8 +5708,8 @@
         <source>Renew password</source>
         <target state="translated">Passwort erneuern</target>
         <jms:reference-file line="58">Notification/Mail/MailRequestPasswordUpdate.php</jms:reference-file>
-        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee9dca727a184d24dd17095c1acacff79855df0d" resname="Reorder collections" approved="yes">
         <source>Reorder collections</source>
@@ -5719,8 +5719,8 @@
       <trans-unit id="fe8356db1811c518f0900dba0e65602c0fdcde3a" resname="Reordonner automatiquement" approved="yes">
         <source>Reordonner automatiquement</source>
         <target state="translated">automatisch neu anordnen</target>
-        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc5b6dcdaa76e91a51a264ce56aedb3ac385fc3b" resname="Repertoire de stockage des fichiers" approved="yes">
         <source>Repertoire de stockage des fichiers</source>
@@ -5751,7 +5751,7 @@
       <trans-unit id="0173481a881e3245000ec3fc5da8d26053ec2d37" resname="Require authentication to download documents" approved="yes">
         <source>Require authentication to download documents</source>
         <target state="translated">Authentifizierung benötigen, um Dokumente zu herunterladen</target>
-        <jms:reference-file line="33">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c91dfa0024a9c65cb1f4cba0f4744e66fbcccba" resname="Require email validation to activate the account" approved="yes">
         <source>Require email validation to activate the account</source>
@@ -5913,32 +5913,32 @@
       <trans-unit id="741cd64a01685389e2fabdb7091a3b70f6be63ee" resname="SMTP encryption" approved="yes">
         <source>SMTP encryption</source>
         <target state="translated">SMTP Verschlüsselung</target>
-        <jms:reference-file line="40">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d4a434baeeacaeeeb7e0ad914adfe6f76fb4fb6" resname="SMTP host" approved="yes">
         <source>SMTP host</source>
         <target state="translated">SMTP Host</target>
-        <jms:reference-file line="34">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c0c4b23b7cf057f27996bf14973bc8778d0f86e" resname="SMTP password" approved="yes">
         <source>SMTP password</source>
         <target state="translated">SMTP Passwort</target>
-        <jms:reference-file line="53">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="65b5a10871b0ff8eb5019b42bd57ef00c06a45a8" resname="SMTP port" approved="yes">
         <source>SMTP port</source>
         <target state="translated">SMTP Port</target>
-        <jms:reference-file line="37">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aa18a4725d6a5fd47cfc64a79cfe902abb215068" resname="SMTP user" approved="yes">
         <source>SMTP user</source>
         <target state="translated">SMTP Benutzer</target>
-        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="78bb8826fcc2504583e625386c238563e6207595" resname="SSL" approved="yes">
         <source>SSL</source>
         <target state="translated">SSL</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f40d195970d52ea94bbf5b0aa1dbe9822f10dd5" resname="SUBDEFS" approved="yes">
         <source>SUBDEFS</source>
@@ -5948,15 +5948,15 @@
       <trans-unit id="efc007a393f66cdb14d57d385822a3d9e36ef873" resname="Save" approved="yes">
         <source>Save</source>
         <target state="translated">Speichern</target>
-        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
         <jms:reference-file line="41">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="108">actions/Feedback/list.html.twig</jms:reference-file>
+        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/worker-manager/worker_ftp.html.twig</jms:reference-file>
         <jms:reference-file line="75">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="3">admin/search-engine/elastic-search.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="960c9d85e9849fa58deb038c6c9bcf36ec973c99" resname="Save all changes" approved="yes">
         <source>Save all changes</source>
@@ -6012,8 +6012,8 @@
       <trans-unit id="ce3df4d818316dd10c7bca5ae8539c894dc07dbb" resname="See" approved="yes">
         <source>See</source>
         <target state="translated">Sehen</target>
-        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="8">WorkZone/Browser/Browser.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a377f0dd2a261c8e46358dc8d0e8d9868bc6094f" resname="See documentation about structure manipulation." approved="yes">
         <source>See documentation about structure manipulation.</source>
@@ -6023,14 +6023,14 @@
       <trans-unit id="b5c208620e2d74920057e4d500f77788b86f41db" resname="See documentation at %url%" approved="yes">
         <source>See documentation at %url%</source>
         <target state="translated">Lesen Sie die Dokumentation auf %url%</target>
-        <jms:reference-file line="38">Form/Configuration/WebservicesFormType.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b945126af2994e142e712b4e6f3c2cb2dd186a76" resname="See my order" approved="yes">
         <source>See my order</source>
         <target state="translated">Meine Bestellung ansehen</target>
-        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
         <jms:reference-file line="74">Notification/Mail/MailInfoOrderDelivered.php</jms:reference-file>
+        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="369b9cb821dd6966e989359a1b8aadaf9c4db387" resname="See others" approved="yes">
         <source>See others</source>
@@ -6060,10 +6060,10 @@
       <trans-unit id="913afff1faf79724f1f685fe8b1e36a729123ca2" resname="Select all" approved="yes">
         <source>Select all</source>
         <target state="translated">Alle auswählen</target>
-        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="57">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="224">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c83f0d10a0a04ab6ae1ceb098113b081e9bc4d5" resname="Select all collections" approved="yes">
         <source>Select all collections</source>
@@ -6097,10 +6097,10 @@
         <target state="translated">Senden</target>
         <jms:reference-file line="101">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="46">web/login/forgot-password.html.twig</jms:reference-file>
-        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="113">prod/upload/upload.html.twig</jms:reference-file>
         <jms:reference-file line="110">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="185">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="220">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/admin/dashboard.html.twig</jms:reference-file>
@@ -6213,8 +6213,8 @@
       <trans-unit id="396c2137a0b503759e5d4930af8a16aa28ce3ee7" resname="Short description" approved="yes">
         <source>Short description</source>
         <target state="translated">Kurzbeschreibung</target>
-        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="18">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="32e50dd99f3b67dc93272aa6c904b83d37f4f48d" resname="Shutter speed" approved="yes">
         <source>Shutter speed</source>
@@ -6245,7 +6245,7 @@
       <trans-unit id="234bf52eb70433473b325e23026794557cca00d9" resname="Single image" approved="yes">
         <source>Single image</source>
         <target state="translated">Einzelbild</target>
-        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e78af337eef67e03f72ea26dbe1a69c326e3660" resname="Site web" approved="yes">
         <source>Site web</source>
@@ -6256,13 +6256,13 @@
         <source>Size</source>
         <target state="translated">Grösse</target>
         <jms:reference-file line="37">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
         <jms:reference-file line="116">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="000f280b111f7ab59b5f5f4462a40de0553664cc" resname="Slide show" approved="yes">
         <source>Slide show</source>
         <target state="translated">Diashow</target>
-        <jms:reference-file line="54">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6412f8f76fca194e1e7e1c3b13556497ac125db" resname="Some files are being downloaded" approved="yes">
         <source>Some files are being downloaded</source>
@@ -6314,8 +6314,8 @@
       <trans-unit id="8657e88f4bf4b28dd29659361c70f11dea58efa5" resname="Sous-titre" approved="yes">
         <source>Sous-titre</source>
         <target state="translated">Untertitel</target>
-        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="16">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="970f057325af27424f32675051fea5366873b007" resname="Space bar" approved="yes">
         <source>Space bar</source>
@@ -6330,8 +6330,8 @@
       <trans-unit id="952f375412e89ff213a8aca383d18e5691354347" resname="Start" approved="yes">
         <source>Start</source>
         <target state="translated">Start</target>
-        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="15">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
@@ -6348,14 +6348,14 @@
       <trans-unit id="7ec5491e76522fe1687d799f35ab2ba39ae573fe" resname="Start validation" approved="yes">
         <source>Start validation</source>
         <target state="translated">Bestätigung starten</target>
+        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
         <jms:reference-file line="47">Notification/Mail/MailInfoReminderFeedback.php</jms:reference-file>
         <jms:reference-file line="70">Notification/Mail/MailInfoValidationReminder.php</jms:reference-file>
-        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="faa9e7e7ef5a264c58c68a4a0b9c8bd54241450a" resname="Started" approved="yes">
         <source>Started</source>
         <target state="translated">Begonnen</target>
-        <jms:reference-file line="42">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="46">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e1c8377cce4ac872e1c3e8fc6bc760c5130946d" resname="Status des documents a rechercher" approved="yes">
         <source>Status des documents a rechercher</source>
@@ -6382,20 +6382,20 @@
         <target state="translated">Stop</target>
         <jms:reference-file line="8">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/upload/lazaret.html.twig</jms:reference-file>
-        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="10">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="59">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51e9111b87116e60566740d13ba1c1eddb042333" resname="Stopped" approved="yes">
         <source>Stopped</source>
         <target state="translated">Gestoppt</target>
-        <jms:reference-file line="43">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="47">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67b5fefd39cf2223cfc9023e91571fd2a87cd76a" resname="Stories" approved="yes">
         <source>Stories</source>
         <target state="translated">Berichte</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="315bc332aafca63cad8ac042c2e2f5111544fe9d" resname="Story Not Found" approved="yes">
@@ -6533,14 +6533,14 @@
       <trans-unit id="dd631af5459e2fae291effe51fbb608d13a75163" resname="Suppression de %n_element% playlists" approved="yes">
         <source>Suppression de %n_element% playlists</source>
         <target state="translated">Löschen von %n_element% Playlisten</target>
-        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="299c2796a0d682b2495627623e9f228410b8a84a" resname="Suppression de %n_element% videos" approved="yes">
         <source>Suppression de %n_element% videos</source>
         <target state="translated">Löschen von %n_element% Videos</target>
-        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1acfc1c7d761310db2e5e876c0cade4d522cfed2" resname="Supprimer" approved="yes">
         <source>Supprimer</source>
@@ -6566,7 +6566,7 @@
       <trans-unit id="d91e1888f2dc09f11a876e25966a6fbd32b9cd87" resname="TLS" approved="yes">
         <source>TLS</source>
         <target state="translated">TLS</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a524057f93fd59da6998f240a0602fabc16dfb02" resname="Tableau de bord" approved="yes">
         <source>Tableau de bord</source>
@@ -6576,11 +6576,11 @@
       <trans-unit id="848eed0fbd5429f556b2982dec3ea87136e33e44" resname="Tags" approved="yes">
         <source>Tags</source>
         <target state="translated">Tags</target>
-        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="49">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e98caed82acc9fa2f1ba9edeab7789e75e49c36" resname="Target Device" approved="yes">
         <source>Target Device</source>
@@ -6602,12 +6602,12 @@
       <trans-unit id="c78d2fc3a6668b4edc8cf013ce4c6cf8c269b1bf" resname="Task name" approved="yes">
         <source>Task name</source>
         <target state="translated">Aufgabe Name</target>
-        <jms:reference-file line="25">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="29">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b953a851b67dcb4e540270e49fe450d1d613eb1e" resname="Task period (in seconds)" approved="yes">
         <source>Task period (in seconds)</source>
         <target state="translated">Aufgabe Zeit (in Sekunden)</target>
-        <jms:reference-file line="32">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="36">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cf459f472a871f1b053e16008a15cd566921aab0" resname="Technical Informations" approved="yes">
         <source>Technical Informations</source>
@@ -6628,7 +6628,7 @@
       <trans-unit id="97738411d629b01052974cc98ddb83a2cb4f8182" resname="Terms of Use" approved="yes">
         <source>Terms of Use</source>
         <target state="translated">Nutzungsbedingungen</target>
-        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="501">web/common/dialog_export.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a6a1d25b018c9318540556e3fe374fdf8b23aff8" resname="Terms of service" approved="yes">
@@ -6647,7 +6647,7 @@
       <trans-unit id="903b3a1a72b51b7b51f85ec8c81def53ed9c9b0c" resname="The Phraseanet Web API allows other web application to rely on this instance" approved="yes">
         <source>The Phraseanet Web API allows other web application to rely on this instance</source>
         <target state="translated">Die Phraseanet Web API ermöglicht, andere Web Anwendungen, auf diese Instanz zu vertrauen</target>
-        <jms:reference-file line="23">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2558cc2c887bbe4e2444ec6ef83b4982386e871a" resname="The URL you used is out of date, please login" approved="yes">
         <source>The URL you used is out of date, please login</source>
@@ -6761,7 +6761,7 @@
       <trans-unit id="d29ae57dd01be0f4c5b2e1993379c00443a9c937" resname="The task status" approved="yes">
         <source>The task status</source>
         <target state="translated">Aufgabe Status</target>
-        <jms:reference-file line="40">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="44">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2e77a8fce4b585aac7e3e493f08aa4d8f56bc7e2" resname="The upgrade is already started" approved="yes">
         <source>The upgrade is already started</source>
@@ -6801,7 +6801,7 @@
       <trans-unit id="3fc5195b4a6ff8dc205dbbad17104fa93db88281" resname="Thesaurus Min score" approved="yes">
         <source>Thesaurus Min score</source>
         <target state="translated">Thesaurus Hits (minimal)</target>
-        <jms:reference-file line="70">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="678">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="163fc70a23cf29331bab9896c9a8a0cb0b113bd6" resname="Thesaurus branch" approved="yes">
@@ -6869,7 +6869,7 @@
       <trans-unit id="58e76d1cc6a26f43783774d888c3a260970f637b" resname="This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases." approved="yes">
         <source>This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases.</source>
         <target state="translated">Diese Option deaktiviert die Markierung der Datenbanken, auf denen ein Benutzer sich selbst anmelden kann und Anmeldung wird auf alle gewährte Datenbanken gehandelt.</target>
-        <jms:reference-file line="23">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="814c3298cccd06ad65ccac8a35e4f2104a4af17e" resname="This user does not participate to the validation but is only viewer." approved="yes">
         <source>This user does not participate to the validation but is only viewer.</source>
@@ -6910,19 +6910,19 @@
       <trans-unit id="eb97899aedcd5609782b5ccb4ffa390e0e66a3eb" resname="Titre" approved="yes">
         <source>Titre</source>
         <target state="translated">Titel</target>
-        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="24">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="9">prod/Baskets/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="01594f4dad04782844c8175778fdf66deabf580d" resname="Toggle loop" approved="yes">
         <source>Toggle loop</source>
@@ -7026,8 +7026,8 @@
       <trans-unit id="c2739616a133e476dda18386df0d2487d526766a" resname="URL de callback" approved="yes">
         <source>URL de callback</source>
         <target state="translated">Callback URL</target>
-        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="102">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="268f900effee1beb15231a1504d02543e8827bb3" resname="Un document commande" approved="yes">
         <source>Un document commande</source>
@@ -7194,15 +7194,15 @@
         <source>Upload</source>
         <target state="translated">Upload</target>
         <jms:reference-file line="94">web/common/menubar.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="16">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="83">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9ee782a49540357e87b6dc0dde09d8bec6507af" resname="Upload URL is not set, please contact an admin" approved="yes">
         <source>Upload URL is not set, please contact an admin</source>
@@ -7232,12 +7232,12 @@
       <trans-unit id="ea1fd4c4c366bf2e13d348b67b75e96039d7a1d7" resname="Use Google Chart API" approved="yes">
         <source>Use Google Chart API</source>
         <target state="translated">Benutzen Sie die Google Chart API</target>
-        <jms:reference-file line="32">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2023f20c3153f9d593dfe4e5447b24866e27bd34" resname="Use a SMTP server" approved="yes">
         <source>Use a SMTP server</source>
         <target state="translated">Benutzen Sie einen SMTP Server</target>
-        <jms:reference-file line="28">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="32">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="337f9aa5d63611e88aedd8cc09ee1488fb9fe3a4" resname="Use an existing index" approved="yes">
         <source>Use an existing index</source>
@@ -7257,7 +7257,7 @@
       <trans-unit id="c42cc91c040b3c093f851494375a1be868018231" resname="Use recaptcha API" approved="yes">
         <source>Use recaptcha API</source>
         <target state="translated">Benutzen Sie ReCaptcha API</target>
-        <jms:reference-file line="41">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17a74b77867e7b3f4f5e5b2ad90be36cf800dfda" resname="Use the Flash uploader" approved="yes">
         <source>Use the Flash uploader</source>
@@ -7274,22 +7274,22 @@
       <trans-unit id="1d2b0439bd02b54c622696c45588eab8d051dfb9" resname="Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token" approved="yes">
         <source>Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token</source>
         <target state="translated">Mit mod_token benutzen. Vorsicht, benötigt die folgende Module: Apache und mod_h264_streaming mod_auth_token</target>
-        <jms:reference-file line="31">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="73e8bd6eff9e8b1460684911486ad731e3097ab2" resname="Used for guest account" approved="yes">
         <source>Used for guest account</source>
         <target state="translated">Für Gastkonto benutzt</target>
-        <jms:reference-file line="34">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84e635021b5a8691329da2b22cbdbb7137ddc018" resname="Used in search engine" approved="yes">
         <source>Used in search engine</source>
         <target state="translated">im Suchmaschine benutzt</target>
-        <jms:reference-file line="23">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a54e4b6b720a84b428f0feda87f35d92cc219ee7" resname="Used when opening the application" approved="yes">
         <source>Used when opening the application</source>
         <target state="translated">wird benutzt beim Eröffnen der Anwendung</target>
-        <jms:reference-file line="30">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5bb94bfadf4a04bc6b31a3298c5f19a7dead6769" resname="User already exists" approved="yes">
         <source>User already exists</source>
@@ -7344,7 +7344,7 @@
       <trans-unit id="3482565eef4d4cd1decb5ebfad6ecfc5943d30da" resname="Users must accept Terms of Use for each export" approved="yes">
         <source>Users must accept Terms of Use for each export</source>
         <target state="translated">Die Benutzer müssen die Nutzungsbedingungen für jeden Export akzeptieren</target>
-        <jms:reference-file line="37">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28f4718f1cf2cd1f31d49c8bce276341ffe222bd" resname="Users suggestion" approved="yes">
         <source>Users suggestion</source>
@@ -7359,8 +7359,8 @@
       <trans-unit id="3b3e9155f69edf73caab337bf5f64231188b1e48" resname="VALIDATION" approved="yes">
         <source>VALIDATION</source>
         <target state="translated">Bestätigung</target>
-        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="6">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e400a7eef4ab49bbe657b3e3c557d64e091a356" resname="Validate e-mail address" approved="yes">
         <source>Validate e-mail address</source>
@@ -7370,9 +7370,9 @@
       <trans-unit id="dd74d182c641e4c78502d863b44d0aeff1575e54" resname="Validation" approved="yes">
         <source>Validation</source>
         <target state="translated">Bestätigung</target>
+        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validate.php</jms:reference-file>
         <jms:reference-file line="78">eventsmanager/notify/validate.php</jms:reference-file>
-        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="79">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="86">lightbox/IE6/validate.html.twig</jms:reference-file>
@@ -7390,9 +7390,9 @@
       <trans-unit id="6c259e54dcc7188e7cfe33403eca78cda53017fc" resname="Validations" approved="yes">
         <source>Validations</source>
         <target state="translated">Bestätigung</target>
+        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="119">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="165">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="51">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="100">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
@@ -7409,7 +7409,7 @@
       <trans-unit id="0cedbcdb95addc9f8d1b024fcbaf3d87dc6d044b" resname="Validity period of the download links" approved="yes">
         <source>Validity period of the download links</source>
         <target state="translated">Download-Links Gültigkeitsdauer</target>
-        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="74">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db671097785924a80ca79c2a37675116e90899e8" resname="Vers quel API voulez vous vous connecter ?" approved="yes">
         <source>Vers quel API voulez vous vous connecter ?</source>
@@ -7449,8 +7449,8 @@
       <trans-unit id="56b71e89fb1079caaadefd0889e9a22e8b0560e3" resname="Videos" approved="yes">
         <source>Videos</source>
         <target state="translated">Videos</target>
-        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="174">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="18af7efc4ef7f30783dbb1ad1bc0b9aed857a19c" resname="View on %title%" approved="yes">
         <source>View on %title%</source>
@@ -7602,10 +7602,10 @@
       <trans-unit id="12ee49ba726f4422d3dcc6bc7b92ab9de279d211" resname="Vous n'avez selectionne aucun element" approved="yes">
         <source>Vous n'avez selectionne aucun element</source>
         <target state="translated">Sie haben kein Element ausgewählt.</target>
+        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e8fd52d6c7e92e6907f1148d2e458871d17c1ae" resname="Vous ne pouvez pas editer plusieurs elements simultanement" approved="yes">
         <source>Vous ne pouvez pas editer plusieurs elements simultanement</source>
@@ -7651,8 +7651,8 @@
       <trans-unit id="94bfa418b59cf2b1d326f614666ece16ef9cbded" resname="Watch my access requests status" approved="yes">
         <source>Watch my access requests status</source>
         <target state="translated">Meine Zugriffsanfrage Status anschauen</target>
-        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
         <jms:reference-file line="39">Notification/Mail/MailSuccessEmailConfirmationUnregistered.php</jms:reference-file>
+        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d67f8b5513fcc1166cb7086a07bf29144de7c879" resname="Watermark" approved="yes">
         <source>Watermark</source>
@@ -7692,8 +7692,8 @@
       <trans-unit id="ceffd5b622d10de1a19822471cb3804cb61cba28" resname="Which playlist you want to put you %number% elements into ?" approved="yes">
         <source>Which playlist you want to put you %number% elements into ?</source>
         <target state="translated">Welche Playlist möchten Sie für Ihre %number% Elemente benutzen?</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e2507e568a039431c507b30f44aa72cbb1ed929" resname="Whoops, looks like something went wrong." approved="yes">
         <source>Whoops, looks like something went wrong.</source>
@@ -7738,9 +7738,9 @@
       <trans-unit id="5397e0583f14f6c88de06b1ef28f460a1fb5b0ae" resname="Yes" approved="yes">
         <source>Yes</source>
         <target state="translated">Ja</target>
+        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="33">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="13">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4de66b40cf0800d4a25cc75b4f3f593cfc44ef6c" resname="You are Admin" approved="yes">
         <source>You are Admin</source>
@@ -8054,85 +8054,85 @@
       <trans-unit id="162536d0e4aeccdde8b707acd6111800a25d549b" resname="action : bridge" approved="yes">
         <source>action : bridge</source>
         <target state="translated">Bridge</target>
-        <jms:reference-file line="1038">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3ffc763c6cf92695a7ce387f904bbe6e7a94bdbc" resname="action : collection" approved="yes">
         <source>action : collection</source>
         <target state="translated">Verschieben</target>
-        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="38">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddc3c6161fab39cbaf5d3f59af82090b32a2c36c" resname="action : editer" approved="yes">
         <source>action : editer</source>
         <target state="translated">Bearbeiten</target>
         <jms:reference-file line="10">prod/preview/caption.html.twig</jms:reference-file>
-        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="24">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b62efbefb9b0e40c14ac8218ac4257603c5b75c" resname="action : exporter" approved="yes">
         <source>action : exporter</source>
         <target state="translated">Exportieren</target>
-        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="25">prod/preview/tools.html.twig</jms:reference-file>
-        <jms:reference-file line="1040">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="52">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="128">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="129">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="130">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0c9b7eb3d21f5a48ac5ecb0a0d969b8d3818e41" resname="action : outils" approved="yes">
         <source>action : outils</source>
         <target state="translated">Werkzeuge</target>
-        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="70">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="71e15cbcf85fd5fe848fe7fa210fa8318a09f842" resname="action : print" approved="yes">
         <source>action : print</source>
         <target state="translated">Drucken</target>
         <jms:reference-file line="20">prod/preview/tools.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="138">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="139">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="140">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d222a71a73f44cb6bdf237790f350f0b1fb9eb1f" resname="action : publier" approved="yes">
         <source>action : publier</source>
         <target state="translated">Veröffentlichen</target>
-        <jms:reference-file line="1039">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="63">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17948b21adfde1bf589b2a34a2c8253e2af91913" resname="action : push" approved="yes">
         <source>action : push</source>
         <target state="translated">Push</target>
-        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="47">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f22184cfa5be236b7193d80d5f8407a36b108b79" resname="action : status" approved="yes">
         <source>action : status</source>
         <target state="translated">Eigenschaften</target>
-        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="24ade348bc49c69cced4d173e31f7369aa466772" resname="action : supprimer" approved="yes">
         <source>action : supprimer</source>
         <target state="translated">Löschen</target>
-        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="221">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="222">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b88ca5fbb2e89cb79b08c981283383361be312bf" resname="action:: nouveau panier" approved="yes">
         <source>action:: nouveau panier</source>
@@ -8545,21 +8545,21 @@
       <trans-unit id="df2642eaa7386518762050a368f5d2c49a3fe42a" resname="admin::compte-utilisateur activite" approved="yes">
         <source>admin::compte-utilisateur activite</source>
         <target state="translated">Tätigkeit</target>
-        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="312">Controller/Admin/UserController.php</jms:reference-file>
-        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="122">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10b0a44531159b40162fd9349abbe2bd21946c3e" resname="admin::compte-utilisateur adresse" approved="yes">
         <source>admin::compte-utilisateur adresse</source>
         <target state="translated">Adresse</target>
-        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="304">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="363">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="87">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e922f2ca7321d1d1f403e937dbf109db04bac722" resname="admin::compte-utilisateur changer mon mot de passe" approved="yes">
         <source>admin::compte-utilisateur changer mon mot de passe</source>
@@ -8569,11 +8569,11 @@
       <trans-unit id="218d3257842bd2817f0ba7bcd02f3729c60e591d" resname="admin::compte-utilisateur code postal" approved="yes">
         <source>admin::compte-utilisateur code postal</source>
         <target state="translated">PLZ</target>
-        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="306">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="370">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="94">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc2f858e3323d3baa8be27661724b11ce9c0a57b" resname="admin::compte-utilisateur confirmer la nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur confirmer la nouvelle adresse email</source>
@@ -8593,23 +8593,23 @@
       <trans-unit id="d79bdc62fa5ecc611e96fe7ab9f5cf4d4debabae" resname="admin::compte-utilisateur email" approved="yes">
         <source>admin::compte-utilisateur email</source>
         <target state="translated">E-Mail</target>
-        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="301">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="335">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="112">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="22">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="452">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d194728e348f759c2a443df96338ba1e2c8adfb5" resname="admin::compte-utilisateur fax" approved="yes">
         <source>admin::compte-utilisateur fax</source>
         <target state="translated">Fax</target>
-        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="309">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="384">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="136">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6e2b9ddcaf97ba5258571cb54935f1ff6b581a2" resname="admin::compte-utilisateur id utilisateur" approved="yes">
         <source>admin::compte-utilisateur id utilisateur</source>
@@ -8621,34 +8621,34 @@
         <target state="translated">Benutzername</target>
         <jms:reference-file line="36">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="19">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
-        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="35">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="188">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f5fe48877b8b43297cc3c999ab84bbe0bd60f5af" resname="admin::compte-utilisateur mot de passe" approved="yes">
         <source>admin::compte-utilisateur mot de passe</source>
         <target state="translated">Passwort</target>
-        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="195">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e2d7957bf48ebf857d73e4395e78fa73e193b5d" resname="admin::compte-utilisateur nom" approved="yes">
         <source>admin::compte-utilisateur nom</source>
         <target state="translated">Name</target>
-        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="299">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="321">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="13">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="444">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dbac236fd2ee8bcce590e0cdc7c4a418885c52b" resname="admin::compte-utilisateur nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur nouvelle adresse email</source>
@@ -8664,42 +8664,42 @@
       <trans-unit id="28c517ddecdb662c767290d2e1fa53ef198307fa" resname="admin::compte-utilisateur poste" approved="yes">
         <source>admin::compte-utilisateur poste</source>
         <target state="translated">Beruf</target>
-        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="310">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="356">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="108">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eadb6eaa53204a688e4059a35261b6878fda8b37" resname="admin::compte-utilisateur prenom" approved="yes">
         <source>admin::compte-utilisateur prenom</source>
         <target state="translated">Vorname</target>
-        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="300">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="328">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="67">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ee82fdcf687c10dd1e5040a5b84d9a90d079a9a" resname="admin::compte-utilisateur sexe" approved="yes">
         <source>admin::compte-utilisateur sexe</source>
         <target state="translated">Anrede</target>
         <jms:reference-file line="44">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="78b65792aca82024d5f1ff60dec83a501c01e15e" resname="admin::compte-utilisateur societe" approved="yes">
         <source>admin::compte-utilisateur societe</source>
         <target state="translated">Unternehmen</target>
-        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="311">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="349">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="107">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="16">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="493">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d15ba95c86a58884d598415b8f8a400ab636cd9" resname="admin::compte-utilisateur tel" approved="yes">
         <source>admin::compte-utilisateur tel</source>
@@ -8711,10 +8711,10 @@
         <target state="translated">Telefon</target>
         <jms:reference-file line="308">Controller/Admin/UserController.php</jms:reference-file>
         <jms:reference-file line="342">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="19">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="510">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="29d3952c833272679cb313988c698f11cb6bbb64" resname="admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer" approved="yes">
         <source>admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer</source>
@@ -8724,11 +8724,11 @@
       <trans-unit id="00a39eeb4e86af2189a6080e16418d249d98a12b" resname="admin::compte-utilisateur ville" approved="yes">
         <source>admin::compte-utilisateur ville</source>
         <target state="translated">Ort</target>
-        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="305">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="377">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="101">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f752312fcd370b6547b296ca173da51487a2c5d" resname="admin::compte-utilisateur: L'email a correctement ete mis a jour" approved="yes">
         <source>admin::compte-utilisateur: L'email a correctement ete mis a jour</source>
@@ -8817,24 +8817,24 @@
         <target state="translated">Frau</target>
         <jms:reference-file line="50">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="314">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="50">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7af00728508b30971b5cd3eb769433546ad9abfa" resname="admin::compte-utilisateur:sexe: mademoiselle" approved="yes">
         <source>admin::compte-utilisateur:sexe: mademoiselle</source>
         <target state="translated">Fräulein</target>
         <jms:reference-file line="49">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="313">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="47">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db663dadd7bd9b045a68cafcfe2ca4e0c832e50a" resname="admin::compte-utilisateur:sexe: monsieur" approved="yes">
         <source>admin::compte-utilisateur:sexe: monsieur</source>
         <target state="translated">Herr</target>
         <jms:reference-file line="51">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="315">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="53">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cfc904c9a87afe2d3986041a6bdb542298607880" resname="admin::monitor: bases sur lesquelles l'utilisateur est connecte :" approved="yes">
         <source>admin::monitor: bases sur lesquelles l'utilisateur est connecte :</source>
@@ -8917,10 +8917,10 @@
       <trans-unit id="14e4b19f7496c10dbb05e61dee0c436c0792235f" resname="admin::monitor: module validation" approved="yes">
         <source>admin::monitor: module validation</source>
         <target state="translated">Lightbox</target>
+        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="207">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="238">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="315">Phrasea/Controller/LightboxController.php</jms:reference-file>
-        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="85">lib/classes/phrasea.php</jms:reference-file>
         <jms:reference-file line="78">web/common/menubar.html.twig</jms:reference-file>
       </trans-unit>
@@ -9611,6 +9611,17 @@
         <target state="translated">Verbindungstest mit Expose (nicht implementiert)</target>
         <jms:reference-file line="69">admin/phraseanet-service/expose.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="6d3478b79db541608a0ba8e3877cba7c52256add" resname="admin:searchengine:aggregates:New field, please confirm setting.">
+        <source>admin:searchengine:aggregates:New field, please confirm setting.</source>
+        <target state="new">admin:searchengine:aggregates:New field, please confirm setting.</target>
+        <jms:reference-file line="146">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="157">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="b6dee9dc48adef7fe2f3a1e52b98e7a009fef83d" resname="admin:searchengine:aggregates:This field does not exists in current databoxes.">
+        <source>admin:searchengine:aggregates:This field does not exists in current databoxes.</source>
+        <target state="new">admin:searchengine:aggregates:This field does not exists in current databoxes.</target>
+        <jms:reference-file line="136">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8f3cd845b8adbcdf064486cdd24733f53bce8bb3" resname="admin:worker Retrieve configuration error" approved="yes">
         <source>admin:worker Retrieve configuration error</source>
         <target state="translated">Worker Abruf Konfigurationsfehler</target>
@@ -9619,8 +9630,8 @@
       <trans-unit id="8f1dba76b561684930a25a984046b3b4149785ca" resname="alert" approved="yes">
         <source>alert</source>
         <target state="translated">Vorsicht</target>
-        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="306">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="edde11c24ed5e6df4e416143e77248e908567faa" resname="all caches services have been flushed" approved="yes">
         <source>all caches services have been flushed</source>
@@ -9692,14 +9703,14 @@
       <trans-unit id="e2c1d05cc230f0bd66de9600c3304eaf374ffa24" resname="basket:action:delete record form basket" approved="yes">
         <source>basket:action:delete record form basket</source>
         <target state="translated">Datensatz vom Sammelkorb entfernen</target>
-        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="378b261cf0bdda80ad072999d7bed4361180c838" resname="basket:action:delete record form database" approved="yes">
         <source>basket:action:delete record form database</source>
         <target state="translated">Datensatz von Datenbank vonlöschen</target>
-        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="79">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c501b5741b2a182f189a0ee99109f2a55fd2aaa8" resname="basket:feedback Delete item" approved="yes">
         <source>basket:feedback Delete item</source>
@@ -9742,48 +9753,48 @@
         <jms:reference-file line="250">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="404">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="487">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
+        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
         <jms:reference-file line="119">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="69">web/thesaurus/import-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="228">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="653">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1054">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1173">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
-        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
-        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c6f716e883e5747e4bc8a8afc7a0ec1ccf44e0b5" resname="boutton::appliquer" approved="yes">
         <source>boutton::appliquer</source>
         <target state="translated">Anwenden</target>
-        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="40">WorkerManager/Form/WorkerConfigurationType.php</jms:reference-file>
+        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="43">WorkerManager/Form/WorkerPullAssetsType.php</jms:reference-file>
         <jms:reference-file line="77">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb7084f3be2ac7d8cf870a9bb83df976dc65ad5b" resname="boutton::chercher" approved="yes">
         <source>boutton::chercher</source>
         <target state="translated">suchen</target>
-        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="126">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="61">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a71090794c12d5b26f62d9f0c68c0d894f7e00e" resname="boutton::choisir" approved="yes">
         <source>boutton::choisir</source>
@@ -9805,14 +9816,14 @@
       <trans-unit id="32e5c3419a0a410255ee44e462fd7329f708873f" resname="boutton::demarrer" approved="yes">
         <source>boutton::demarrer</source>
         <target state="translated">Dia Show</target>
-        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="9">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d49d2b52ce2f1912f7ada4a3f57ab39fd2e9904e" resname="boutton::editer" approved="yes">
         <source>boutton::editer</source>
         <target state="translated">Bearbeiten</target>
-        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="26">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6b126c214de4c40550d9dc32b02766809b1cac1a" resname="boutton::enregistrer" approved="yes">
         <source>boutton::enregistrer</source>
@@ -9840,16 +9851,16 @@
         <target state="translated">schliessen</target>
         <jms:reference-file line="59">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="90">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="23">web/lightbox/sc_note.html.twig</jms:reference-file>
-        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
+        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
         <jms:reference-file line="45">web/thesaurus/link-field-step3.html.twig</jms:reference-file>
         <jms:reference-file line="115">web/thesaurus/accept.html.twig</jms:reference-file>
         <jms:reference-file line="129">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce91bb36902944da7788997865b8c482a59e80fe" resname="boutton::generer" approved="yes">
         <source>boutton::generer</source>
@@ -9864,9 +9875,9 @@
       <trans-unit id="1e4c65d295605a0e884818b5c06d32a63fd692d5" resname="boutton::modifier" approved="yes">
         <source>boutton::modifier</source>
         <target state="translated">ändern</target>
-        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
-        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="1">Bridge/Dailymotion/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="65">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef6ccc2669466ac98a3d580bd7bab8f33d0e4bcc" resname="boutton::monter" approved="yes">
@@ -9877,22 +9888,22 @@
       <trans-unit id="a6083d9bc73ab5df12f4949b67577186f6e8c240" resname="boutton::pause" approved="yes">
         <source>boutton::pause</source>
         <target state="translated">Pause</target>
-        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="28bb622fa0fe835d89deb626494ce572cbd27072" resname="boutton::precedent" approved="yes">
         <source>boutton::precedent</source>
         <target state="translated">vorherige</target>
+        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="426">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="516">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="629">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="696">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="754">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="866">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ac4cff651bd34d7b0f295259a0c0907d6af5cd1" resname="boutton::rechercher" approved="yes">
         <source>boutton::rechercher</source>
@@ -9923,26 +9934,26 @@
       <trans-unit id="e0af1d0d7872c48928d4faef76c45567426e62f9" resname="boutton::retour" approved="yes">
         <source>boutton::retour</source>
         <target state="translated">Zurück</target>
-        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="28">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="20">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
+        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
+        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="223">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
         <jms:reference-file line="50">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
         <jms:reference-file line="162">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
+        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a7a9651d909792bcf98f2d1e96c43cb1d3a618e4" resname="boutton::retry" approved="yes">
         <source>boutton::retry</source>
@@ -9952,55 +9963,55 @@
       <trans-unit id="bd9ec3151bdf1eae02e402222d4e36949525a27f" resname="boutton::suivant" approved="yes">
         <source>boutton::suivant</source>
         <target state="translated">folgende</target>
+        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="365">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="429">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="519">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="632">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="699">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="757">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a83f74309cdfc79345f54eb1f4e4e2747316f820" resname="boutton::supprimer" approved="yes">
         <source>boutton::supprimer</source>
         <target state="translated">Löschen</target>
         <jms:reference-file line="43">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
-        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
-        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="35">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
+        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="93">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="136">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="151">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="176">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="201">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="410">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="68b702f13ff62025c57948bf5c4a5b47af10dee9" resname="boutton::telecharger" approved="yes">
         <source>boutton::telecharger</source>
         <target state="translated">Download</target>
         <jms:reference-file line="160">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="21">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4288c5788ee74d7fa3f325987a8e752687b43023" resname="boutton::telecharger tous les documents" approved="yes">
         <source>boutton::telecharger tous les documents</source>
         <target state="translated">Alle Dokumente herunterladen</target>
-        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="99">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a14c32cf4cd3784ed567e115f3ef016ad2ee2265" resname="boutton::tester" approved="yes">
         <source>boutton::tester</source>
@@ -10012,57 +10023,57 @@
         <source>boutton::valider</source>
         <target state="translated">Bestätigen</target>
         <jms:reference-file line="49">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="886">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="70">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="19">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
         <jms:reference-file line="351">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="373">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Update.html.twig</jms:reference-file>
+        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
         <jms:reference-file line="130">admin/collection/suggested_value.html.twig</jms:reference-file>
-        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="46">admin/collection/create.html.twig</jms:reference-file>
         <jms:reference-file line="58">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
-        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
-        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="41">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
         <jms:reference-file line="159">admin/statusbit/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
+        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
+        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
+        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="34">mobile/lightbox/note_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b27b98c3e0119082312d402ca0b89dd39f00f5c8" resname="boutton::vue graphique" approved="yes">
@@ -10257,8 +10268,8 @@
       <trans-unit id="dbfe8cf37a8d7b4941dd9f89e79302038b2bedef" resname="dans %feed_name%" approved="yes">
         <source>dans %feed_name%</source>
         <target state="translated">in %feed_name%</target>
-        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="52">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aab7fdd9c18941cbc8d78fa0c690361ffd8c50bf" resname="date dajout" approved="yes">
         <source>date dajout</source>
@@ -10307,10 +10318,10 @@
       <trans-unit id="9ead47a82a0d25985f22f10651d1f93b3abba317" resname="edit" approved="yes">
         <source>edit</source>
         <target state="translated">Bearbeiten</target>
-        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="32">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="143">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="164">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd35f7126454c3af225a579bd27f89176be81c3d" resname="edit: chosiir limage du regroupement" approved="yes">
         <source>edit: chosiir limage du regroupement</source>
@@ -10634,12 +10645,12 @@
       <trans-unit id="0d25ab4ea387d19f49a120acb928c7f9500b0cf3" resname="index::advance_search: disable-facet" approved="yes">
         <source>index::advance_search: disable-facet</source>
         <target state="translated">Facetten mit nur einem Ergebnis ausblenden (experimentell)</target>
-        <jms:reference-file line="911">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="16b1c68bd21754876991dfc8df38b024383fbca4" resname="index::advance_search: facet" approved="yes">
         <source>index::advance_search: facet</source>
         <target state="translated">Einstellungen für Facetten</target>
-        <jms:reference-file line="907">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="909">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f830d57f4cedb2a49c7b109f9b91b0f8ba83e8b" resname="index::advance_search: facet-order" approved="yes">
         <source>index::advance_search: facet-order</source>
@@ -10659,7 +10670,7 @@
       <trans-unit id="dfb02fcdeb804315cd6ad8388efcfb4ccc4abf38" resname="index::advance_search: hidden-facet-values-order" approved="yes">
         <source>index::advance_search: hidden-facet-values-order</source>
         <target state="translated">Versteckte Facetten</target>
-        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="921">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a35cc75d1072f7dad99c8e91596298f55f20a54" resname="index::advance_search: order-by-hits" approved="yes">
         <source>index::advance_search: order-by-hits</source>
@@ -10670,6 +10681,11 @@
         <source>index::advance_search: order-by-hits-asc</source>
         <target state="translated">Nach Vorkommen asc</target>
         <jms:reference-file line="256">web/prod/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ea214aed2c346724c9b874431706654f560585b6" resname="index::advance_search: show-unset-field-facet">
+        <source>index::advance_search: show-unset-field-facet</source>
+        <target state="new">index::advance_search: show-unset-field-facet</target>
+        <jms:reference-file line="918">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1039a002699408da4c4fe74638a6b44f60499069" resname="index:advanced-preferences:: use truncation" approved="yes">
         <source>index:advanced-preferences:: use truncation</source>
@@ -10724,9 +10740,9 @@
       <trans-unit id="49956c0a16703da1e642ef7ea5f5d56ddb026c9b" resname="lightbox::recaptitulatif" approved="yes">
         <source>lightbox::recaptitulatif</source>
         <target state="translated">Übersicht</target>
-        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
         <jms:reference-file line="96">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="95">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e96c3b316d4e505d764d209e1074dcd059e396c3" resname="lightbox::see_less_basket" approved="yes">
@@ -10838,8 +10854,8 @@
       <trans-unit id="46f7a3bb71222626147c7e64c6a59a3f4c3d8e42" resname="login::notification: Mise a jour du mot de passe avec succes" approved="yes">
         <source>login::notification: Mise a jour du mot de passe avec succes</source>
         <target state="translated">erfolgreiche Passwort Aktualisierung</target>
-        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
         <jms:reference-file line="67">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28dd2416483329c548279196d0c60f722578632f" resname="login::notification: demande de confirmation par mail envoyee" approved="yes">
         <source>login::notification: demande de confirmation par mail envoyee</source>
@@ -10929,15 +10945,15 @@
         <source>no</source>
         <target state="translated">Nein</target>
         <jms:reference-file line="91">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="14">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6c632badea2664bc707979fac5e58072b6a2feba" resname="no image selected" approved="yes">
         <source>no image selected</source>
         <target state="translated">Kein Bild wurde ausgewählt</target>
-        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="307">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37031f99ac78580c9f82e04fa237d295ea10ca41" resname="non" approved="yes">
         <source>non</source>
@@ -10948,10 +10964,10 @@
       <trans-unit id="a81b09d9521597ebcaf0cc8b49ad7a8be8e4cc61" resname="notice" approved="yes">
         <source>notice</source>
         <target state="translated">Beschreibung</target>
-        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="77">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cafe5f11d6a3b26e59f28454d0ad90a951c64a6a" resname="nouveau" approved="yes">
         <source>nouveau</source>
@@ -11222,7 +11238,7 @@
       <trans-unit id="0259e4e17a1f2697d4f4f0108080276a5d7573de" resname="original logo" approved="yes">
         <source>original logo</source>
         <target state="translated">Originales logo</target>
-        <jms:reference-file line="23">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5898fc860300e228dcd54c0b1045b5fa0dcda502" resname="oui" approved="yes">
         <source>oui</source>
@@ -11299,8 +11315,8 @@
       <trans-unit id="9069777ad6c5ece82d14a23d39082acba0873d60" resname="paniers::description du nouveau panier" approved="yes">
         <source>paniers::description du nouveau panier</source>
         <target state="translated">Beschreibung</target>
-        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="647fb4052fcefc4f2cbbe79aa1a04e8acbd37f59" resname="par %user_name%" approved="yes">
         <source>par %user_name%</source>
@@ -11320,7 +11336,7 @@
       <trans-unit id="ead5a6379197deb9163d2101354822e6caaa30eb" resname="personalize logo" approved="yes">
         <source>personalize logo</source>
         <target state="translated">Logo anpassen</target>
-        <jms:reference-file line="24">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f16110620b1971f58336063cbdb64df7e0e0c7ac" resname="pertinence" approved="yes">
         <source>pertinence</source>
@@ -11330,7 +11346,7 @@
       <trans-unit id="da819bd8e531681e8cc8b0c5f30da694b7ffe03c" resname="php.ini path" approved="yes">
         <source>php.ini path</source>
         <target state="translated">php.ini Pfad</target>
-        <jms:reference-file line="44">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4827b7c0fd9fb14fc29a808b020353c744b83978" resname="phraseanet:: Creer une base sur un serveur different de l'application box" approved="yes">
         <source>phraseanet:: Creer une base sur un serveur different de l'application box</source>
@@ -11371,11 +11387,11 @@
       <trans-unit id="8039b17c124d6907eb83dc8b705888769f45d82d" resname="phraseanet:: adresse" approved="yes">
         <source>phraseanet:: adresse</source>
         <target state="translated">Adresse</target>
-        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="31">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="89">web/admin/connected-users.html.twig</jms:reference-file>
-        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a934108e5aa19f91fafd6eb9ee20b00bc248bab9" resname="phraseanet:: aide" approved="yes">
         <source>phraseanet:: aide</source>
@@ -11464,8 +11480,8 @@
       <trans-unit id="da1f4cb9f98aef274dbb8f5992dedaf20e91ea71" resname="phraseanet:: preview" approved="yes">
         <source>phraseanet:: preview</source>
         <target state="translated">Voransicht</target>
-        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
         <jms:reference-file line="267">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2baca947f8536e2ff6bab1c45c1876c04706a6a0" resname="phraseanet:: propositions" approved="yes">
         <source>phraseanet:: propositions</source>
@@ -11482,19 +11498,19 @@
       <trans-unit id="99a70ecaddc20d59056e5d479c6fa9d0bc113a0e" resname="phraseanet:: sous definition" approved="yes">
         <source>phraseanet:: sous definition</source>
         <target state="translated">Unterauflösung</target>
-        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="93">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c33ce7e20779d5b34c1c812406e2f22b779a45d0" resname="phraseanet:: thesaurus" approved="yes">
         <source>phraseanet:: thesaurus</source>
         <target state="translated">Thesaurus</target>
-        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/index.html.twig</jms:reference-file>
         <jms:reference-file line="11">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
-        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b6022bf4291f5e9d7d7051fe6c3d6a6abbd92c1a" resname="phraseanet:: tri" approved="yes">
         <source>phraseanet:: tri</source>
@@ -11504,10 +11520,10 @@
       <trans-unit id="771634fc3ec89c0a08c7666e776fc5db3072f318" resname="phraseanet:: tri par date" approved="yes">
         <source>phraseanet:: tri par date</source>
         <target state="translated">nach Datum sortieren</target>
-        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="318">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="320">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="321">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db34986ff3eb1fd0e90f897a97eaf52ea6708600" resname="phraseanet:: tri par nom" approved="yes">
         <source>phraseanet:: tri par nom</source>
@@ -11581,9 +11597,9 @@
         <source>phraseanet::chargement</source>
         <target state="translated">Bitte warten...</target>
         <jms:reference-file line="48">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="278">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="34">admin/collection/suggested_value.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="70c4053d038cd11fa8fcb91bf79e580b89fad194" resname="phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible" approved="yes">
         <source>phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible</source>
@@ -11601,8 +11617,8 @@
         <source>phraseanet::erreur: Votre session est fermee, veuillez vous re-authentifier</source>
         <target state="translated">Sie sind nun abgemeldet. Bitte loggen Sie sich wieder ein</target>
         <jms:reference-file line="38">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="754677fa0aa06c7f10237a728e6f33eaea06d42b" resname="phraseanet::erreur: echec du serveur de mail" approved="yes">
         <source>phraseanet::erreur: echec du serveur de mail</source>
@@ -11750,35 +11766,35 @@
       <trans-unit id="fdb5ea435d0e0d2d8e9dc7e2dc925c031406385c" resname="preview:: Description" approved="yes">
         <source>preview:: Description</source>
         <target state="translated">Beschreibung</target>
-        <jms:reference-file line="954">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="963">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="424597224c5d2322b6e8db99037234f7b2641de0" resname="preview:: Historique" approved="yes">
         <source>preview:: Historique</source>
         <target state="translated">Historie</target>
-        <jms:reference-file line="955">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="964">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="74e09022ffbf0d295142654902e9d7a007f209a5" resname="preview:: Popularite" approved="yes">
         <source>preview:: Popularite</source>
         <target state="translated">Beliebtheit</target>
-        <jms:reference-file line="958">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="967">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9c61385964471a1171066ba2ba3622a98ffb84b" resname="preview:: arreter le diaporama" approved="yes">
         <source>preview:: arreter le diaporama</source>
         <target state="translated">stoppen</target>
-        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="96">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="62">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77a36033b8fdccc947d744ae8e3120c7d8dafa46" resname="preview:: demarrer le diaporama" approved="yes">
         <source>preview:: demarrer le diaporama</source>
         <target state="translated">Dia-Schau</target>
-        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="94">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="60">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a5cc2b2cd9b0421d131185277e9005d8e616582c" resname="preview::date" approved="yes">
         <source>preview::date</source>
@@ -11807,7 +11823,7 @@
       <trans-unit id="2b03b2c44ce1a3c17af6b603d666344f64ebe942" resname="preview::tab:feedback" approved="yes">
         <source>preview::tab:feedback</source>
         <target state="translated">Bestätigung</target>
-        <jms:reference-file line="956">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="965">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7f27fe47e2d3556c660a6fade6ceba7e8e62c4c" resname="preview::tab:feedback closed" approved="yes">
         <source>preview::tab:feedback closed</source>
@@ -11975,20 +11991,20 @@
       <trans-unit id="98ab0e2a8cf4a7c9f6952361e6c750a8009b70a5" resname="prive" approved="yes">
         <source>prive</source>
         <target state="translated">privat</target>
-        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="79">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="039db3240f9c47314f5b8f05835c54795f45324e" resname="privé" approved="yes">
         <source>privé</source>
         <target state="translated">privat</target>
-        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="60">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6dd8429cc900b9460f1e9d4be6155a6ee1b6de42" resname="processing" approved="yes">
         <source>processing</source>
         <target state="translated">verarbeitend</target>
-        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="308">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f63658cad863dee4a5876278e836472380183ade" resname="prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble" approved="yes">
         <source>prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble</source>
@@ -12004,7 +12020,7 @@
       <trans-unit id="f8877a3e5fa41e324ef59243c175353144990647" resname="prod::action:property title" approved="yes">
         <source>prod::action:property title</source>
         <target state="translated">Eigenschaften</target>
-        <jms:reference-file line="1044">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1053">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef27ad74061e0e15683e84dec7f5559f7797637f" resname="prod::advancesearch:tooltips:datefield_restriction_explanation" approved="yes">
         <source>prod::advancesearch:tooltips:datefield_restriction_explanation</source>
@@ -12170,8 +12186,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="021da4e7ad79ba6ef0855ecca3539db02b2d12f9" resname="prod::export: send mail notification" approved="yes">
         <source>prod::export: send mail notification</source>
         <target state="translated">E-Mail-Anfrage gesendet</target>
+        <jms:reference-file line="1059">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="18">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="1050">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb08c63b1c016e31a255a38795c8e4cb66b0e66e" resname="prod::facet:base_label" approved="yes">
         <source>prod::facet:base_label</source>
@@ -12196,7 +12212,7 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="47f76b5a8ec06b165c0d83ed447999def6f368e4" resname="prod::notification: notification title" approved="yes">
         <source>prod::notification: notification title</source>
         <target state="translated">Benachrichtigungen</target>
-        <jms:reference-file line="1046">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1055">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd532704ccd19891fe39fc3e14235cbfa6b79abf" resname="prod::publication:title" approved="yes">
         <source>prod::publication:title</source>
@@ -12206,17 +12222,17 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="5fa97d7a05eb572c80ae0ccf85be3a27dcddb943" resname="prod::push: List name can not be empty" approved="yes">
         <source>prod::push: List name can not be empty</source>
         <target state="translated">Name der Liste wird erfordert</target>
-        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1057">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2682250f21be2e6ce7e89ab678c50a394191206a" resname="prod::push: New list title" approved="yes">
         <source>prod::push: New list title</source>
         <target state="translated">Neue Liste</target>
-        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1056">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="19aeacc47cb48d5ae39c216aa0d456ac0f2ea55d" resname="prod::push: add" approved="yes">
         <source>prod::push: add</source>
         <target state="translated">Hinzufügen</target>
-        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1058">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dee7c522bf9e0eea45e003fb4d0f736bc251a954" resname="prod::push:push_set_title" approved="yes">
         <source>prod::push:push_set_title</source>
@@ -12361,19 +12377,19 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="6ad73c8fd370f62ccd3bf50cd9cc3563aed5273c" resname="prod::tools: document" approved="yes">
         <source>prod::tools: document</source>
         <target state="translated">Dokument</target>
-        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
         <jms:reference-file line="74">Controller/Prod/ToolsController.php</jms:reference-file>
+        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e36d93428a247d085ffbb974db21290395643463" resname="prod::videoTools:chapterTitle" approved="yes">
         <source>prod::videoTools:chapterTitle</source>
         <target state="translated">Kapiteltitel</target>
-        <jms:reference-file line="1042">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1051">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4dc1d766c992fbd57317a321602272b20469a64" resname="prod::workzone:Actions" approved="yes">
         <source>prod::workzone:Actions</source>
         <target state="translated">Aktionen</target>
-        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6140f86d00814c5627728413d43421ce867c11db" resname="prod::workzone:feedback add user">
         <source>prod::workzone:feedback add user</source>
@@ -12589,8 +12605,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="a2a8888f67982de346cedbe03b5884757de77925" resname="prod:expose:publication:Parent Publication" approved="yes">
         <source>prod:expose:publication:Parent Publication</source>
         <target state="translated">Übergeordnete Veröffentlichung</target>
-        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/ExposeNew.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="41">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d190364e0bc239d60124d5a906249199fcedbcf7" resname="prod:expose:publication:Password" approved="yes">
@@ -12924,13 +12940,18 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
         <target state="translated">Filter entfernen</target>
         <jms:reference-file line="218">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="9fb38743f0e67ac389f4d31a55eff4ec5acac703" resname="prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)">
+        <source>prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</source>
+        <target state="new">prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</target>
+        <jms:reference-file line="59">Elastic/Search/FacetsResponse.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="61c9b2b17db77a27841bbeeabff923448b0f6388" resname="public" approved="yes">
         <source>public</source>
         <target state="translated">öffentlich</target>
-        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="64">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9647ab4603346566d2218fda731606baafcbe408" resname="publication : autheur" approved="yes">
         <source>publication : autheur</source>
@@ -13038,11 +13059,11 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="1d740fd7fe206b5e6e57bef828e876a1bc484dd5" resname="rafraichir" approved="yes">
         <source>rafraichir</source>
         <target state="translated">Aktualisieren</target>
+        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/results/feeds.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/results/feeds.html.twig</jms:reference-file>
-        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
-        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0dea865dcd106d77e52ea8bffe6f87e2add0ac53" resname="recordtype" approved="yes">
         <source>recordtype</source>
@@ -13231,8 +13252,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
         <source>report:: Connexion</source>
         <target state="translated">Verbindungen</target>
         <jms:reference-file line="666">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="afa9685c95f7dff29cb2ad048da368c6e3dbadbc" resname="report:: Databox content" approved="yes">
         <source>report:: Databox content</source>
@@ -13307,14 +13328,14 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="48808e405192603e079ef1ccbbc1a1df98e317bd" resname="report:: collections" approved="yes">
         <source>report:: collections</source>
         <target state="translated">Kollektionen</target>
-        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="96">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a1193a920be0725a4560344ca10db36147ffd34" resname="report:: commentaire" approved="yes">
         <source>report:: commentaire</source>
         <target state="translated">Kommentar</target>
-        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="99">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="51f822380b654c4fc5adb28eb0643f37aac0d89b" resname="report:: copyright" approved="yes">
         <source>report:: copyright</source>
@@ -13324,9 +13345,9 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="cf3a5321aa85f0706b89021206bd8cd1ad57da54" resname="report:: date" approved="yes">
         <source>report:: date</source>
         <target state="translated">Datum</target>
+        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="669">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="670">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e125eaf6fca2110f86b6ebba60371a4875c87e03" resname="report:: document ajoute" approved="yes">
         <source>report:: document ajoute</source>
@@ -13377,21 +13398,21 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="26d00286d5aecf7cfda0e1395c4208440409b8c0" resname="report:: non-renseigne" approved="yes">
         <source>report:: non-renseigne</source>
         <target state="translated">nicht ausgefüllt</target>
-        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
-        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
+        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
+        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
         <jms:reference-file line="117">module/report/validate.php</jms:reference-file>
+        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
+        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="411">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="508">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="520">module/report/activity.php</jms:reference-file>
-        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
         <jms:reference-file line="117">module/report/sent.php</jms:reference-file>
-        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
         <jms:reference-file line="161">module/report/download.php</jms:reference-file>
-        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
-        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
         <jms:reference-file line="110">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="118">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="123">module/report/connexion.php</jms:reference-file>
+        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="07c06c0cac8bd3e3507a72d6cb7fa1ee23a6bf13" resname="report:: page d'accueil" approved="yes">
         <source>report:: page d'accueil</source>
@@ -13423,9 +13444,9 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="8df95f5dffb705018ebae64a4850f1f93bafc098" resname="report:: question" approved="yes">
         <source>report:: question</source>
         <target state="translated">Anfrage</target>
-        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="43">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b9ef4ecd16724b3218cf46f9956b8b157498c3a1" resname="report:: questions" approved="yes">
         <source>report:: questions</source>
@@ -13445,8 +13466,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="8fb18670b89f5cefede425401428a70189f654ea" resname="report:: record id" approved="yes">
         <source>report:: record id</source>
         <target state="translated">Record id</target>
-        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="90">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a11e1e1373aae28668cdf7a08486e767283bbaa2" resname="report:: resolution" approved="yes">
         <source>report:: resolution</source>
@@ -13726,7 +13747,7 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="44a5de1cdcf30547c937f197cd3d58e143de62a6" resname="setup::custom-link:help-menu" approved="yes">
         <source>setup::custom-link:help-menu</source>
         <target state="translated">Hilfemenü</target>
-        <jms:reference-file line="58">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0286ea45f1074802cfe8fbf84b7c439fb287d0de" resname="setup::custom-link:language-link" approved="yes">
         <source>setup::custom-link:language-link</source>
@@ -13741,7 +13762,7 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="2de3bc78c6fb26b56dd934a81dc76afdba8c79ab" resname="setup::custom-link:location" approved="yes">
         <source>setup::custom-link:location</source>
         <target state="translated">Ort auswählen</target>
-        <jms:reference-file line="57">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4db79dfecabb4b9acb44a4b49e9b6b433b28d04" resname="setup::custom-link:location-link" approved="yes">
         <source>setup::custom-link:location-link</source>
@@ -13751,13 +13772,13 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="ccfe45428ee9769a865d3d90c0e4dc50a6b68e9c" resname="setup::custom-link:name-link" approved="yes">
         <source>setup::custom-link:name-link</source>
         <target state="translated">Links Name</target>
-        <jms:reference-file line="23">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="97">web/admin/setup.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fdecb6454c7adeaeb05bac7f574ee70884900ca2" resname="setup::custom-link:navigation-bar" approved="yes">
         <source>setup::custom-link:navigation-bar</source>
         <target state="translated">Navigationsleiste</target>
-        <jms:reference-file line="59">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4696021003b181f9acc9261382e07364c6b83036" resname="setup::custom-link:order-link" approved="yes">
         <source>setup::custom-link:order-link</source>
@@ -13767,12 +13788,12 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="1b09a3a0a8b0205f23b3fe59074f8dfd72d0b0ae" resname="setup::custom-link:placeholder-link-url" approved="yes">
         <source>setup::custom-link:placeholder-link-url</source>
         <target state="translated">zB: https://docs.phraseanet.com</target>
-        <jms:reference-file line="47">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="52">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a1380c70f5190d6c0c38214fe24ac99272ef7bd2" resname="setup::custom-link:select-language" approved="yes">
         <source>setup::custom-link:select-language</source>
         <target state="translated">Sprache auswählen</target>
-        <jms:reference-file line="34">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67572283912404fe90681e8566d880e1fd10d58e" resname="setup::custom-link:title-custom-link" approved="yes">
         <source>setup::custom-link:title-custom-link</source>
@@ -13812,8 +13833,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="9fef1c0f1a70c8bc024e6691f1584083c27d2b13" resname="status:: numero de bit" approved="yes">
         <source>status:: numero de bit</source>
         <target state="translated">Status Nummer</target>
-        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="802c606a20e093fac7d2b5a45d947a4dff96e628" resname="status:: retrouver sous forme de filtre dans la recherche" approved="yes">
         <source>status:: retrouver sous forme de filtre dans la recherche</source>
@@ -13978,8 +13999,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="c8eadb101df19fb4960c791cf1afaa49d3516feb" resname="task::ftp:proxy" approved="yes">
         <source>task::ftp:proxy</source>
         <target state="translated">Proxy</target>
-        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="5">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d50701eb37a2e5b7dfe3358ba91ff9a1cc6f10ef" resname="task::ftp:proxy password" approved="yes">
         <source>task::ftp:proxy password</source>
@@ -13989,8 +14010,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="a7e5c84ff2404f76423afe64d0f5b8fbea07c024" resname="task::ftp:proxy port" approved="yes">
         <source>task::ftp:proxy port</source>
         <target state="translated">Proxy Port</target>
-        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="11">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d927a070b462263321072111c64cc0505c9d14" resname="task::ftp:proxy user" approved="yes">
         <source>task::ftp:proxy user</source>
@@ -14092,8 +14113,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="416134a1966f12f8d23f9f54f3cc32ea43ef3e46" resname="thesaurus:: Lier la branche de thesaurus au champ" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ</source>
         <target state="translated">Die Verzweigung mit dem Feld %s verbinden</target>
-        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="213a599ea75e45b7e28a260a71b032b3e3601e2b" resname="thesaurus:: Lier la branche de thesaurus au champ %branch%" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ %branch%</source>
@@ -14103,9 +14124,9 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="227338ab622537da92490cedc6709de0b9122e56" resname="thesaurus:: Nouveau synonyme" approved="yes">
         <source>thesaurus:: Nouveau synonyme</source>
         <target state="translated">Neuer Synonym</target>
+        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
         <jms:reference-file line="1050">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6bec8860c3453260869cea4fb043fac543cf724" resname="thesaurus:: Nouveau terme" approved="yes">
         <source>thesaurus:: Nouveau terme</source>
@@ -14115,8 +14136,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="ef0a054e6da228e6ad009d469c4bdf31b1de7999" resname="thesaurus:: Nouveau terme specifique" approved="yes">
         <source>thesaurus:: Nouveau terme specifique</source>
         <target state="translated">Neuer bestimmte Begriff</target>
-        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="261cd0e03ca27d32466be99d5cd9a0426d3a508c" resname="thesaurus:: Proprietes" approved="yes">
         <source>thesaurus:: Proprietes</source>
@@ -14138,8 +14159,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="f56e32a67c0a47d74d3441e499bfe64858ffee36" resname="thesaurus:: accepter..." approved="yes">
         <source>thesaurus:: accepter...</source>
         <target state="translated">Annehmen</target>
-        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="10">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c56e1002fd59b3fed0108426b7926f3252d9fc8d" resname="thesaurus:: afficher les termes refuses" approved="yes">
         <source>thesaurus:: afficher les termes refuses</source>
@@ -14254,15 +14275,15 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
         <target state="translated">Text</target>
         <jms:reference-file line="5">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="85">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-text.html.twig</jms:reference-file>
+        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8ec3584a75e01816472150b1c24268c9612dd51" resname="thesaurus:: export en topics" approved="yes">
         <source>thesaurus:: export en topics</source>
         <target state="translated">Themen</target>
+        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="1233">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-topics.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a09dafb2a5c9c7200a3125cca1148346e7bc1843" resname="thesaurus:: exporter" approved="yes">
         <source>thesaurus:: exporter</source>
@@ -14657,8 +14678,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="1118f7e206d8ec4d92392f3e8c2804b156b3a082" resname="thumbnail validation" approved="yes">
         <source>thumbnail validation</source>
         <target state="translated">Miniaturansicht Bestätigung</target>
-        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="309">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e96ed809b61066d6ea96ba9afc8747a042b361a" resname="tout le monde" approved="yes">
         <source>tout le monde</source>
@@ -14705,8 +14726,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
         <source>upload:: Status :</source>
         <target state="translated">Status</target>
         <jms:reference-file line="80">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
         <jms:reference-file line="462">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4fea0574cc81b5fd40ab0537b0905cc4c3806039" resname="users rights have been reseted" approved="yes">
         <source>users rights have been reseted</source>
@@ -14716,11 +14737,11 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="e204d28a2874f6123747650d3e4003d4357d75eb" resname="validate" approved="yes">
         <source>validate</source>
         <target state="translated">Bestätigen</target>
+        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="120">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="160">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="186">actions/Tools/index.html.twig</jms:reference-file>
-        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c02a2db6d6cdf30d37962e221624cc7661f4b892" resname="validation:: NON" approved="yes">
         <source>validation:: NON</source>
@@ -14786,128 +14807,128 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
       <trans-unit id="ecbe1590a62c751a6bafe631fc5d05158d0962b4" resname="workzone:datepicker:april" approved="yes">
         <source>workzone:datepicker:april</source>
         <target state="translated">April</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="23ed9061fbf1a184658e05e57a121a72474b54eb" resname="workzone:datepicker:august" approved="yes">
         <source>workzone:datepicker:august</source>
         <target state="translated">August</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e55bc758f272d38198385584d6f50c2dd0eae13" resname="workzone:datepicker:december" approved="yes">
         <source>workzone:datepicker:december</source>
         <target state="translated">Dezember</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db178b383e47bbe58670afd6a67528a4712444d7" resname="workzone:datepicker:february" approved="yes">
         <source>workzone:datepicker:february</source>
         <target state="translated">Februar</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4e3f12ef1defef487381a8339ea49840666414a" resname="workzone:datepicker:friday" approved="yes">
         <source>workzone:datepicker:friday</source>
         <target state="translated">Freitag</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="93f6bd6902114b73c225005188bce87569a3ac9c" resname="workzone:datepicker:january" approved="yes">
         <source>workzone:datepicker:january</source>
         <target state="translated">Januar</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0f1d297c3d3d9bc7cd800a9bd1a938904f4440ab" resname="workzone:datepicker:july" approved="yes">
         <source>workzone:datepicker:july</source>
         <target state="translated">Juli</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d860a667674628da86b76fb3be676370a61893c" resname="workzone:datepicker:june" approved="yes">
         <source>workzone:datepicker:june</source>
         <target state="translated">Juni</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2242d17f28dc262529688d688b5c2e128813ad8b" resname="workzone:datepicker:march" approved="yes">
         <source>workzone:datepicker:march</source>
         <target state="translated">März</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2ce30e1185f0f46df340ca727d4d9d89f42b6f5b" resname="workzone:datepicker:may" approved="yes">
         <source>workzone:datepicker:may</source>
         <target state="translated">Mai</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a7199e82486037293a2cfb17003ed9a30e2cfb2" resname="workzone:datepicker:monday" approved="yes">
         <source>workzone:datepicker:monday</source>
         <target state="translated">Montag</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0bbaf1d4dbaa3b5eb27154fcc9579f89c848b091" resname="workzone:datepicker:nextText" approved="yes">
         <source>workzone:datepicker:nextText</source>
         <target state="translated">nächste</target>
-        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="204">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ba391713621e89b5ecec7bc867e949e386332732" resname="workzone:datepicker:november" approved="yes">
         <source>workzone:datepicker:november</source>
         <target state="translated">November</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46727c5b9b3455e2cec4fc761568262af710f119" resname="workzone:datepicker:october" approved="yes">
         <source>workzone:datepicker:october</source>
         <target state="translated">Oktober</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7eef21d25b8fa0b6940fe6c87640f82612d0393f" resname="workzone:datepicker:prevText" approved="yes">
         <source>workzone:datepicker:prevText</source>
         <target state="translated">vorherige</target>
-        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="203">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d4fa7c1a1d4486201a760bcfb2f342ec8329f00" resname="workzone:datepicker:saturday" approved="yes">
         <source>workzone:datepicker:saturday</source>
         <target state="translated">Samstag</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8aa1e4c6df39f7365a4fab8f3c70d3d8d4757ee" resname="workzone:datepicker:september" approved="yes">
         <source>workzone:datepicker:september</source>
         <target state="translated">September</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd48f23064201336fafcab46a34c085d5a886cb6" resname="workzone:datepicker:sunday" approved="yes">
         <source>workzone:datepicker:sunday</source>
         <target state="translated">Sonntag</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de522dc0285d55c95bb9af4aa39020ac35548353" resname="workzone:datepicker:thursday" approved="yes">
         <source>workzone:datepicker:thursday</source>
         <target state="translated">Donnerstag</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d274289f8c48bcb43c06efe9386967b7f8fb56df" resname="workzone:datepicker:tuesday" approved="yes">
         <source>workzone:datepicker:tuesday</source>
         <target state="translated">Dienstag</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="423742b6f616f9847ea24afec03e24b15f3ff10f" resname="workzone:datepicker:wednesday" approved="yes">
         <source>workzone:datepicker:wednesday</source>
         <target state="translated">Mittwoch</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbfb58c29147c5881e828d18a477f922211873a0" resname="workzone:feedback:expiration-closed" approved="yes">
         <source>workzone:feedback:expiration-closed</source>
@@ -14930,8 +14951,8 @@ Vorsicht: die aktuelle Werte werden durch die neue Werte überschrieben</target>
         <source>yes</source>
         <target state="translated">Ja</target>
         <jms:reference-file line="89">web/common/technical_datas.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="580">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="76">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="646b0ebbe9829e44e9e99e9ab991a526f758001d" resname="you are about to change the  representation thumbnail of your video" approved="yes">
         <source>you are about to change the  representation thumbnail of your video</source>

--- a/resources/locales/messages.en.xlf
+++ b/resources/locales/messages.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:31:06Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:22Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,8 +9,8 @@
       <trans-unit id="da39a3ee5e6b4b0d3255bfef95601890afd80709" resname="">
         <source></source>
         <target state="new"></target>
-        <jms:reference-file line="47">Form/Configuration/EmailFormType.php</jms:reference-file>
-        <jms:reference-file line="60">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c03e9a1b443b7d9ac9a84e4d2cf55ebc016a9c5b" resname="                                Add" approved="yes">
         <source>                                Add</source>
@@ -20,73 +20,73 @@
       <trans-unit id="17b36ba11b9598e1ca72638a17637c71db031f8b" resname="#3567c6" approved="yes">
         <source>#3567c6</source>
         <target state="translated">#3567c6</target>
-        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="86">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c18097cf04c5f24e6b201e44603c26f000cbf266" resname="#4497d5" approved="yes">
         <source>#4497d5</source>
         <target state="translated">#4497d5</target>
-        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="654b7f2144322b13150ca53f8eb712644275fbbb" resname="#5aa53b" approved="yes">
         <source>#5aa53b</source>
         <target state="translated">#5aa53b</target>
-        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="81184afa6b2fb59a54a368a94c5af314882f4379" resname="#a1d0d0" approved="yes">
         <source>#a1d0d0</source>
         <target state="translated">#a1d0d0</target>
-        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="69760e828adabd5e543638f8b396d108e4e1c7f6" resname="#ad0800" approved="yes">
         <source>#ad0800</source>
         <target state="translated">#ad0800</target>
-        <jms:reference-file line="71">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
-        <jms:reference-file line="72">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8868030f047d29838dccd3ebd90a8cbcf5cf97b9" resname="#b151ee" approved="yes">
         <source>#b151ee</source>
         <target state="translated">#b151ee</target>
-        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="87">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df800d7d3f6bec2f0c48d7b18ad0f7515b4ed8a4" resname="#b8d84e" approved="yes">
         <source>#b8d84e</source>
         <target state="translated">#b8d84e</target>
-        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d3505d50f73a3440832d861060fc212eb2d929a" resname="#c875ea" approved="yes">
         <source>#c875ea</source>
         <target state="translated">#c875ea</target>
-        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="88">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cdd9fb48ed6b38bdf4cd732d30851062312f64b3" resname="#e46990" approved="yes">
         <source>#e46990</source>
         <target state="translated">#e46990</target>
-        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="89">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="22a0112b6eafc281d17f1b98fb8405847d01f04b" resname="#f06006" approved="yes">
         <source>#f06006</source>
         <target state="translated">#f06006</target>
-        <jms:reference-file line="73">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db6ca79114142b612eebf0ca5f80b94c80cbf453" resname="#f4ea5b" approved="yes">
         <source>#f4ea5b</source>
         <target state="translated">#f4ea5b</target>
-        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc4fad5f043fc9875dcdc532a296ec359a6c39e1" resname="#f5842b" approved="yes">
         <source>#f5842b</source>
         <target state="translated">#f5842b</target>
-        <jms:reference-file line="74">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="590b78bf59d578b0efdd1a7b1a385e8004fa88e8" resname="#ffc322" approved="yes">
         <source>#ffc322</source>
         <target state="translated">#ffc322</target>
-        <jms:reference-file line="75">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0cc996e2ae03790c84ef6edc0601ba0245d7cf1c" resname="#ffccd7" approved="yes">
         <source>#ffccd7</source>
         <target state="translated">#ffccd7</target>
-        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="90">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9378053eb7743587671aa830ffd2c9f1b13ad1a" resname="%ElementsCount% records" approved="yes">
         <source>%ElementsCount% records</source>
@@ -177,28 +177,28 @@
       <trans-unit id="24c43d6925295b9738f6fe69e4fb3dc7a2030f0f" resname="%nb_records% records" approved="yes">
         <source>%nb_records% records</source>
         <target state="translated">%nb_records% records</target>
-        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Tooltip/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="107">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e39dc3a90b0674916ef22f19912638564f33e518" resname="%nb_view% vue" approved="yes">
         <source>%nb_view% vue</source>
         <target state="translated">%nb_view% view</target>
-        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae7480d89dfd1ca0d1732014aee13f9958836bf8" resname="%nb_view% vues" approved="yes">
         <source>%nb_view% vues</source>
         <target state="translated">%nb_view% views</target>
-        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="7">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de0804eb70c10b14d71df74292e45c6daa13d672" resname="%number% documents&lt;br/&gt;selectionnes" approved="yes">
         <source><![CDATA[%number% documents<br/>selectionnes]]></source>
         <target state="translated"><![CDATA[%number% documents<br/>selected]]></target>
-        <jms:reference-file line="268">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="263">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac5c6fe2979cfa2496c95dcb218f135fd916040d" resname="%quantity% Stories attached to the WorkZone" approved="yes">
         <source>%quantity% Stories attached to the WorkZone</source>
@@ -279,7 +279,7 @@
       <trans-unit id="f9b19aa0c7cf7aab245692450b473acff6a077e4" resname="%total% reponses" approved="yes">
         <source>%total% reponses</source>
         <target state="translated">%total% responses</target>
-        <jms:reference-file line="316">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="311">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="99d2e1a7e8d0ba4a7132282b53b15e503b91c2cb" resname="%user% a envoye son rapport de validation de %title%" approved="yes">
         <source>%user% a envoye son rapport de validation de %title%</source>
@@ -384,7 +384,7 @@
       <trans-unit id="4412a659c3e1ca169796ab2f540a932ea7cbe2a4" resname="*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance" approved="yes">
         <source>*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance</source>
         <target state="translated">*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance.</target>
-        <jms:reference-file line="28">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="356a192b7913b04c54574d18c28d46e6395428ab" resname="1" approved="yes">
         <source>1</source>
@@ -526,7 +526,7 @@
       <trans-unit id="62a3ad0fef668c4e2a220f6982de94942fbf1d1e" resname="AR" approved="yes">
         <source>AR</source>
         <target state="translated">AR</target>
-        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8887b473975b3b740e5afe559123403a6c219524" resname="About Roles :" approved="yes">
         <source>About Roles :</source>
@@ -625,17 +625,17 @@
       <trans-unit id="c3cd636a585b20c40ac2df5ffb403e83cb2eef51" resname="Actions" approved="yes">
         <source>Actions</source>
         <target state="translated">Actions</target>
-        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="26">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4a4f00323184bd750ee72b5c05e6e17d1584bfd" resname="Activate highlight" approved="yes">
         <source>Activate highlight</source>
         <target state="translated">Activate highlight on full text (experimental). Impact the time performance of search.</target>
-        <jms:reference-file line="74">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="85">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="682">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a733b809d2f1233496ab516eed0f3ef75cf3791a" resname="Active" approved="yes">
@@ -668,10 +668,10 @@
       <trans-unit id="61cc55aa0453184734c3fa0b621eda6fa874bd83" resname="Add" approved="yes">
         <source>Add</source>
         <target state="translated">Add</target>
-        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="514">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="515">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
+        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="983c5aed52d2f74bf36e97dc34dbce97fdd43f5b" resname="Add a&#10;                    new field" approved="yes">
         <source>Add a
@@ -734,7 +734,7 @@
       <trans-unit id="74ab95a4dbfaecbcd1fd586b71d97066ab7431c2" resname="Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only." approved="yes">
         <source>Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.</source>
         <target state="translated">Adds an option in forms to force the recipients of a Push or a Feedback to authenticate.</target>
-        <jms:reference-file line="52">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="65">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e7afebcfbae000b22c7c85e5560f89a2a0280b4" resname="Admin" approved="yes">
         <source>Admin</source>
@@ -780,22 +780,22 @@
       <trans-unit id="a810fdb68ba89818cce5c607021256e40cf14170" resname="Afficher la fiche descriptive" approved="yes">
         <source>Afficher la fiche descriptive</source>
         <target state="translated">Show Caption</target>
-        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="946bf37a064ede9145bd8e3c7ce50e8608885518" resname="Afficher le titre" approved="yes">
         <source>Afficher le titre</source>
         <target state="translated">Show Title</target>
-        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee793299aa2f135a4330889d59d362d1652fa577" resname="Afficher le type" approved="yes">
         <source>Afficher le type</source>
         <target state="translated">Display type</target>
-        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1041">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7627cf7574df870b584ab3bd8a67d62d7ab4a18b" resname="Afficher les status" approved="yes">
         <source>Afficher les status</source>
         <target state="translated">Show Status</target>
-        <jms:reference-file line="1005">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="47743dc906e82db1978c23daf01e4d5e727702bd" resname="Afficher une icone" approved="yes">
         <source>Afficher une icone</source>
@@ -830,16 +830,16 @@
       <trans-unit id="5e8a35671080dba23a7f84416dcf97fd975a33e6" resname="Ajouter a" approved="yes">
         <source>Ajouter a</source>
         <target state="translated">Add to</target>
-        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6be348e8c91127640dc04e94dca7d5503ddb6c7d" resname="Ajouter ma selection courrante" approved="yes">
         <source>Ajouter ma selection courrante</source>
         <target state="translated">Add my current selection</target>
+        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
         <jms:reference-file line="15">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/orders/order_item.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d391a678bc6acf01f3f67c57b07853c5a588171" resname="Ajouter un nouvel utilisateur" approved="yes">
         <source>Ajouter un nouvel utilisateur</source>
@@ -859,7 +859,7 @@
       <trans-unit id="6a72085653e4c5be8c7640c868ef787cbcf063d1" resname="All" approved="yes">
         <source>All</source>
         <target state="translated">All</target>
-        <jms:reference-file line="35">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="189">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="199">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="209">actions/Feedback/list.html.twig</jms:reference-file>
@@ -883,7 +883,7 @@
       <trans-unit id="619eebecff3aef2d53d82536ebc2604fb07900e2" resname="Allow the website to be indexed by search engines like Google" approved="yes">
         <source>Allow the website to be indexed by search engines like Google</source>
         <target state="translated">Allow search engines (such as Google) indexation</target>
-        <jms:reference-file line="48">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77c7b4909d393bbb0e9e72d3dd008972625771b3" resname="Allowed" approved="yes">
         <source>Allowed</source>
@@ -956,13 +956,11 @@
       <trans-unit id="f0cf9a47c6b420dda55c973a12840600fc19b7fb" resname="An error occured" approved="yes">
         <source>An error occured</source>
         <target state="translated">An error occurred</target>
-        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="164">Controller/Prod/MoveCollectionController.php</jms:reference-file>
-        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="251">Controller/Prod/BasketController.php</jms:reference-file>
-        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="218">Controller/Prod/StoryController.php</jms:reference-file>
+        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="71">Controller/Admin/DataboxesController.php</jms:reference-file>
         <jms:reference-file line="86">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="159">Controller/Admin/DataboxController.php</jms:reference-file>
@@ -984,12 +982,14 @@
         <jms:reference-file line="667">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="700">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="808">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="23">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="194">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
         <jms:reference-file line="19">admin/databox/databox.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a16a3255c311eccbe2471bfc5b5cd92f3b907654" resname="An error occured when wanting to change status!" approved="yes">
         <source>An error occured when wanting to change status!</source>
@@ -1030,13 +1030,13 @@
       <trans-unit id="98a5e115c36d45b5c1cb4ed3537f847a5210d1e7" resname="An error occurred" approved="yes">
         <source>An error occurred</source>
         <target state="translated">An error occurred</target>
-        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
-        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="2081">Controller/Api/V1Controller.php</jms:reference-file>
         <jms:reference-file line="2527">Controller/Api/V1Controller.php</jms:reference-file>
-        <jms:reference-file line="135">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="531">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="126">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="136">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
         <jms:reference-file line="81">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e861f79c8744b5cb0b59ce4f0100603952751b1" resname="An error occurred reading this file" approved="yes">
@@ -1057,7 +1057,7 @@
       <trans-unit id="3ad56f9f5a406f1c69267d4ac341168e3affa3e7" resname="Anonymous report" approved="yes">
         <source>Anonymous report</source>
         <target state="translated">Anonymous report</target>
-        <jms:reference-file line="34">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d7854118cda9d187ac6091c889576577aab8a36b" resname="Any time" approved="yes">
         <source>Any time</source>
@@ -1093,7 +1093,7 @@
       <trans-unit id="498778131fed5b01b06132a7c29c2d29829410c4" resname="Application description" approved="yes">
         <source>Application description</source>
         <target state="translated">META Description markup content</target>
-        <jms:reference-file line="36">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9ec030ab77d85f2493f1ebc5ab78e62e83fc383" resname="Application desktop" approved="yes">
         <source>Application desktop</source>
@@ -1103,7 +1103,7 @@
       <trans-unit id="ee3ac8b2def14068e5827dcd2499e831cb89712c" resname="Application title" approved="yes">
         <source>Application title</source>
         <target state="translated">Application title</target>
-        <jms:reference-file line="30">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="866fef154cc77e6c30d7c9e97387dae0fb72dd08" resname="Application web" approved="yes">
         <source>Application web</source>
@@ -1134,8 +1134,8 @@
       <trans-unit id="b8fb717785e899f8e3bacfd74a395da7a434af9e" resname="Apply changes" approved="yes">
         <source>Apply changes</source>
         <target state="translated">Apply changes</target>
-        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="112">actions/Property/index.html.twig</jms:reference-file>
+        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e585e139fb6fc86d30e02ba78bdbb4dff6ac6b9" resname="Apply status on story children." approved="yes">
         <source>Apply status on story children.</source>
@@ -1275,8 +1275,8 @@
       <trans-unit id="d6caeca6303e9c722c929fbb58744a013a7ba7db" resname="Audio Codec" approved="yes">
         <source>Audio Codec</source>
         <target state="translated">Audio Codec</target>
-        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="37">Media/Subdef/Audio.php</jms:reference-file>
+        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a80232c45008d73666e95544f7c9c8c0896536af" resname="Audio Samplerate" approved="yes">
         <source>Audio Samplerate</source>
@@ -1301,17 +1301,17 @@
       <trans-unit id="9e761dfcff90efcb07867accd3e8b109762fc596" resname="Auth_token directory path" approved="yes">
         <source>Auth_token directory path</source>
         <target state="translated">Auth_token directory path</target>
-        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77277d274230409567d5eaa8a27e1a1b8f08cef6" resname="Auth_token mount point" approved="yes">
         <source>Auth_token mount point</source>
         <target state="translated">Auth_token mount point</target>
-        <jms:reference-file line="34">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ef5e08e2db8aa52ae7a50b9d9f0bd6920b69a37" resname="Auth_token passphrase" approved="yes">
         <source>Auth_token passphrase</source>
         <target state="translated">Auth_token passphrase</target>
-        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb7b626329225c9775b113922aa0d1662b5901a2" resname="Authoriser l'access" approved="yes">
         <source>Authoriser l'access</source>
@@ -1337,27 +1337,27 @@
       <trans-unit id="d5f364d5d9a0a95fdba37f29a65a9ba61d6329ef" resname="Authorize *Phraseanet Navigator*" approved="yes">
         <source>Authorize *Phraseanet Navigator*</source>
         <target state="translated">DEPRECATED, Authorise *Phraseanet Navigator*</target>
-        <jms:reference-file line="27">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b85de40822e66ce4309b94ccad5bb731f2a89373" resname="Authorize Adobe cc Plugin to connect." approved="yes">
         <source>Authorize Adobe cc Plugin to connect.</source>
         <target state="translated">Authorize Adobe CC Plugin to log in</target>
-        <jms:reference-file line="36">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e1ead524b95ba3b45281df7ba45d2addbbf1a79" resname="Authorize Microsoft Office Plugin to connect." approved="yes">
         <source>Authorize Microsoft Office Plugin to connect.</source>
         <target state="translated">Authorize Microsoft Office Plugin to connect</target>
-        <jms:reference-file line="32">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c614ba7c453cdcd4d21b20e8286c6266c891e0c6" resname="Auto" approved="yes">
         <source>Auto</source>
         <target state="translated">Auto</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e57297a1b1a46f4190603240a211144dde456ffe" resname="Auto select databases" approved="yes">
         <source>Auto select databases</source>
         <target state="translated">Auto select databases</target>
-        <jms:reference-file line="22">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7c91a8c4806cffc223b40523b3233bd23412ad4" resname="AutoRegister information" approved="yes">
         <source>AutoRegister information</source>
@@ -1385,7 +1385,7 @@
       <trans-unit id="45fc87c2d0ade465c57c00f7aa434a4d0bebe106" resname="Available in multi-export tab" approved="yes">
         <source>Available in multi-export tab</source>
         <target state="translated">Available in multi-export tab.</target>
-        <jms:reference-file line="23">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="37940d53912d9cc9ab0441c09c3754d6e83c438b" resname="Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes." approved="yes">
         <source>Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes.</source>
@@ -1395,11 +1395,11 @@
       <trans-unit id="b52b36b7269fbfc58ec24bb724691951a3decbe8" resname="Back" approved="yes">
         <source>Back</source>
         <target state="translated">Previous</target>
-        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
         <jms:reference-file line="69">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="92">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="134">mobile/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="738444fb7badaeb28467562ed8af8e1311e42eac" resname="Back to Feedback" approved="yes">
         <source>Back to Feedback</source>
@@ -1420,9 +1420,9 @@
         <source>Bad request format, only JSON is allowed</source>
         <target state="translated">Bad request format. Only JSON is allowed.</target>
         <jms:reference-file line="191">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="61">Controller/Admin/RootController.php</jms:reference-file>
         <jms:reference-file line="223">Controller/Admin/RootController.php</jms:reference-file>
-        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa0d7d2cb29f1ca72b4108bfaa0bf5686d3910ff" resname="Bad request, please contact an admin" approved="yes">
         <source>Bad request, please contact an admin</source>
@@ -1531,7 +1531,7 @@
       <trans-unit id="54a2cf5e634dbba0be2bf8a55f79252f5c790bdb" resname="Browser" approved="yes">
         <source>Browser</source>
         <target state="translated">Browser</target>
-        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d90cbe9431fb9e8d6013b651c2fb46a598de9eb" resname="Business Fields" approved="yes">
         <source>Business Fields</source>
@@ -1549,7 +1549,7 @@
       <trans-unit id="4a9b7a5a8f68ffe693f4205fc0d2916e373e4b64" resname="By default it is available for admins" approved="yes">
         <source>By default it is available for admins</source>
         <target state="translated">By default it is available for admins.</target>
-        <jms:reference-file line="27">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a8e6c2695279fb4760d299974903123f751b3bf" resname="By field" approved="yes">
         <source>By field</source>
@@ -1577,12 +1577,12 @@
         <target state="translated">Cancel</target>
         <jms:reference-file line="131">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="28">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
-        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="114">actions/Property/index.html.twig</jms:reference-file>
-        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
+        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
+        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
         <jms:reference-file line="68">admin/fields/templates.html.twig</jms:reference-file>
         <jms:reference-file line="42">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae1f9ef7dc1cee4760e7f208f36c225e3ab1aa1f" resname="Cancel all" approved="yes">
         <source>Cancel all</source>
@@ -1603,14 +1603,14 @@
       <trans-unit id="f1f842e1950136f97e6b449b2ee8ee2a88c9d214" resname="Carousel" approved="yes">
         <source>Carousel</source>
         <target state="translated">Carousel</target>
-        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="790d9876f3745353f60eb4d5232b26bb597ca5a3" resname="Categorie" approved="yes">
         <source>Categorie</source>
         <target state="translated">Category</target>
-        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="38">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bf1584669680e7841bf069b9495ea2f012bff60b" resname="Ce champ est decrit comme element du %DublinCoreElementSet%" approved="yes">
         <source>Ce champ est decrit comme element du %DublinCoreElementSet%</source>
@@ -1640,14 +1640,14 @@
       <trans-unit id="17061b6a22c3d9f7255c7f6208394911623ea1cd" resname="Ce champ est obligatoire" approved="yes">
         <source>Ce champ est obligatoire</source>
         <target state="translated">This field is mandatory</target>
-        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="798">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="823">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="691">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="713">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e821f6f0c9613624f82ae880c01573ab0c0a0eac" resname="Ce champ est relie a une branche de thesaurus" approved="yes">
         <source>Ce champ est relie a une branche de thesaurus</source>
@@ -1668,12 +1668,12 @@
       <trans-unit id="9fb36da9009b1be61fc35e5de8ef5ea79ceca1c1" resname="Ce champ est trop long %length% caracteres max" approved="yes">
         <source>Ce champ est trop long %length% caracteres max</source>
         <target state="translated">Too long, expecting %length% characters max.</target>
-        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="801">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="826">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="694">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="716">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a436b2b01f08a63284006c23ac3b38c9a699cbd" resname="Ce champ est utilise en titre a l'affichage" approved="yes">
         <source>Ce champ est utilise en titre a l'affichage</source>
@@ -1750,8 +1750,8 @@
       <trans-unit id="b030d590c21c95efe2ba71da1d0f1198a7e655b4" resname="Choisir" approved="yes">
         <source>Choisir</source>
         <target state="translated">Choose</target>
-        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="150">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="168">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="368">web/admin/subdefs.html.twig</jms:reference-file>
@@ -1763,13 +1763,13 @@
       <trans-unit id="3f657f29e68346624be98bea3924a6748900a66c" resname="Choose a new password" approved="yes">
         <source>Choose a new password</source>
         <target state="translated">Choose a new password</target>
-        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="15">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ad9476afb3cde04fd01e41ab85a0180eabfdb1c" resname="Choose the title of the document to export" approved="yes">
         <source>Choose the title of the document to export</source>
         <target state="translated">Enable filename choice option when downloading</target>
-        <jms:reference-file line="40">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0506773f181511d306efe57b7d20af4ea44fa1b3" resname="Civility" approved="yes">
         <source>Civility</source>
@@ -1779,8 +1779,8 @@
       <trans-unit id="719ea396ad92e01b4757ec2b93bb1e5f270f771d" resname="Clear" approved="yes">
         <source>Clear</source>
         <target state="translated">Clear</target>
-        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/log_scheduler.html.twig</jms:reference-file>
+        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7135ee5eaed0e404c4fcf48d6eb7d2808f8e55f2" resname="Clear list" approved="yes">
         <source>Clear list</source>
@@ -1827,8 +1827,8 @@
       <trans-unit id="30c54a96f8011b39819ba18bcb53fcbb092d650d" resname="Collection" approved="yes">
         <source>Collection</source>
         <target state="translated">Collection</target>
-        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="446">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/databox/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="814cd4d896d0d93eac2f4d71dc24c91a46cd5e28" resname="Collection %collection%" approved="yes">
@@ -1898,10 +1898,10 @@
       <trans-unit id="f7853f027e327a9ddf52dd60f8d1719ae6904333" resname="Confidentialite" approved="yes">
         <source>Confidentialite</source>
         <target state="translated">Confidentiality</target>
-        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="56">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e9445beaddb548587c6f275e49da38e9fc7b785" resname="Confidentialite : privee" approved="yes">
         <source>Confidentialite : privee</source>
@@ -1992,7 +1992,7 @@
       <trans-unit id="da54a34bad5b32178cd5a344200f3beb72b8b214" resname="Cooliris" approved="yes">
         <source>Cooliris</source>
         <target state="translated">Cooliris</target>
-        <jms:reference-file line="55">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a1757945390259d3dbb7c551d01c23638463d39" resname="Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :" approved="yes">
         <source>Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :</source>
@@ -2048,7 +2048,7 @@
       <trans-unit id="26a9831600fb0e895035038bcac30cc389b393e0" resname="Create index" approved="yes">
         <source>Create index</source>
         <target state="translated">Create index</target>
-        <jms:reference-file line="56">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="67">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c175379b0389b2d6057b0b7db996720f1fb92fc7" resname="Creation date" approved="yes">
         <source>Creation date</source>
@@ -2068,9 +2068,9 @@
       <trans-unit id="2bd00521d39c34d7b8a4a42573e1cf42fb319036" resname="Creer" approved="yes">
         <source>Creer</source>
         <target state="translated">Create</target>
-        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e0c179a64761a8abdbd1a1ef499e6aa7fd41b516" resname="Creer la tache d'ecriture des metadonnees" approved="yes">
         <source>Creer la tache d'ecriture des metadonnees</source>
@@ -2115,8 +2115,8 @@
       <trans-unit id="6a2b9fb6f6a60bde44a1bbe5e058c013cb1004ea" resname="Creer une playlist" approved="yes">
         <source>Creer une playlist</source>
         <target state="translated">Create a Playlist</target>
-        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c26eb5f5ded79caa39c9dd44376bf3556f6466" resname="Creez une application pour commencer a utiliser l'API Phraseanet" approved="yes">
         <source>Creez une application pour commencer a utiliser l'API Phraseanet</source>
@@ -2148,12 +2148,12 @@
       <trans-unit id="19dff4dad0a7214ece14624f8c4c9fb206a1cfdd" resname="Current password" approved="yes">
         <source>Current password</source>
         <target state="translated">Current password</target>
-        <jms:reference-file line="26">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e8ae2dcb43aa1748c5f5facbb8bcc2b52a627059" resname="Current session" approved="yes">
         <source>Current session</source>
         <target state="translated">Current session</target>
-        <jms:reference-file line="43">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="46">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="081ae3fdc403609cf6e760849ebb14117b7a50cb" resname="Custom" approved="yes">
         <source>Custom</source>
@@ -2169,12 +2169,12 @@
       <trans-unit id="ce3e4bed2954adbf05f8edfaf1a4c0cc0cea70e9" resname="DE" approved="yes">
         <source>DE</source>
         <target state="translated">DE</target>
-        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="129bcdb9bbdbd9bba49b7e1eb1ec49698604f0b0" resname="DU" approved="yes">
         <source>DU</source>
         <target state="translated">DU</target>
-        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e2dc4518235e7567a3d68c45cb6165ec116fa3c" resname="Danger zone !" approved="yes">
         <source>Danger zone !</source>
@@ -2256,13 +2256,13 @@
       <trans-unit id="910c2f8e114bda3eef68b7f17eee5e864be52dc4" resname="Date de connexion" approved="yes">
         <source>Date de connexion</source>
         <target state="translated">Login date</target>
-        <jms:reference-file line="22">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d5e8d1af5f3c137fb998b7afa347eeea683a7229" resname="Date de création" approved="yes">
         <source>Date de création</source>
         <target state="translated">Creation date</target>
-        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a13dfa9c55746372090d1ffbd465703786b7f90" resname="Date de demande" approved="yes">
         <source>Date de demande</source>
@@ -2274,8 +2274,8 @@
       <trans-unit id="c004345fde85bded2c74513e29c8cd58d74b594f" resname="Date de modification" approved="yes">
         <source>Date de modification</source>
         <target state="translated">Modification date</target>
-        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="11">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce084029e351b4bfa9f425ae70e8aaa14a8904e5" resname="Date(s) from field(s)" approved="yes">
         <source>Date(s) from field(s)</source>
@@ -2318,7 +2318,7 @@
       <trans-unit id="7f4c92d36ad39747b7393498e20a21e3898d5ea6" resname="Default TTL in seconds of sub-definition url" approved="yes">
         <source>Default TTL in seconds of sub-definition url</source>
         <target state="translated">Default TTL in seconds for JWT of sub-definition url</target>
-        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="21cec17f6cd9c992f10804a71ea6d286a56c456a" resname="Default basket" approved="yes">
         <source>Default basket</source>
@@ -2328,27 +2328,27 @@
       <trans-unit id="1747ef3d688685c5844db2dc7c98aafd78ce3893" resname="Default export title" approved="yes">
         <source>Default export title</source>
         <target state="translated">Default export title</target>
-        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0865e6ae43db7711e100ad36595c2b38742f0b9f" resname="Default mail sender address" approved="yes">
         <source>Default mail sender address</source>
         <target state="translated">Default e-mail address sender</target>
-        <jms:reference-file line="22">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1ad516bc09a2a902e2bf2d738bed0236b5a61c5e" resname="Default query" approved="yes">
         <source>Default query</source>
         <target state="translated">Default query</target>
-        <jms:reference-file line="26">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27cbd98bc854aa8480d4c436e762e9f30a00474e" resname="Default searched type" approved="yes">
         <source>Default searched type</source>
         <target state="translated">Default searched type</target>
-        <jms:reference-file line="29">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ccd20794e5c5f8f28ac9b0b2f57b29bcd31ddfc6" resname="Default validation links duration" approved="yes">
         <source>Default validation links duration</source>
         <target state="translated">Default feedback links duration</target>
-        <jms:reference-file line="29">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="332c9d57e19e2419cf5246fc9283f182eb316b8d" resname="Define a webhook URL" approved="yes">
         <source>Define a webhook URL</source>
@@ -2363,7 +2363,7 @@
       <trans-unit id="3b6bf506a535e9bf22431eace58b8f2f704dbd2a" resname="Defined in Apache configuration" approved="yes">
         <source>Defined in Apache configuration</source>
         <target state="translated">Defined in Apache configuration.</target>
-        <jms:reference-file line="41">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a147677ac3ad9bbeaa766ccee9b2f2d3c7e1d59" resname="Delai depasse lors du contact avec le serveur WEB" approved="yes">
         <source>Delai depasse lors du contact avec le serveur WEB</source>
@@ -2433,20 +2433,20 @@
       <trans-unit id="57ec2e2addbd6a4117f16c1fff5f491fe3c5642c" resname="Deplacement %n_element% elements" approved="yes">
         <source>Deplacement %n_element% elements</source>
         <target state="translated">Moving %n_element% documents</target>
-        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17c91ee147631da4f5aacabed0e198eb02955790" resname="Dernier access" approved="yes">
         <source>Dernier access</source>
         <target state="translated">Last access</target>
-        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="821ed4c906c76220f9dc83eba5e0b861e22baa04" resname="Derniere mise a jour le %updated_on%" approved="yes">
         <source>Derniere mise a jour le %updated_on%</source>
         <target state="translated">Last Update on %updated_on%</target>
-        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="45">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dcce9368ad626fe4addfa719b7a16807d464aa9b" resname="Derniers envois" approved="yes">
         <source>Derniers envois</source>
@@ -2462,29 +2462,29 @@
       <trans-unit id="55f8ebc805e65b5b71ddafdae390e3be2bcd69af" resname="Description" approved="yes">
         <source>Description</source>
         <target state="translated">Caption</target>
-        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/Tooltip/DCESFieldInfo.html.twig</jms:reference-file>
-        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="31">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85cce1e14782f67cb830f74002ebe5603783c674" resname="Deselect all" approved="yes">
         <source>Deselect all</source>
         <target state="translated">Deselect all</target>
-        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="60">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="225">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd281ce85e6f98a7dad0aa31a2e493a85ef178ca" resname="Design of personalization logo section" approved="yes">
         <source>Design of personalization logo section</source>
         <target state="translated">Design of logo customization section</target>
-        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac930a136ebd04a19bc5f2ce1769fc065efb7bdf" resname="Detailed view URL" approved="yes">
         <source>Detailed view URL</source>
@@ -2510,8 +2510,8 @@
       <trans-unit id="45e147abd920eeb1aca320340e18cf67b4c77252" resname="Dimension" approved="yes">
         <source>Dimension</source>
         <target state="translated">Size</target>
-        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Unknown.php</jms:reference-file>
+        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Image.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8b6613d50c2d8718fd7cab023e1530ce11650736" resname="Disable document type sharing" approved="yes">
@@ -2522,12 +2522,12 @@
       <trans-unit id="f4f4473df8cb59f0a369aebee3d1509adc0151c6" resname="Disabled" approved="yes">
         <source>Disabled</source>
         <target state="translated">Disabled</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e304849daf61291daab688ef3154c851694909e6" resname="Disallow the possibility for the end user to disable push authentication" approved="yes">
         <source>Disallow the possibility for the end user to disable push authentication</source>
         <target state="translated">Removes the choice of authentication options in submission forms</target>
-        <jms:reference-file line="55">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="68">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa9fd169cd55f0433c6e7a4b5d758f90d0847411" resname="Display &amp; action settings" approved="yes">
         <source><![CDATA[Display & action settings]]></source>
@@ -2567,7 +2567,7 @@
       <trans-unit id="1dc1290f2dcd49c014e5cae4004924885fbd68ed" resname="Do you really want to end the activity of this session?" approved="yes">
         <source>Do you really want to end the activity of this session?</source>
         <target state="translated">Do you really want to end the activity of this session?</target>
-        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="017fd7aedf39f509d51ce202368e4f0ea943de4e" resname="Do you want to send your report ?" approved="yes">
         <source>Do you want to send your report ?</source>
@@ -2603,12 +2603,12 @@
       <trans-unit id="3859bdaa8c6ffa767307d2ebc130439c543819c8" resname="Document title" approved="yes">
         <source>Document title</source>
         <target state="translated">Document title</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="687c82861c956e47456186f6522cfc8dbadb8ef6" resname="Documents" approved="yes">
         <source>Documents</source>
         <target state="translated">Documents</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1096d02ee2e62ae8ea5873c92b391094d9f9516e" resname="Documents indisponibles" approved="yes">
         <source>Documents indisponibles</source>
@@ -2646,7 +2646,7 @@
       <trans-unit id="4e4528018d1a0aa11f7dc17b5425174a7436d334" resname="Drop index" approved="yes">
         <source>Drop index</source>
         <target state="translated">Drop index</target>
-        <jms:reference-file line="49">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a9c043f68c147a7c8d8c2fa14ddfaba6e05da62" resname="Duree" approved="yes">
         <source>Duree</source>
@@ -2661,8 +2661,8 @@
       <trans-unit id="0d01e2e86669e98441ab4dce5520696c318b7098" resname="E-mail" approved="yes">
         <source>E-mail</source>
         <target state="translated">E-mail</target>
-        <jms:reference-file line="23">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="37">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9cf2896f8b2e9e6a28f9b151e8be31f220a5d256" resname="E-mail domain" approved="yes">
         <source>E-mail domain</source>
@@ -2672,7 +2672,7 @@
       <trans-unit id="734a78cd06d0929c433f487754d18bf073e43bf6" resname="EN" approved="yes">
         <source>EN</source>
         <target state="translated">EN</target>
-        <jms:reference-file line="37">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a908567d2c0292366061394efd6d40b139e033c5" resname="ERREUR : La classe de subdef est necessaire et egal a &quot;thumbnail&quot;,&quot;preview&quot; ou &quot;document&quot;" approved="yes">
         <source>ERREUR : La classe de subdef est necessaire et egal a "thumbnail","preview" ou "document"</source>
@@ -2692,7 +2692,7 @@
       <trans-unit id="9debabbaa01a190fabe8324c5e6e2f2808052099" resname="ES" approved="yes">
         <source>ES</source>
         <target state="translated">ES</target>
-        <jms:reference-file line="38">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5301648dcf6b53cefc9ed52999aaa92d4603cae0" resname="Edit" approved="yes">
         <source>Edit</source>
@@ -2717,9 +2717,9 @@
       <trans-unit id="5184ecbec7829b91dda100c703ea3fa284c7f5e8" resname="Edition de 1 element" approved="yes">
         <source>Edition de 1 element</source>
         <target state="translated">Editing 1 document</target>
-        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="10">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99ead0eb32b2089a9933db5ccc262e2fc35fd0a6" resname="Edition des droits de %display_name%" approved="yes">
         <source>Edition des droits de %display_name%</source>
@@ -2754,19 +2754,19 @@
       <trans-unit id="201b9ab150a2ab3e5641814c373f8db1949199d0" resname="ElasticSearch index name" approved="yes">
         <source>ElasticSearch index name</source>
         <target state="translated">ElasticSearch index name</target>
-        <jms:reference-file line="44">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="55">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="666">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b89586db0b00163ce75ae7426f06aa2e2a57b223" resname="ElasticSearch server host" approved="yes">
         <source>ElasticSearch server host</source>
         <target state="translated">ElasticSearch server host</target>
-        <jms:reference-file line="37">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="48">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="654">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18fd7d0c79d71cd9317190ae98dccdb1f7cf8b76" resname="ElasticSearch service port" approved="yes">
         <source>ElasticSearch service port</source>
         <target state="translated">ElasticSearch service port</target>
-        <jms:reference-file line="40">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="51">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="658">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="84add5b2952787581cb9a8851eef63d1ec75d22b" resname="Email" approved="yes">
@@ -2847,7 +2847,7 @@
       <trans-unit id="16edbca430dbc855d01b65c634474ae1648e1890" resname="Empty if not used" approved="yes">
         <source>Empty if not used</source>
         <target state="translated">Empty if not used.</target>
-        <jms:reference-file line="45">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c90ec9c48fe61ec12eff0a4e00b6d74780aa38" resname="Empty quarantine" approved="yes">
         <source>Empty quarantine</source>
@@ -2879,8 +2879,8 @@
       <trans-unit id="0413c20ae2fd31e0a1eef73e7768c8e1c68558d9" resname="En cours d'encodage" approved="yes">
         <source>En cours d'encodage</source>
         <target state="translated">Encoding in progress</target>
-        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="531">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="56">actions/Bridge/records_list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="43494e363213dc176e0699b914ccf966ccbd994d" resname="En cours d'envoi" approved="yes">
@@ -2891,42 +2891,42 @@
       <trans-unit id="4b4a90ee07557c5f8d1a9aedaed0fafacc4cc58f" resname="Enable FTP export" approved="yes">
         <source>Enable FTP export</source>
         <target state="translated">Enable FTP export</target>
-        <jms:reference-file line="22">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4f48c8f3f90677271cd196305954c1bc820a420" resname="Enable FTP for users" approved="yes">
         <source>Enable FTP for users</source>
         <target state="translated">Enable FTP for users</target>
-        <jms:reference-file line="26">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="25b38d3df5918f72187522a9cf74625c729ac6ad" resname="Enable Forcing authentication to see push content" approved="yes">
         <source>Enable Forcing authentication to see push content</source>
         <target state="translated">Enable Login Password option for Push and Feedback</target>
-        <jms:reference-file line="51">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e2edcbbb1c6aa26ccce6fbf04bec121c904dcec" resname="Enable H264 stream mode" approved="yes">
         <source>Enable H264 stream mode</source>
         <target state="translated">Enable H264 stream mode</target>
-        <jms:reference-file line="30">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc15a5aec96be87d7fec6a07972f8ac99693b265" resname="Enable HD substitution" approved="yes">
         <source>Enable HD substitution</source>
         <target state="translated">Enable source document substitution</target>
-        <jms:reference-file line="28">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="344fc3edd6987653de543b2ecd2d31aec2f3cca0" resname="Enable Phraseanet Web API" approved="yes">
         <source>Enable Phraseanet Web API</source>
         <target state="translated">Enable Phraseanet Web API</target>
-        <jms:reference-file line="22">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee98e71194d6f532c3c777fa20a957c3ba490089" resname="Enable SMTP authentication" approved="yes">
         <source>Enable SMTP authentication</source>
         <target state="translated">Enable SMTP authentication</target>
-        <jms:reference-file line="31">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1abba66821d3efad3698297ceac2c3fc0e985faf" resname="Enable auto registration" approved="yes">
         <source>Enable auto registration</source>
         <target state="translated">Enable auto registration</target>
-        <jms:reference-file line="26">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84aa616ef0b3e29513430631bf82c50c9cde7406" resname="Enable document type sharing" approved="yes">
         <source>Enable document type sharing</source>
@@ -2936,43 +2936,43 @@
       <trans-unit id="af559a0c4023968d8723bcdfe3337ce72eca48eb" resname="Enable maintenance message broadcast" approved="yes">
         <source>Enable maintenance message broadcast</source>
         <target state="translated">Broadcast the maintenance message</target>
-        <jms:reference-file line="25">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2b8f6db16b5583a7d9ef39a74fe471390d73bd74" resname="Enable multi-doc mode" approved="yes">
         <source>Enable multi-doc mode</source>
         <target state="translated">Enable multi-doc mode</target>
-        <jms:reference-file line="25">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="af54ffee479b01e950445015c81b8e68c1347a66" resname="Enable possibility to notify users when publishing a new feed entry" approved="yes">
         <source>Enable possibility to notify users when publishing a new feed entry</source>
         <target state="translated">Enable possibility to notify users when publishing a news feed entry</target>
-        <jms:reference-file line="58">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="35a2e4d551405a7ce8cdf754de5a47c8922b52d7" resname="Enable thesaurus" approved="yes">
         <source>Enable thesaurus</source>
         <target state="translated">Enable Thesaurus</target>
-        <jms:reference-file line="22">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="56848224e379e98e9a4cbcad0b51a0e99f7980f0" resname="Enable this setting to share on Facebook and Twitter" approved="yes">
         <source>Enable this setting to share on Facebook and Twitter</source>
         <target state="translated">Enable this setting for obtaining permalink and/or share media on social network like Facebook and Twitter etc ...</target>
-        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8c91cee722569eccd85bf170aff83c6b8e3b4d1" resname="Enable thumbnail substitution" approved="yes">
         <source>Enable thumbnail substitution</source>
         <target state="translated">Enable thumbnail substitution</target>
-        <jms:reference-file line="31">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df174a3f2faa31814e06540acda7af8825403fac" resname="Enabled" approved="yes">
         <source>Enabled</source>
         <target state="translated">Enabled</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c2951dce186cc543b533d553a40cd64c767c6d7b" resname="End Activity" approved="yes">
         <source>End Activity</source>
         <target state="translated">End activity</target>
         <jms:reference-file line="13">web/account/sessions.html.twig</jms:reference-file>
-        <jms:reference-file line="41">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61983e17f966924dc25febd5756e710e2102d38f" resname="End Range" approved="yes">
         <source>End Range</source>
@@ -2982,7 +2982,7 @@
       <trans-unit id="b5d90b80b452e4c8e3f1840c23372475d8861803" resname="End session activity" approved="yes">
         <source>End session activity</source>
         <target state="translated">End session activity</target>
-        <jms:reference-file line="69">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="42f2df94366ecaac40f51500a7583ecc8c6d424b" resname="Enter your e-mail address to retrieve your password" approved="yes">
         <source>Enter your e-mail address to retrieve your password</source>
@@ -3127,8 +3127,8 @@
       <trans-unit id="40019ae278d51a265b82e37738989bf1b22157b7" resname="Etendue de la publication" approved="yes">
         <source>Etendue de la publication</source>
         <target state="translated">Publication scope</target>
-        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="255f8b2705b27e25acc23428730bfd7a32d9a0db" resname="Etes vous sur de supprimer %number% photos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% photos ?</source>
@@ -3143,14 +3143,14 @@
       <trans-unit id="e7f864e2cef6464cd4342b0a0b607c6b53fd8263" resname="Etes vous sur de supprimer %number% playlists ?" approved="yes">
         <source>Etes vous sur de supprimer %number% playlists ?</source>
         <target state="translated">Do you confirm that you want to delete of %number% playlists ?</target>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0181b1da6f09b84ae46efce781899eb57ec74b8" resname="Etes vous sur de supprimer %number% videos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% videos ?</source>
         <target state="translated">Confirm delete of %number% videos ?</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46a1884f7b083976b0fd0678f10b8f00ee93cde9" resname="Ex : Paris, bleu, montagne" approved="yes">
         <source>Ex : Paris, bleu, montagne</source>
@@ -3175,9 +3175,9 @@
       <trans-unit id="f3e4fadb9e370a1e2c0c622c01fc8c77daf93a2c" resname="Export" approved="yes">
         <source>Export</source>
         <target state="translated">Export</target>
+        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="75">Controller/Prod/DoDownloadController.php</jms:reference-file>
         <jms:reference-file line="76">Controller/Prod/DoDownloadController.php</jms:reference-file>
-        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c26d273867dffc55d40f46e6a163067c75969f5" resname="Export ranges" approved="yes">
         <source>Export ranges</source>
@@ -3192,7 +3192,7 @@
       <trans-unit id="6d2830b1e76dc7300fce6745176601827d233de8" resname="FR" approved="yes">
         <source>FR</source>
         <target state="translated">FR</target>
-        <jms:reference-file line="36">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="acb28212fba0272ee990cebd571ebe09b463312e" resname="FTP" approved="yes">
         <source>FTP</source>
@@ -3218,10 +3218,10 @@
         <source>Feedback</source>
         <target state="translated">Feedback</target>
         <jms:reference-file line="122">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="54">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="90d95d818c456d269d000b3d82579506f6e34c5f" resname="Feedback:: Requested by %initiator% on %createdDate%" approved="yes">
         <source>Feedback:: Requested by %initiator% on %createdDate%</source>
@@ -3281,11 +3281,11 @@
       <trans-unit id="aadf78d4b7c7c7341aa891adca70897c4f978cb6" resname="File is not present in quarantine anymore, please refresh" approved="yes">
         <source>File is not present in quarantine anymore, please refresh</source>
         <target state="translated">Document is not in quarantine anymore, please refresh</target>
+        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="56">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="136">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="157">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
-        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3491d2e44dd1896af3411bb1a048847c13647feb" resname="File is too big : 64k max" approved="yes">
         <source>File is too big : 64k max</source>
@@ -3430,7 +3430,7 @@
       <trans-unit id="a5ec616668f5ea6fa47eec00bbe6e31964599856" resname="GD" approved="yes">
         <source>GD</source>
         <target state="translated">GD Library</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a45e2e1fd0f0cb30474f4cfd3d8fbdc9fd7fb9" resname="GOP size" approved="yes">
         <source>GOP size</source>
@@ -3440,7 +3440,7 @@
       <trans-unit id="9c30a3485a5887f1ba5abd2a291d304a01863e55" resname="Gallery" approved="yes">
         <source>Gallery</source>
         <target state="translated">Gallery</target>
-        <jms:reference-file line="57">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="259242b8cd71adbfc416f01eaef816dacc0d8384" resname="General configuration" approved="yes">
         <source>General configuration</source>
@@ -3496,7 +3496,7 @@
       <trans-unit id="efd1f5fd46c31701d2e70555e9ab45efe27b4048" resname="Geonames server address" approved="yes">
         <source>Geonames server address</source>
         <target state="translated">Geonames server address</target>
-        <jms:reference-file line="35">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5334c3c15248b80aba72d8a192cb45256f6de263" resname="Get a notification when a mail export fails" approved="yes">
         <source>Get a notification when a mail export fails</source>
@@ -3506,7 +3506,7 @@
       <trans-unit id="05a07cd950e4b273afdde28fa0b591cc75524121" resname="Get setting form index" approved="yes">
         <source>Get setting form index</source>
         <target state="translated">Get setting form index</target>
-        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="92">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee485ef50d127d2c51fe0091051d8c390d03ed59" resname="Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side." approved="yes">
         <source>Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side.</source>
@@ -3541,7 +3541,7 @@
       <trans-unit id="442bee77a51f11ee32ca32751c4e244e80de6e3d" resname="Google Analytics identifier" approved="yes">
         <source>Google Analytics identifier</source>
         <target state="translated">Google Analytics identifier</target>
-        <jms:reference-file line="39">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="362c03cff3bb37904f552194e92e5f13c721882f" resname="Grant rights" approved="yes">
         <source>Grant rights</source>
@@ -3561,7 +3561,7 @@
       <trans-unit id="cd6d6f27b3e16afd7cdd573b85b3cc5bfd22e8db" resname="GraphicsMagick" approved="yes">
         <source>GraphicsMagick</source>
         <target state="translated">GraphicsMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="779f61efcfe62182d0052c9526f3910378764758" resname="Graphiste (preview au rollover)" approved="yes">
         <source>Graphiste (preview au rollover)</source>
@@ -3613,8 +3613,8 @@
       <trans-unit id="d0d3632efe2a20cf1235aead5d817e03308131cc" resname="Hello %username%" approved="yes">
         <source>Hello %username%</source>
         <target state="translated">Hi %username%</target>
-        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="82">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="62">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c47ae15370cfe1ed2781eedc1dc2547d12d9e972" resname="Help" approved="yes">
@@ -3630,21 +3630,21 @@
       <trans-unit id="78860a4e5b33556e6a8947485d8b042d9e58234e" resname="Hide information about users" approved="yes">
         <source>Hide information about users</source>
         <target state="translated">Hide information about users</target>
-        <jms:reference-file line="35">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="70f8bb9a8a5393ef080507a89e4b98d139000d65" resname="Home" approved="yes">
         <source>Home</source>
         <target state="translated">Home</target>
-        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="3">login/include/language-block.html.twig</jms:reference-file>
-        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="49">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99f3b7dca04d6f354a9d2a3b633d9578a9ad8cac" resname="Homepage slideshow" approved="yes">
         <source>Homepage slideshow</source>
         <target state="translated">Homepage slideshow setting</target>
-        <jms:reference-file line="51">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8e41286dd8a6f03ef89a5aa958b1dad86ba4211f" resname="Hyperfocal distance" approved="yes">
         <source>Hyperfocal distance</source>
@@ -3654,13 +3654,13 @@
       <trans-unit id="f39bf9043aaeea61e7a0ba3949d854bd3997cb2a" resname="I have read the terms of use" approved="yes">
         <source>I have read the terms of use</source>
         <target state="translated">I have read the terms of use</target>
-        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
         <jms:reference-file line="68">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ea424d38af72dd1366a08aad1f47eca3e7ec3d24" resname="IP" approved="yes">
         <source>IP</source>
         <target state="translated">IP address</target>
-        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f325d995b6d028ccc75771b1679537b623521c4" resname="ISO" approved="yes">
         <source>ISO</source>
@@ -3685,17 +3685,17 @@
       <trans-unit id="447a3b86a8a61425d5c46aed97eb2e7cf0bb769c" resname="If request is bigger, then mail is still available" approved="yes">
         <source>If request is bigger, then mail is still available</source>
         <target state="translated">If request is bigger, then mail is still available.</target>
-        <jms:reference-file line="23">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d9e4315a74579080394bc6a6fdb7f5eccbf41e8" resname="If set to 0, duration is permanent" approved="yes">
         <source>If set to 0, duration is permanent</source>
         <target state="translated">If set to 0, duration is permanent.</target>
-        <jms:reference-file line="30">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="516e5bc94c0583cb8e632e13c36f77e514e0afc3" resname="If you notice any unfamiliar devices or locations, click on button %button% to end the session." approved="yes">
         <source>If you notice any unfamiliar devices or locations, click on button %button% to end the session.</source>
         <target state="translated">If you notice any unfamiliar devices or locations, click on the button %button% to end the session.</target>
-        <jms:reference-file line="15">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="17">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f91c7b9a3a35352f74a9fb8708e35ddbb36a852b" resname="If you plan to store large files, be sure it will fit in these directories." approved="yes">
         <source>If you plan to store large files, be sure it will fit in these directories.</source>
@@ -3725,7 +3725,7 @@
       <trans-unit id="57a8e563190f921afb876d6489bb40ed74f43a1a" resname="ImageMagick" approved="yes">
         <source>ImageMagick</source>
         <target state="translated">ImageMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3e38a20c1629a473809ea6a14c9cdf4204d3ac3b" resname="Images par secondes" approved="yes">
         <source>Images par secondes</source>
@@ -3741,7 +3741,7 @@
       <trans-unit id="bae76060aa0bb6aaf66ce914cf80b0786f965dc7" resname="Imagine driver" approved="yes">
         <source>Imagine driver</source>
         <target state="translated">Imagine driver</target>
-        <jms:reference-file line="52">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca13920228ea59b30c40b8372f53df3bf4631520" resname="In the answer grid" approved="yes">
         <source>In the answer grid</source>
@@ -3778,9 +3778,9 @@
       <trans-unit id="54937b3a4f8cfa4576692882d3ff7b14c90c4ce5" resname="Informations" approved="yes">
         <source>Informations</source>
         <target state="translated">Info</target>
-        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/account/base.html.twig</jms:reference-file>
+        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e1e0586141223b0143df16f7422dae5a43b77103" resname="Informations personnelles" approved="yes">
         <source>Informations personnelles</source>
@@ -3829,8 +3829,8 @@
         <source>Invalid file type, only (%supported_file_types%) file formats are supported</source>
         <target state="translated">Invalid file type. Only %supported_file_types% file formats are supported.</target>
         <jms:reference-file line="60">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
         <jms:reference-file line="199">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="65fd566280b15a384df25c73315b0dcbc6dacb69" resname="Invalid file type, only (%supported_file_types%) file formats are supported'" approved="yes">
         <source>Invalid file type, only (%supported_file_types%) file formats are supported'</source>
@@ -3867,8 +3867,8 @@
       <trans-unit id="8606f0ad87b5f92e01e46416cad301829571b7a7" resname="Inverser" approved="yes">
         <source>Inverser</source>
         <target state="translated">Reverse</target>
-        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3067f6d77794b736024c9a5594c1823612581e07" resname="It is not recommended to install Phraseanet without HTTPS support" approved="yes">
         <source>It is not recommended to install Phraseanet without HTTPS support</source>
@@ -3898,13 +3898,13 @@
       <trans-unit id="aa288d5bdc9be4c044885fa43c6f3758a1087d5a" resname="Keywords used for indexing purposes by search engines robots" approved="yes">
         <source>Keywords used for indexing purposes by search engines robots</source>
         <target state="translated">Keywords used for indexing purposes by search engines crawlers</target>
-        <jms:reference-file line="33">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e9f378dcffe600d99f66ba5fa74cd91d10b2256" resname="L'upload a echoue" approved="yes">
         <source>L'upload a echoue</source>
         <target state="translated">Upload failed</target>
-        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="486">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="94fe10f78d9c8b531bbd609a20f373289599035c" resname="L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%" approved="yes">
         <source>L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%</source>
@@ -3948,20 +3948,20 @@
       <trans-unit id="cfa0120ab592ae2bc3198dbde15a7a87a0c792c4" resname="La taille maximale d'une video est de %duration% minutes." approved="yes">
         <source>La taille maximale d'une video est de %duration% minutes.</source>
         <target state="translated">The maximum duration for a video is %duration% minutes.</target>
-        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="900">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dcfd86b957b9cf12ede165c6c2fa0acf12f3eeb" resname="La video a ete rejetee" approved="yes">
         <source>La video a ete rejetee</source>
         <target state="translated">Video has been rejected</target>
-        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="527">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="653e67f152ecc63ff3ee1014e86cc630a35dfe1a" resname="La video a ete supprimee" approved="yes">
         <source>La video a ete supprimee</source>
         <target state="translated">Video has been deleted</target>
-        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="525">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="da1c672d0d761ed5ac292335ed60e14ff3073265" resname="La video est restreinte" approved="yes">
         <source>La video est restreinte</source>
@@ -4057,16 +4057,16 @@
       <trans-unit id="b96ead6ab3add78d8448fcb2d18af281bb2cb278" resname="Le poids maximum d'un fichier est de %size%" approved="yes">
         <source>Le poids maximum d'un fichier est de %size%</source>
         <target state="translated">Maximum filesize is %size%</target>
-        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="906">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="814">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="13b9d7ef8e81663d7162d25b84cec1c24041e630" resname="Le record n'a pas de fichier physique" approved="yes">
         <source>Le record n'a pas de fichier physique</source>
         <target state="translated">No physical file for this record</target>
-        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="896">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="808">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a596c989f20650068f6278338c1a966b7a8693f8" resname="Le token n'a pas encore ete genere" approved="yes">
         <source>Le token n'a pas encore ete genere</source>
@@ -4087,9 +4087,9 @@
       <trans-unit id="e330465da3182b7f6ed1b78217993edb4e22aacb" resname="Les elements ne peuvent etre uploades (problemes de type ou de droit)" approved="yes">
         <source>Les elements ne peuvent etre uploades (problemes de type ou de droit)</source>
         <target state="translated">Selected files can't be uploaded (file type or rights error)</target>
-        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="15">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="72d3dbec389dce620bfa531d37c5f199ca2ccfda" resname="Les indications donnees ci dessous sont a titre informatif." approved="yes">
         <source>Les indications donnees ci dessous sont a titre informatif.</source>
@@ -4213,7 +4213,7 @@
       <trans-unit id="4e5a2893bdcc7d239c1db72e4c4ffbe4bea73174" resname="Login" approved="yes">
         <source>Login</source>
         <target state="translated">Login</target>
-        <jms:reference-file line="32">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
         <jms:reference-file line="9">login/oauth/login.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/mapping.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/bind.html.twig</jms:reference-file>
@@ -4264,7 +4264,7 @@
       <trans-unit id="ca62571facf94a0b6b601235fa440be30c505b24" resname="Maintenance message" approved="yes">
         <source>Maintenance message</source>
         <target state="translated">Maintenance message</target>
-        <jms:reference-file line="22">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb66e0bf5a145832586ceac41b71a4f95abcbc7e" resname="Maintenance state" approved="yes">
         <source>Maintenance state</source>
@@ -4324,22 +4324,22 @@
       <trans-unit id="bfceb124609fe75ad259082ced98a09429f02d2c" resname="Matomo Analytics identifier" approved="yes">
         <source>Matomo Analytics identifier</source>
         <target state="translated">Matomo Analytics property (site id)</target>
-        <jms:reference-file line="45">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d17f219ba947499e5a2f9b63a78d54deb821e1f8" resname="Matomo Analytics url" approved="yes">
         <source>Matomo Analytics url</source>
         <target state="translated">Matomo Analytics URL</target>
-        <jms:reference-file line="42">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28736b7711fa32497f69497b45453226c3bea0aa" resname="Maximum megabytes allowed for download" approved="yes">
         <source>Maximum megabytes allowed for download</source>
         <target state="translated">Maximum megabytes allowed for download</target>
-        <jms:reference-file line="22">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e91bcca4090d4b36db511b03beb7800d72baa230" resname="Maximum number of pages to be extracted from PDF" approved="yes">
         <source>Maximum number of pages to be extracted from PDF</source>
         <target state="translated">Maximum number of pages extracted from PDF</target>
-        <jms:reference-file line="61">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="453c592dee2184bc6fb63b94d517cf1a6354590b" resname="Mes applications" approved="yes">
         <source>Mes applications</source>
@@ -4377,7 +4377,7 @@
       <trans-unit id="cb4f425374af2741715669ed8b541a666078b729" resname="Minimum number of letters before truncation" approved="yes">
         <source>Minimum number of letters before truncation</source>
         <target state="translated">Minimum number of characters before truncation</target>
-        <jms:reference-file line="22">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="815d1b7d85075463e14c340ff9897a6c4af09ec3" resname="Missing &quot;structure&quot; parameter" approved="yes">
         <source>Missing "structure" parameter</source>
@@ -4547,14 +4547,14 @@
       <trans-unit id="d850ee188c7c55b64bc3624534de5c5051a57dc6" resname="New password" approved="yes">
         <source>New password</source>
         <target state="translated">New password</target>
-        <jms:reference-file line="47">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="39">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="49">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="572cfba6707b8e82f8c893b2188bede937e3f662" resname="New password (confirmation)" approved="yes">
         <source>New password (confirmation)</source>
         <target state="translated">Confirm new password</target>
-        <jms:reference-file line="48">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="40">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17b2b838c5ce22c961a36736534a5029d6ba0087" resname="New task" approved="yes">
         <source>New task</source>
@@ -4571,8 +4571,8 @@
       <trans-unit id="816c52fd2bdd94a63cd0944823a6c0aa9384c103" resname="No" approved="yes">
         <source>No</source>
         <target state="translated">No</target>
-        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="283">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c123d8ad43d08cc48c3d6a7676e65f71eea59df" resname="No URL available" approved="yes">
         <source>No URL available</source>
@@ -4694,19 +4694,19 @@
       <trans-unit id="22838b9a8bf000656dd4ff96d8ac904c8c33fade" resname="Nom du nouveau panier" approved="yes">
         <source>Nom du nouveau panier</source>
         <target state="translated">Name</target>
-        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c57d307e10f641b5b496db576d0dcd69d1daf25e" resname="Non-Restreinte (publique)" approved="yes">
         <source>Non-Restreinte (publique)</source>
         <target state="translated">Unrestricted (public)</target>
-        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6eef6648406c333a4035cd5e60d0bf2ecf2606d7" resname="None" approved="yes">
         <source>None</source>
         <target state="translated">None</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
         <jms:reference-file line="56">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="260">admin/user/registrations.html.twig</jms:reference-file>
       </trans-unit>
@@ -4738,8 +4738,8 @@
       <trans-unit id="a6633333760410e40ad92a50baade0b83afe8f7f" resname="Not aggregated" approved="yes">
         <source>Not aggregated</source>
         <target state="translated">Not aggregated</target>
-        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="241">admin/fields/templates.html.twig</jms:reference-file>
+        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc451929f50e088ffcff10e90dfe157d2319e753" resname="Notification par email" approved="yes">
         <source>Notification par email</source>
@@ -4800,25 +4800,25 @@
       <trans-unit id="997c69f6571530618bb38ac03f4cf2d236dcc15e" resname="Number of replicas" approved="yes">
         <source>Number of replicas</source>
         <target state="translated">Number of replicas</target>
-        <jms:reference-file line="66">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="77">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="674">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5c2a8aa4e676273c8d8f177856923ed9950e54bb" resname="Number of shards" approved="yes">
         <source>Number of shards</source>
         <target state="translated">Number of shards</target>
-        <jms:reference-file line="62">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="73">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="670">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a44db49e9b745fe2a96ae2a2ef3595913e274b33" resname="Number of threads to use for FFMpeg" approved="yes">
         <source>Number of threads to use for FFMpeg</source>
         <target state="translated">Number of threads for FFmpeg</target>
-        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ce3bd4224c8c1780db56b4125ecf3f24bf748b7" resname="OK" approved="yes">
         <source>OK</source>
         <target state="translated">OK</target>
-        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="535">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a98216a32426b9e66a4ac1eb6df2e96e1b495c" resname="Ok" approved="yes">
         <source>Ok</source>
@@ -4869,10 +4869,10 @@
       <trans-unit id="94946e4d2391ccf8ff24f984869ae8fcf9ede7c4" resname="Or login with" approved="yes">
         <source>Or login with</source>
         <target state="translated">Or login with</target>
-        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
         <jms:reference-file line="103">web/login/index.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="91">login/oauth/login.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
+        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d75774c0f96b6ee44eb6643c9fea71b50b90ea8" resname="Order" approved="yes">
         <source>Order</source>
@@ -4912,7 +4912,7 @@
       <trans-unit id="77561f3d48cb738cc40f376dec4616a77da54ee1" resname="Original name" approved="yes">
         <source>Original name</source>
         <target state="translated">Original name</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="672c78971d44f4576ab54c347b873ad9dc98f5f1" resname="Oups ! something went wrong !" approved="yes">
         <source>Oups ! something went wrong !</source>
@@ -4932,9 +4932,9 @@
       <trans-unit id="fb06270f7c212baabc8749ffc36e49dc8f321548" resname="Page" approved="yes">
         <source>Page</source>
         <target state="translated">Page</target>
-        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="600584c2d5ccb97c0c0c424d9f32d6b102fcb040" resname="Pages" approved="yes">
         <source>Pages</source>
@@ -4944,31 +4944,31 @@
       <trans-unit id="fe42b90acc297644b70123354014701c49384489" resname="Paniers" approved="yes">
         <source>Paniers</source>
         <target state="translated">Baskets</target>
+        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="127">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="173">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="55">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="142">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="379c70ed96868079feece6d5c6a2b91545c2515b" resname="Par %author%" approved="yes">
         <source>Par %author%</source>
         <target state="translated">by %author%</target>
-        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="25">mobile/lightbox/feed.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8be3c943b1609fffbfc51aad666d0a04adf83c9d" resname="Password" approved="yes">
         <source>Password</source>
         <target state="translated">Password</target>
-        <jms:reference-file line="41">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
-        <jms:reference-file line="52">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="81">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e3c007b7794e8f9fc4381136dfc7cdff5aa788a8" resname="Password (confirmation)" approved="yes">
         <source>Password (confirmation)</source>
         <target state="translated">Confirm password</target>
-        <jms:reference-file line="53">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e77cc0549ad99a9d3ba5c384f7f329db24d6d0c" resname="Password is empty at line %line%" approved="yes">
         <source>Password is empty at line %line%</source>
@@ -4998,7 +4998,7 @@
       <trans-unit id="102bbf0d1fb0a23cb8d8fb6eb03685b4509176c0" resname="Percent of the time left before the end of the validation to send a reminder email" approved="yes">
         <source>Percent of the time left before the end of the validation to send a reminder email</source>
         <target state="translated">Percent of the time left before the end of the validation to send a reminder email</target>
-        <jms:reference-file line="26">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3d8de900b56813bb78e97afbf22578720d473219" resname="Periodically fetches an FTP repository content locally" approved="yes">
         <source>Periodically fetches an FTP repository content locally</source>
@@ -5064,14 +5064,14 @@
       <trans-unit id="cd95b41f85ddc0922e3fce8844279c55e9e3cdd9" resname="Playlist" approved="yes">
         <source>Playlist</source>
         <target state="translated">Playlist</target>
-        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77b69f32c8780049ce0eec9782c3b77bb1e52bc3" resname="Playlists" approved="yes">
         <source>Playlists</source>
         <target state="translated">Playlists</target>
-        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="183">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a79729c3f4563330799d576273950579e1ba3f5" resname="Please accept the terms of use to register." approved="yes">
         <source>Please accept the terms of use to register.</source>
@@ -5200,7 +5200,7 @@
       <trans-unit id="40c963556bf21635f163641ae0bbc354c6f8452c" resname="Prefix for notification emails" approved="yes">
         <source>Prefix for notification emails</source>
         <target state="translated">Prefix for e-mail notifications</target>
-        <jms:reference-file line="25">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="29">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="474ae549026692693381925784cc30e5b706f330" resname="Prerequisite and Configuration" approved="yes">
         <source>Prerequisite and Configuration</source>
@@ -5215,7 +5215,7 @@
       <trans-unit id="be11dff872b14e749d330f920d6b159e107f277a" resname="Presentation de vignettes de panier" approved="yes">
         <source>Presentation de vignettes de panier</source>
         <target state="translated">Basket display setup</target>
-        <jms:reference-file line="998">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1007">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e709e76ff5425bd59879423588e80e67d778fa57" resname="Presets" approved="yes">
         <source>Presets</source>
@@ -5281,13 +5281,13 @@
       <trans-unit id="a255047b3f86eb4c0c79377f0725c89ceafe07ae" resname="Publique" approved="yes">
         <source>Publique</source>
         <target state="translated">Public</target>
-        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="40">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107e7fab79b95c8f34990d625dd309e15996acba" resname="Publishers" approved="yes">
         <source>Publishers</source>
         <target state="translated">Publishers</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f7f57b519fc9bc5683b4808641d3b33f53b6f9d" resname="Push" approved="yes">
         <source>Push</source>
@@ -5474,13 +5474,12 @@
         <source>Re-initialiser</source>
         <target state="translated">Reset</target>
         <jms:reference-file line="411">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca2a6abfc98ae1a46c15a6f8bbdc5fac25531462" resname="Re-ordonner" approved="yes">
         <source>Re-ordonner</source>
         <target state="translated">Set order</target>
-        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="13">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="211">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="212">prod/WorkZone/Macros.html.twig</jms:reference-file>
@@ -5488,6 +5487,7 @@
         <jms:reference-file line="290">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="294">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="295">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9b19a5a212deb29444cc1b420ad81703205848be" resname="Read-only" approved="yes">
         <source>Read-only</source>
@@ -5497,12 +5497,12 @@
       <trans-unit id="8af84354a61a59531041ee67713997b84e7657ee" resname="Recaptcha private key" approved="yes">
         <source>Recaptcha private key</source>
         <target state="translated">reCAPTCHA private key</target>
-        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c821a7953fa090cedb78553591582972bd8836e9" resname="Recaptcha public key" approved="yes">
         <source>Recaptcha public key</source>
         <target state="translated">reCAPTCHA public key</target>
-        <jms:reference-file line="45">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="80f271a01202ec6ae47a6b61ad2bd75e4ccb4845" resname="Receive notification when I receive a push" approved="yes">
         <source>Receive notification when I receive a push</source>
@@ -5639,10 +5639,10 @@
       <trans-unit id="d672995a14650d0e018026b64f297663d8c71c8d" resname="Register" approved="yes">
         <source>Register</source>
         <target state="translated">Register</target>
-        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="10">login/include/register-link-block.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ab985702970c5012a1c1a2db7b65d95926aecaf" resname="Register approbation" approved="yes">
         <source>Register approbation</source>
@@ -5674,7 +5674,7 @@
       <trans-unit id="ced7b308a348567fbf21dd775ee496dd01207f24" resname="Remember me" approved="yes">
         <source>Remember me</source>
         <target state="translated">Remember me</target>
-        <jms:reference-file line="51">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="55">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8005b356e3a4dba94a532df1deec4ebce882d13" resname="Reminder : validate '%title%'" approved="yes">
         <source>Reminder : validate '%title%'</source>
@@ -5711,8 +5711,8 @@
         <source>Renew password</source>
         <target state="translated">Renew password</target>
         <jms:reference-file line="58">Notification/Mail/MailRequestPasswordUpdate.php</jms:reference-file>
-        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee9dca727a184d24dd17095c1acacff79855df0d" resname="Reorder collections" approved="yes">
         <source>Reorder collections</source>
@@ -5722,8 +5722,8 @@
       <trans-unit id="fe8356db1811c518f0900dba0e65602c0fdcde3a" resname="Reordonner automatiquement" approved="yes">
         <source>Reordonner automatiquement</source>
         <target state="translated">Sort automatically</target>
-        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc5b6dcdaa76e91a51a264ce56aedb3ac385fc3b" resname="Repertoire de stockage des fichiers" approved="yes">
         <source>Repertoire de stockage des fichiers</source>
@@ -5754,7 +5754,7 @@
       <trans-unit id="0173481a881e3245000ec3fc5da8d26053ec2d37" resname="Require authentication to download documents" approved="yes">
         <source>Require authentication to download documents</source>
         <target state="translated">Require authentication to download documents</target>
-        <jms:reference-file line="33">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c91dfa0024a9c65cb1f4cba0f4744e66fbcccba" resname="Require email validation to activate the account" approved="yes">
         <source>Require email validation to activate the account</source>
@@ -5916,32 +5916,32 @@
       <trans-unit id="741cd64a01685389e2fabdb7091a3b70f6be63ee" resname="SMTP encryption" approved="yes">
         <source>SMTP encryption</source>
         <target state="translated">SMTP encryption</target>
-        <jms:reference-file line="40">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d4a434baeeacaeeeb7e0ad914adfe6f76fb4fb6" resname="SMTP host" approved="yes">
         <source>SMTP host</source>
         <target state="translated">SMTP host</target>
-        <jms:reference-file line="34">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c0c4b23b7cf057f27996bf14973bc8778d0f86e" resname="SMTP password" approved="yes">
         <source>SMTP password</source>
         <target state="translated">SMTP password</target>
-        <jms:reference-file line="53">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="65b5a10871b0ff8eb5019b42bd57ef00c06a45a8" resname="SMTP port" approved="yes">
         <source>SMTP port</source>
         <target state="translated">SMTP port</target>
-        <jms:reference-file line="37">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aa18a4725d6a5fd47cfc64a79cfe902abb215068" resname="SMTP user" approved="yes">
         <source>SMTP user</source>
         <target state="translated">SMTP user</target>
-        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="78bb8826fcc2504583e625386c238563e6207595" resname="SSL" approved="yes">
         <source>SSL</source>
         <target state="translated">SSL</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f40d195970d52ea94bbf5b0aa1dbe9822f10dd5" resname="SUBDEFS" approved="yes">
         <source>SUBDEFS</source>
@@ -5951,15 +5951,15 @@
       <trans-unit id="efc007a393f66cdb14d57d385822a3d9e36ef873" resname="Save" approved="yes">
         <source>Save</source>
         <target state="translated">Save</target>
-        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
         <jms:reference-file line="41">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="108">actions/Feedback/list.html.twig</jms:reference-file>
+        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/worker-manager/worker_ftp.html.twig</jms:reference-file>
         <jms:reference-file line="75">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="3">admin/search-engine/elastic-search.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="960c9d85e9849fa58deb038c6c9bcf36ec973c99" resname="Save all changes" approved="yes">
         <source>Save all changes</source>
@@ -6015,8 +6015,8 @@
       <trans-unit id="ce3df4d818316dd10c7bca5ae8539c894dc07dbb" resname="See" approved="yes">
         <source>See</source>
         <target state="translated">See</target>
-        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="8">WorkZone/Browser/Browser.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a377f0dd2a261c8e46358dc8d0e8d9868bc6094f" resname="See documentation about structure manipulation." approved="yes">
         <source>See documentation about structure manipulation.</source>
@@ -6026,14 +6026,14 @@
       <trans-unit id="b5c208620e2d74920057e4d500f77788b86f41db" resname="See documentation at %url%" approved="yes">
         <source>See documentation at %url%</source>
         <target state="translated">See documentation at %url%</target>
-        <jms:reference-file line="38">Form/Configuration/WebservicesFormType.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b945126af2994e142e712b4e6f3c2cb2dd186a76" resname="See my order" approved="yes">
         <source>See my order</source>
         <target state="translated">See my orders</target>
-        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
         <jms:reference-file line="74">Notification/Mail/MailInfoOrderDelivered.php</jms:reference-file>
+        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="369b9cb821dd6966e989359a1b8aadaf9c4db387" resname="See others" approved="yes">
         <source>See others</source>
@@ -6063,10 +6063,10 @@
       <trans-unit id="913afff1faf79724f1f685fe8b1e36a729123ca2" resname="Select all" approved="yes">
         <source>Select all</source>
         <target state="translated">Select all</target>
-        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="57">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="224">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c83f0d10a0a04ab6ae1ceb098113b081e9bc4d5" resname="Select all collections" approved="yes">
         <source>Select all collections</source>
@@ -6100,10 +6100,10 @@
         <target state="translated">Send</target>
         <jms:reference-file line="101">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="46">web/login/forgot-password.html.twig</jms:reference-file>
-        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="113">prod/upload/upload.html.twig</jms:reference-file>
         <jms:reference-file line="110">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="185">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="220">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/admin/dashboard.html.twig</jms:reference-file>
@@ -6216,8 +6216,8 @@
       <trans-unit id="396c2137a0b503759e5d4930af8a16aa28ce3ee7" resname="Short description" approved="yes">
         <source>Short description</source>
         <target state="translated">Short description</target>
-        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="18">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="32e50dd99f3b67dc93272aa6c904b83d37f4f48d" resname="Shutter speed" approved="yes">
         <source>Shutter speed</source>
@@ -6248,7 +6248,7 @@
       <trans-unit id="234bf52eb70433473b325e23026794557cca00d9" resname="Single image" approved="yes">
         <source>Single image</source>
         <target state="translated">Single image</target>
-        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e78af337eef67e03f72ea26dbe1a69c326e3660" resname="Site web" approved="yes">
         <source>Site web</source>
@@ -6259,13 +6259,13 @@
         <source>Size</source>
         <target state="translated">Size</target>
         <jms:reference-file line="37">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
         <jms:reference-file line="116">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="000f280b111f7ab59b5f5f4462a40de0553664cc" resname="Slide show" approved="yes">
         <source>Slide show</source>
         <target state="translated">Slideshow</target>
-        <jms:reference-file line="54">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6412f8f76fca194e1e7e1c3b13556497ac125db" resname="Some files are being downloaded" approved="yes">
         <source>Some files are being downloaded</source>
@@ -6317,8 +6317,8 @@
       <trans-unit id="8657e88f4bf4b28dd29659361c70f11dea58efa5" resname="Sous-titre" approved="yes">
         <source>Sous-titre</source>
         <target state="translated">Subtitle</target>
-        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="16">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="970f057325af27424f32675051fea5366873b007" resname="Space bar" approved="yes">
         <source>Space bar</source>
@@ -6333,8 +6333,8 @@
       <trans-unit id="952f375412e89ff213a8aca383d18e5691354347" resname="Start" approved="yes">
         <source>Start</source>
         <target state="translated">Start</target>
-        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="15">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
@@ -6351,14 +6351,14 @@
       <trans-unit id="7ec5491e76522fe1687d799f35ab2ba39ae573fe" resname="Start validation" approved="yes">
         <source>Start validation</source>
         <target state="translated">Start feedback</target>
+        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
         <jms:reference-file line="47">Notification/Mail/MailInfoReminderFeedback.php</jms:reference-file>
         <jms:reference-file line="70">Notification/Mail/MailInfoValidationReminder.php</jms:reference-file>
-        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="faa9e7e7ef5a264c58c68a4a0b9c8bd54241450a" resname="Started" approved="yes">
         <source>Started</source>
         <target state="translated">Started</target>
-        <jms:reference-file line="42">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="46">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e1c8377cce4ac872e1c3e8fc6bc760c5130946d" resname="Status des documents a rechercher" approved="yes">
         <source>Status des documents a rechercher</source>
@@ -6385,20 +6385,20 @@
         <target state="translated">Stop</target>
         <jms:reference-file line="8">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/upload/lazaret.html.twig</jms:reference-file>
-        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="10">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="59">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51e9111b87116e60566740d13ba1c1eddb042333" resname="Stopped" approved="yes">
         <source>Stopped</source>
         <target state="translated">Stopped</target>
-        <jms:reference-file line="43">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="47">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67b5fefd39cf2223cfc9023e91571fd2a87cd76a" resname="Stories" approved="yes">
         <source>Stories</source>
         <target state="translated">Stories</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="315bc332aafca63cad8ac042c2e2f5111544fe9d" resname="Story Not Found" approved="yes">
@@ -6536,14 +6536,14 @@
       <trans-unit id="dd631af5459e2fae291effe51fbb608d13a75163" resname="Suppression de %n_element% playlists" approved="yes">
         <source>Suppression de %n_element% playlists</source>
         <target state="translated">Deleting %n_element% playlists</target>
-        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="299c2796a0d682b2495627623e9f228410b8a84a" resname="Suppression de %n_element% videos" approved="yes">
         <source>Suppression de %n_element% videos</source>
         <target state="translated">Deleting %n_element% videos</target>
-        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1acfc1c7d761310db2e5e876c0cade4d522cfed2" resname="Supprimer" approved="yes">
         <source>Supprimer</source>
@@ -6569,7 +6569,7 @@
       <trans-unit id="d91e1888f2dc09f11a876e25966a6fbd32b9cd87" resname="TLS" approved="yes">
         <source>TLS</source>
         <target state="translated">TLS</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a524057f93fd59da6998f240a0602fabc16dfb02" resname="Tableau de bord" approved="yes">
         <source>Tableau de bord</source>
@@ -6579,11 +6579,11 @@
       <trans-unit id="848eed0fbd5429f556b2982dec3ea87136e33e44" resname="Tags" approved="yes">
         <source>Tags</source>
         <target state="translated">Tags</target>
-        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="49">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e98caed82acc9fa2f1ba9edeab7789e75e49c36" resname="Target Device" approved="yes">
         <source>Target Device</source>
@@ -6605,12 +6605,12 @@
       <trans-unit id="c78d2fc3a6668b4edc8cf013ce4c6cf8c269b1bf" resname="Task name" approved="yes">
         <source>Task name</source>
         <target state="translated">Task name</target>
-        <jms:reference-file line="25">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="29">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b953a851b67dcb4e540270e49fe450d1d613eb1e" resname="Task period (in seconds)" approved="yes">
         <source>Task period (in seconds)</source>
         <target state="translated">Task period (in seconds)</target>
-        <jms:reference-file line="32">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="36">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cf459f472a871f1b053e16008a15cd566921aab0" resname="Technical Informations" approved="yes">
         <source>Technical Informations</source>
@@ -6631,7 +6631,7 @@
       <trans-unit id="97738411d629b01052974cc98ddb83a2cb4f8182" resname="Terms of Use" approved="yes">
         <source>Terms of Use</source>
         <target state="translated">Terms of use</target>
-        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="501">web/common/dialog_export.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a6a1d25b018c9318540556e3fe374fdf8b23aff8" resname="Terms of service" approved="yes">
@@ -6650,7 +6650,7 @@
       <trans-unit id="903b3a1a72b51b7b51f85ec8c81def53ed9c9b0c" resname="The Phraseanet Web API allows other web application to rely on this instance" approved="yes">
         <source>The Phraseanet Web API allows other web application to rely on this instance</source>
         <target state="translated">The Phraseanet Web API allows other web application to rely on this instance</target>
-        <jms:reference-file line="23">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2558cc2c887bbe4e2444ec6ef83b4982386e871a" resname="The URL you used is out of date, please login" approved="yes">
         <source>The URL you used is out of date, please login</source>
@@ -6764,7 +6764,7 @@
       <trans-unit id="d29ae57dd01be0f4c5b2e1993379c00443a9c937" resname="The task status" approved="yes">
         <source>The task status</source>
         <target state="translated">The task status</target>
-        <jms:reference-file line="40">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="44">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2e77a8fce4b585aac7e3e493f08aa4d8f56bc7e2" resname="The upgrade is already started" approved="yes">
         <source>The upgrade is already started</source>
@@ -6804,7 +6804,7 @@
       <trans-unit id="3fc5195b4a6ff8dc205dbbad17104fa93db88281" resname="Thesaurus Min score" approved="yes">
         <source>Thesaurus Min score</source>
         <target state="translated">Thesaurus Min score</target>
-        <jms:reference-file line="70">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="678">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="163fc70a23cf29331bab9896c9a8a0cb0b113bd6" resname="Thesaurus branch" approved="yes">
@@ -6872,7 +6872,7 @@
       <trans-unit id="58e76d1cc6a26f43783774d888c3a260970f637b" resname="This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases." approved="yes">
         <source>This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases.</source>
         <target state="translated">This option disables selecting of the databases on which a user can register. Registration is made on all granted databases.</target>
-        <jms:reference-file line="23">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="814c3298cccd06ad65ccac8a35e4f2104a4af17e" resname="This user does not participate to the validation but is only viewer." approved="yes">
         <source>This user does not participate to the validation but is only viewer.</source>
@@ -6913,19 +6913,19 @@
       <trans-unit id="eb97899aedcd5609782b5ccb4ffa390e0e66a3eb" resname="Titre" approved="yes">
         <source>Titre</source>
         <target state="translated">Title</target>
-        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="24">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="9">prod/Baskets/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="01594f4dad04782844c8175778fdf66deabf580d" resname="Toggle loop" approved="yes">
         <source>Toggle loop</source>
@@ -7029,8 +7029,8 @@
       <trans-unit id="c2739616a133e476dda18386df0d2487d526766a" resname="URL de callback" approved="yes">
         <source>URL de callback</source>
         <target state="translated">Callback url</target>
-        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="102">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="268f900effee1beb15231a1504d02543e8827bb3" resname="Un document commande" approved="yes">
         <source>Un document commande</source>
@@ -7197,15 +7197,15 @@
         <source>Upload</source>
         <target state="translated">Upload</target>
         <jms:reference-file line="94">web/common/menubar.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="16">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="83">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9ee782a49540357e87b6dc0dde09d8bec6507af" resname="Upload URL is not set, please contact an admin" approved="yes">
         <source>Upload URL is not set, please contact an admin</source>
@@ -7235,12 +7235,12 @@
       <trans-unit id="ea1fd4c4c366bf2e13d348b67b75e96039d7a1d7" resname="Use Google Chart API" approved="yes">
         <source>Use Google Chart API</source>
         <target state="translated">Use Google Chart API</target>
-        <jms:reference-file line="32">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2023f20c3153f9d593dfe4e5447b24866e27bd34" resname="Use a SMTP server" approved="yes">
         <source>Use a SMTP server</source>
         <target state="translated">Use a SMTP server</target>
-        <jms:reference-file line="28">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="32">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="337f9aa5d63611e88aedd8cc09ee1488fb9fe3a4" resname="Use an existing index" approved="yes">
         <source>Use an existing index</source>
@@ -7260,7 +7260,7 @@
       <trans-unit id="c42cc91c040b3c093f851494375a1be868018231" resname="Use recaptcha API" approved="yes">
         <source>Use recaptcha API</source>
         <target state="translated">Use reCAPTCHA API</target>
-        <jms:reference-file line="41">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17a74b77867e7b3f4f5e5b2ad90be36cf800dfda" resname="Use the Flash uploader" approved="yes">
         <source>Use the Flash uploader</source>
@@ -7277,22 +7277,22 @@
       <trans-unit id="1d2b0439bd02b54c622696c45588eab8d051dfb9" resname="Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token" approved="yes">
         <source>Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token</source>
         <target state="translated">Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token.</target>
-        <jms:reference-file line="31">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="73e8bd6eff9e8b1460684911486ad731e3097ab2" resname="Used for guest account" approved="yes">
         <source>Used for guest account</source>
         <target state="translated">Used for guest account.</target>
-        <jms:reference-file line="34">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84e635021b5a8691329da2b22cbdbb7137ddc018" resname="Used in search engine" approved="yes">
         <source>Used in search engine</source>
         <target state="translated">Used in search engine.</target>
-        <jms:reference-file line="23">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a54e4b6b720a84b428f0feda87f35d92cc219ee7" resname="Used when opening the application" approved="yes">
         <source>Used when opening the application</source>
         <target state="translated">Used when opening the application.</target>
-        <jms:reference-file line="30">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5bb94bfadf4a04bc6b31a3298c5f19a7dead6769" resname="User already exists" approved="yes">
         <source>User already exists</source>
@@ -7347,7 +7347,7 @@
       <trans-unit id="3482565eef4d4cd1decb5ebfad6ecfc5943d30da" resname="Users must accept Terms of Use for each export" approved="yes">
         <source>Users must accept Terms of Use for each export</source>
         <target state="translated">Terms of Use must be accepted by users for each export</target>
-        <jms:reference-file line="37">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28f4718f1cf2cd1f31d49c8bce276341ffe222bd" resname="Users suggestion" approved="yes">
         <source>Users suggestion</source>
@@ -7362,8 +7362,8 @@
       <trans-unit id="3b3e9155f69edf73caab337bf5f64231188b1e48" resname="VALIDATION" approved="yes">
         <source>VALIDATION</source>
         <target state="translated">Feedback</target>
-        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="6">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e400a7eef4ab49bbe657b3e3c557d64e091a356" resname="Validate e-mail address" approved="yes">
         <source>Validate e-mail address</source>
@@ -7373,9 +7373,9 @@
       <trans-unit id="dd74d182c641e4c78502d863b44d0aeff1575e54" resname="Validation" approved="yes">
         <source>Validation</source>
         <target state="translated">Feedback</target>
+        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validate.php</jms:reference-file>
         <jms:reference-file line="78">eventsmanager/notify/validate.php</jms:reference-file>
-        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="79">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="86">lightbox/IE6/validate.html.twig</jms:reference-file>
@@ -7393,9 +7393,9 @@
       <trans-unit id="6c259e54dcc7188e7cfe33403eca78cda53017fc" resname="Validations" approved="yes">
         <source>Validations</source>
         <target state="translated">Feedbacks</target>
+        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="119">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="165">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="51">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="100">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
@@ -7412,7 +7412,7 @@
       <trans-unit id="0cedbcdb95addc9f8d1b024fcbaf3d87dc6d044b" resname="Validity period of the download links" approved="yes">
         <source>Validity period of the download links</source>
         <target state="translated">Validity period of the download links</target>
-        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="74">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db671097785924a80ca79c2a37675116e90899e8" resname="Vers quel API voulez vous vous connecter ?" approved="yes">
         <source>Vers quel API voulez vous vous connecter ?</source>
@@ -7452,8 +7452,8 @@
       <trans-unit id="56b71e89fb1079caaadefd0889e9a22e8b0560e3" resname="Videos" approved="yes">
         <source>Videos</source>
         <target state="translated">Videos</target>
-        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="174">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="18af7efc4ef7f30783dbb1ad1bc0b9aed857a19c" resname="View on %title%" approved="yes">
         <source>View on %title%</source>
@@ -7605,10 +7605,10 @@
       <trans-unit id="12ee49ba726f4422d3dcc6bc7b92ab9de279d211" resname="Vous n'avez selectionne aucun element" approved="yes">
         <source>Vous n'avez selectionne aucun element</source>
         <target state="translated">No document selected</target>
+        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e8fd52d6c7e92e6907f1148d2e458871d17c1ae" resname="Vous ne pouvez pas editer plusieurs elements simultanement" approved="yes">
         <source>Vous ne pouvez pas editer plusieurs elements simultanement</source>
@@ -7654,8 +7654,8 @@
       <trans-unit id="94bfa418b59cf2b1d326f614666ece16ef9cbded" resname="Watch my access requests status" approved="yes">
         <source>Watch my access requests status</source>
         <target state="translated">View my access requests status.</target>
-        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
         <jms:reference-file line="39">Notification/Mail/MailSuccessEmailConfirmationUnregistered.php</jms:reference-file>
+        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d67f8b5513fcc1166cb7086a07bf29144de7c879" resname="Watermark" approved="yes">
         <source>Watermark</source>
@@ -7695,8 +7695,8 @@
       <trans-unit id="ceffd5b622d10de1a19822471cb3804cb61cba28" resname="Which playlist you want to put you %number% elements into ?" approved="yes">
         <source>Which playlist you want to put you %number% elements into ?</source>
         <target state="translated">Select a Playlist to add the %number% documents</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e2507e568a039431c507b30f44aa72cbb1ed929" resname="Whoops, looks like something went wrong." approved="yes">
         <source>Whoops, looks like something went wrong.</source>
@@ -7741,9 +7741,9 @@
       <trans-unit id="5397e0583f14f6c88de06b1ef28f460a1fb5b0ae" resname="Yes" approved="yes">
         <source>Yes</source>
         <target state="translated">Yes</target>
+        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="33">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="13">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4de66b40cf0800d4a25cc75b4f3f593cfc44ef6c" resname="You are Admin" approved="yes">
         <source>You are Admin</source>
@@ -8057,85 +8057,85 @@
       <trans-unit id="162536d0e4aeccdde8b707acd6111800a25d549b" resname="action : bridge" approved="yes">
         <source>action : bridge</source>
         <target state="translated">Bridge</target>
-        <jms:reference-file line="1038">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3ffc763c6cf92695a7ce387f904bbe6e7a94bdbc" resname="action : collection" approved="yes">
         <source>action : collection</source>
         <target state="translated">Move</target>
-        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="38">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddc3c6161fab39cbaf5d3f59af82090b32a2c36c" resname="action : editer" approved="yes">
         <source>action : editer</source>
         <target state="translated">Edit</target>
         <jms:reference-file line="10">prod/preview/caption.html.twig</jms:reference-file>
-        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="24">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b62efbefb9b0e40c14ac8218ac4257603c5b75c" resname="action : exporter" approved="yes">
         <source>action : exporter</source>
         <target state="translated">Export</target>
-        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="25">prod/preview/tools.html.twig</jms:reference-file>
-        <jms:reference-file line="1040">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="52">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="128">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="129">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="130">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0c9b7eb3d21f5a48ac5ecb0a0d969b8d3818e41" resname="action : outils" approved="yes">
         <source>action : outils</source>
         <target state="translated">Tools</target>
-        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="70">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="71e15cbcf85fd5fe848fe7fa210fa8318a09f842" resname="action : print" approved="yes">
         <source>action : print</source>
         <target state="translated">Print</target>
         <jms:reference-file line="20">prod/preview/tools.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="138">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="139">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="140">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d222a71a73f44cb6bdf237790f350f0b1fb9eb1f" resname="action : publier" approved="yes">
         <source>action : publier</source>
         <target state="translated">Publish</target>
-        <jms:reference-file line="1039">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="63">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17948b21adfde1bf589b2a34a2c8253e2af91913" resname="action : push" approved="yes">
         <source>action : push</source>
         <target state="translated">Push</target>
-        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="47">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f22184cfa5be236b7193d80d5f8407a36b108b79" resname="action : status" approved="yes">
         <source>action : status</source>
         <target state="translated">Properties</target>
-        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="24ade348bc49c69cced4d173e31f7369aa466772" resname="action : supprimer" approved="yes">
         <source>action : supprimer</source>
         <target state="translated">Delete</target>
-        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="221">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="222">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b88ca5fbb2e89cb79b08c981283383361be312bf" resname="action:: nouveau panier" approved="yes">
         <source>action:: nouveau panier</source>
@@ -8548,21 +8548,21 @@
       <trans-unit id="df2642eaa7386518762050a368f5d2c49a3fe42a" resname="admin::compte-utilisateur activite" approved="yes">
         <source>admin::compte-utilisateur activite</source>
         <target state="translated">Activity</target>
-        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="312">Controller/Admin/UserController.php</jms:reference-file>
-        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="122">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10b0a44531159b40162fd9349abbe2bd21946c3e" resname="admin::compte-utilisateur adresse" approved="yes">
         <source>admin::compte-utilisateur adresse</source>
         <target state="translated">Address</target>
-        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="304">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="363">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="87">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e922f2ca7321d1d1f403e937dbf109db04bac722" resname="admin::compte-utilisateur changer mon mot de passe" approved="yes">
         <source>admin::compte-utilisateur changer mon mot de passe</source>
@@ -8572,11 +8572,11 @@
       <trans-unit id="218d3257842bd2817f0ba7bcd02f3729c60e591d" resname="admin::compte-utilisateur code postal" approved="yes">
         <source>admin::compte-utilisateur code postal</source>
         <target state="translated">Zip code</target>
-        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="306">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="370">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="94">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc2f858e3323d3baa8be27661724b11ce9c0a57b" resname="admin::compte-utilisateur confirmer la nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur confirmer la nouvelle adresse email</source>
@@ -8596,23 +8596,23 @@
       <trans-unit id="d79bdc62fa5ecc611e96fe7ab9f5cf4d4debabae" resname="admin::compte-utilisateur email" approved="yes">
         <source>admin::compte-utilisateur email</source>
         <target state="translated">E-mail</target>
-        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="301">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="335">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="112">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="22">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="452">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d194728e348f759c2a443df96338ba1e2c8adfb5" resname="admin::compte-utilisateur fax" approved="yes">
         <source>admin::compte-utilisateur fax</source>
         <target state="translated">Fax</target>
-        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="309">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="384">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="136">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6e2b9ddcaf97ba5258571cb54935f1ff6b581a2" resname="admin::compte-utilisateur id utilisateur" approved="yes">
         <source>admin::compte-utilisateur id utilisateur</source>
@@ -8624,34 +8624,34 @@
         <target state="translated">Login</target>
         <jms:reference-file line="36">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="19">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
-        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="35">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="188">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f5fe48877b8b43297cc3c999ab84bbe0bd60f5af" resname="admin::compte-utilisateur mot de passe" approved="yes">
         <source>admin::compte-utilisateur mot de passe</source>
         <target state="translated">Password</target>
-        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="195">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e2d7957bf48ebf857d73e4395e78fa73e193b5d" resname="admin::compte-utilisateur nom" approved="yes">
         <source>admin::compte-utilisateur nom</source>
         <target state="translated">Last name</target>
-        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="299">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="321">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="13">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="444">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dbac236fd2ee8bcce590e0cdc7c4a418885c52b" resname="admin::compte-utilisateur nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur nouvelle adresse email</source>
@@ -8667,42 +8667,42 @@
       <trans-unit id="28c517ddecdb662c767290d2e1fa53ef198307fa" resname="admin::compte-utilisateur poste" approved="yes">
         <source>admin::compte-utilisateur poste</source>
         <target state="translated">Job</target>
-        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="310">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="356">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="108">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eadb6eaa53204a688e4059a35261b6878fda8b37" resname="admin::compte-utilisateur prenom" approved="yes">
         <source>admin::compte-utilisateur prenom</source>
         <target state="translated">First name</target>
-        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="300">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="328">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="67">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ee82fdcf687c10dd1e5040a5b84d9a90d079a9a" resname="admin::compte-utilisateur sexe" approved="yes">
         <source>admin::compte-utilisateur sexe</source>
         <target state="translated">Gender</target>
         <jms:reference-file line="44">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="78b65792aca82024d5f1ff60dec83a501c01e15e" resname="admin::compte-utilisateur societe" approved="yes">
         <source>admin::compte-utilisateur societe</source>
         <target state="translated">Company</target>
-        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="311">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="349">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="107">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="16">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="493">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d15ba95c86a58884d598415b8f8a400ab636cd9" resname="admin::compte-utilisateur tel" approved="yes">
         <source>admin::compte-utilisateur tel</source>
@@ -8714,10 +8714,10 @@
         <target state="translated">Phone</target>
         <jms:reference-file line="308">Controller/Admin/UserController.php</jms:reference-file>
         <jms:reference-file line="342">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="19">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="510">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="29d3952c833272679cb313988c698f11cb6bbb64" resname="admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer" approved="yes">
         <source>admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer</source>
@@ -8727,11 +8727,11 @@
       <trans-unit id="00a39eeb4e86af2189a6080e16418d249d98a12b" resname="admin::compte-utilisateur ville" approved="yes">
         <source>admin::compte-utilisateur ville</source>
         <target state="translated">City</target>
-        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="305">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="377">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="101">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f752312fcd370b6547b296ca173da51487a2c5d" resname="admin::compte-utilisateur: L'email a correctement ete mis a jour" approved="yes">
         <source>admin::compte-utilisateur: L'email a correctement ete mis a jour</source>
@@ -8820,24 +8820,24 @@
         <target state="translated">Mrs.</target>
         <jms:reference-file line="50">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="314">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="50">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7af00728508b30971b5cd3eb769433546ad9abfa" resname="admin::compte-utilisateur:sexe: mademoiselle" approved="yes">
         <source>admin::compte-utilisateur:sexe: mademoiselle</source>
         <target state="translated">Miss</target>
         <jms:reference-file line="49">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="313">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="47">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db663dadd7bd9b045a68cafcfe2ca4e0c832e50a" resname="admin::compte-utilisateur:sexe: monsieur" approved="yes">
         <source>admin::compte-utilisateur:sexe: monsieur</source>
         <target state="translated">Mr.</target>
         <jms:reference-file line="51">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="315">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="53">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cfc904c9a87afe2d3986041a6bdb542298607880" resname="admin::monitor: bases sur lesquelles l'utilisateur est connecte :" approved="yes">
         <source>admin::monitor: bases sur lesquelles l'utilisateur est connecte :</source>
@@ -8920,10 +8920,10 @@
       <trans-unit id="14e4b19f7496c10dbb05e61dee0c436c0792235f" resname="admin::monitor: module validation" approved="yes">
         <source>admin::monitor: module validation</source>
         <target state="translated">Lightbox</target>
+        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="207">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="238">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="315">Phrasea/Controller/LightboxController.php</jms:reference-file>
-        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="85">lib/classes/phrasea.php</jms:reference-file>
         <jms:reference-file line="78">web/common/menubar.html.twig</jms:reference-file>
       </trans-unit>
@@ -9614,6 +9614,17 @@
         <target state="translated">Test connection with Expose (not implemented)</target>
         <jms:reference-file line="69">admin/phraseanet-service/expose.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="6d3478b79db541608a0ba8e3877cba7c52256add" resname="admin:searchengine:aggregates:New field, please confirm setting.">
+        <source>admin:searchengine:aggregates:New field, please confirm setting.</source>
+        <target state="new">admin:searchengine:aggregates:New field, please confirm setting.</target>
+        <jms:reference-file line="146">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="157">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="b6dee9dc48adef7fe2f3a1e52b98e7a009fef83d" resname="admin:searchengine:aggregates:This field does not exists in current databoxes.">
+        <source>admin:searchengine:aggregates:This field does not exists in current databoxes.</source>
+        <target state="new">admin:searchengine:aggregates:This field does not exists in current databoxes.</target>
+        <jms:reference-file line="136">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8f3cd845b8adbcdf064486cdd24733f53bce8bb3" resname="admin:worker Retrieve configuration error" approved="yes">
         <source>admin:worker Retrieve configuration error</source>
         <target state="translated">Worker Retrieve configuration error</target>
@@ -9622,8 +9633,8 @@
       <trans-unit id="8f1dba76b561684930a25a984046b3b4149785ca" resname="alert" approved="yes">
         <source>alert</source>
         <target state="translated">Warning</target>
-        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="306">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="edde11c24ed5e6df4e416143e77248e908567faa" resname="all caches services have been flushed" approved="yes">
         <source>all caches services have been flushed</source>
@@ -9695,14 +9706,14 @@
       <trans-unit id="e2c1d05cc230f0bd66de9600c3304eaf374ffa24" resname="basket:action:delete record form basket" approved="yes">
         <source>basket:action:delete record form basket</source>
         <target state="translated">Delete record from basket</target>
-        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="378b261cf0bdda80ad072999d7bed4361180c838" resname="basket:action:delete record form database" approved="yes">
         <source>basket:action:delete record form database</source>
         <target state="translated">Delete record from database</target>
-        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="79">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c501b5741b2a182f189a0ee99109f2a55fd2aaa8" resname="basket:feedback Delete item" approved="yes">
         <source>basket:feedback Delete item</source>
@@ -9745,48 +9756,48 @@
         <jms:reference-file line="250">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="404">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="487">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
+        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
         <jms:reference-file line="119">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="69">web/thesaurus/import-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="228">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="653">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1054">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1173">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
-        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
-        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c6f716e883e5747e4bc8a8afc7a0ec1ccf44e0b5" resname="boutton::appliquer" approved="yes">
         <source>boutton::appliquer</source>
         <target state="translated">Apply</target>
-        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="40">WorkerManager/Form/WorkerConfigurationType.php</jms:reference-file>
+        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="43">WorkerManager/Form/WorkerPullAssetsType.php</jms:reference-file>
         <jms:reference-file line="77">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb7084f3be2ac7d8cf870a9bb83df976dc65ad5b" resname="boutton::chercher" approved="yes">
         <source>boutton::chercher</source>
         <target state="translated">Search</target>
-        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="126">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="61">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a71090794c12d5b26f62d9f0c68c0d894f7e00e" resname="boutton::choisir" approved="yes">
         <source>boutton::choisir</source>
@@ -9808,14 +9819,14 @@
       <trans-unit id="32e5c3419a0a410255ee44e462fd7329f708873f" resname="boutton::demarrer" approved="yes">
         <source>boutton::demarrer</source>
         <target state="translated">Slideshow</target>
-        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="9">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d49d2b52ce2f1912f7ada4a3f57ab39fd2e9904e" resname="boutton::editer" approved="yes">
         <source>boutton::editer</source>
         <target state="translated">Edit</target>
-        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="26">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6b126c214de4c40550d9dc32b02766809b1cac1a" resname="boutton::enregistrer" approved="yes">
         <source>boutton::enregistrer</source>
@@ -9843,16 +9854,16 @@
         <target state="translated">Close</target>
         <jms:reference-file line="59">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="90">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="23">web/lightbox/sc_note.html.twig</jms:reference-file>
-        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
+        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
         <jms:reference-file line="45">web/thesaurus/link-field-step3.html.twig</jms:reference-file>
         <jms:reference-file line="115">web/thesaurus/accept.html.twig</jms:reference-file>
         <jms:reference-file line="129">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce91bb36902944da7788997865b8c482a59e80fe" resname="boutton::generer" approved="yes">
         <source>boutton::generer</source>
@@ -9867,9 +9878,9 @@
       <trans-unit id="1e4c65d295605a0e884818b5c06d32a63fd692d5" resname="boutton::modifier" approved="yes">
         <source>boutton::modifier</source>
         <target state="translated">Modify</target>
-        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
-        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="1">Bridge/Dailymotion/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="65">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef6ccc2669466ac98a3d580bd7bab8f33d0e4bcc" resname="boutton::monter" approved="yes">
@@ -9880,22 +9891,22 @@
       <trans-unit id="a6083d9bc73ab5df12f4949b67577186f6e8c240" resname="boutton::pause" approved="yes">
         <source>boutton::pause</source>
         <target state="translated">Pause</target>
-        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="28bb622fa0fe835d89deb626494ce572cbd27072" resname="boutton::precedent" approved="yes">
         <source>boutton::precedent</source>
         <target state="translated">Previous</target>
+        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="426">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="516">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="629">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="696">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="754">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="866">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ac4cff651bd34d7b0f295259a0c0907d6af5cd1" resname="boutton::rechercher" approved="yes">
         <source>boutton::rechercher</source>
@@ -9926,26 +9937,26 @@
       <trans-unit id="e0af1d0d7872c48928d4faef76c45567426e62f9" resname="boutton::retour" approved="yes">
         <source>boutton::retour</source>
         <target state="translated">Back</target>
-        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="28">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="20">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
+        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
+        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="223">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
         <jms:reference-file line="50">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
         <jms:reference-file line="162">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
+        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a7a9651d909792bcf98f2d1e96c43cb1d3a618e4" resname="boutton::retry" approved="yes">
         <source>boutton::retry</source>
@@ -9955,55 +9966,55 @@
       <trans-unit id="bd9ec3151bdf1eae02e402222d4e36949525a27f" resname="boutton::suivant" approved="yes">
         <source>boutton::suivant</source>
         <target state="translated">Next</target>
+        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="365">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="429">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="519">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="632">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="699">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="757">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a83f74309cdfc79345f54eb1f4e4e2747316f820" resname="boutton::supprimer" approved="yes">
         <source>boutton::supprimer</source>
         <target state="translated">Delete</target>
         <jms:reference-file line="43">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
-        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
-        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="35">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
+        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="93">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="136">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="151">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="176">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="201">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="410">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="68b702f13ff62025c57948bf5c4a5b47af10dee9" resname="boutton::telecharger" approved="yes">
         <source>boutton::telecharger</source>
         <target state="translated">Download</target>
         <jms:reference-file line="160">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="21">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4288c5788ee74d7fa3f325987a8e752687b43023" resname="boutton::telecharger tous les documents" approved="yes">
         <source>boutton::telecharger tous les documents</source>
         <target state="translated">Download all</target>
-        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="99">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a14c32cf4cd3784ed567e115f3ef016ad2ee2265" resname="boutton::tester" approved="yes">
         <source>boutton::tester</source>
@@ -10015,57 +10026,57 @@
         <source>boutton::valider</source>
         <target state="translated">Validate</target>
         <jms:reference-file line="49">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="886">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="70">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="19">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
         <jms:reference-file line="351">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="373">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Update.html.twig</jms:reference-file>
+        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
         <jms:reference-file line="130">admin/collection/suggested_value.html.twig</jms:reference-file>
-        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="46">admin/collection/create.html.twig</jms:reference-file>
         <jms:reference-file line="58">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
-        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
-        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="41">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
         <jms:reference-file line="159">admin/statusbit/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
+        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
+        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
+        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="34">mobile/lightbox/note_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b27b98c3e0119082312d402ca0b89dd39f00f5c8" resname="boutton::vue graphique" approved="yes">
@@ -10260,8 +10271,8 @@
       <trans-unit id="dbfe8cf37a8d7b4941dd9f89e79302038b2bedef" resname="dans %feed_name%" approved="yes">
         <source>dans %feed_name%</source>
         <target state="translated">in %feed_name%</target>
-        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="52">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aab7fdd9c18941cbc8d78fa0c690361ffd8c50bf" resname="date dajout" approved="yes">
         <source>date dajout</source>
@@ -10310,10 +10321,10 @@
       <trans-unit id="9ead47a82a0d25985f22f10651d1f93b3abba317" resname="edit" approved="yes">
         <source>edit</source>
         <target state="translated">edit</target>
-        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="32">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="143">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="164">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd35f7126454c3af225a579bd27f89176be81c3d" resname="edit: chosiir limage du regroupement" approved="yes">
         <source>edit: chosiir limage du regroupement</source>
@@ -10637,12 +10648,12 @@
       <trans-unit id="0d25ab4ea387d19f49a120acb928c7f9500b0cf3" resname="index::advance_search: disable-facet" approved="yes">
         <source>index::advance_search: disable-facet</source>
         <target state="translated">Hide facets with 1 result (experimental)</target>
-        <jms:reference-file line="911">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="16b1c68bd21754876991dfc8df38b024383fbca4" resname="index::advance_search: facet" approved="yes">
         <source>index::advance_search: facet</source>
         <target state="translated">Facets Preferences</target>
-        <jms:reference-file line="907">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="909">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f830d57f4cedb2a49c7b109f9b91b0f8ba83e8b" resname="index::advance_search: facet-order" approved="yes">
         <source>index::advance_search: facet-order</source>
@@ -10662,7 +10673,7 @@
       <trans-unit id="dfb02fcdeb804315cd6ad8388efcfb4ccc4abf38" resname="index::advance_search: hidden-facet-values-order" approved="yes">
         <source>index::advance_search: hidden-facet-values-order</source>
         <target state="translated">Hidden Facets</target>
-        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="921">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a35cc75d1072f7dad99c8e91596298f55f20a54" resname="index::advance_search: order-by-hits" approved="yes">
         <source>index::advance_search: order-by-hits</source>
@@ -10673,6 +10684,11 @@
         <source>index::advance_search: order-by-hits-asc</source>
         <target state="translated">By Hits asc</target>
         <jms:reference-file line="256">web/prod/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ea214aed2c346724c9b874431706654f560585b6" resname="index::advance_search: show-unset-field-facet">
+        <source>index::advance_search: show-unset-field-facet</source>
+        <target state="new">index::advance_search: show-unset-field-facet</target>
+        <jms:reference-file line="918">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1039a002699408da4c4fe74638a6b44f60499069" resname="index:advanced-preferences:: use truncation" approved="yes">
         <source>index:advanced-preferences:: use truncation</source>
@@ -10727,9 +10743,9 @@
       <trans-unit id="49956c0a16703da1e642ef7ea5f5d56ddb026c9b" resname="lightbox::recaptitulatif" approved="yes">
         <source>lightbox::recaptitulatif</source>
         <target state="translated">Summary</target>
-        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
         <jms:reference-file line="96">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="95">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e96c3b316d4e505d764d209e1074dcd059e396c3" resname="lightbox::see_less_basket" approved="yes">
@@ -10841,8 +10857,8 @@
       <trans-unit id="46f7a3bb71222626147c7e64c6a59a3f4c3d8e42" resname="login::notification: Mise a jour du mot de passe avec succes" approved="yes">
         <source>login::notification: Mise a jour du mot de passe avec succes</source>
         <target state="translated">Password update done</target>
-        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
         <jms:reference-file line="67">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28dd2416483329c548279196d0c60f722578632f" resname="login::notification: demande de confirmation par mail envoyee" approved="yes">
         <source>login::notification: demande de confirmation par mail envoyee</source>
@@ -10932,15 +10948,15 @@
         <source>no</source>
         <target state="translated">No</target>
         <jms:reference-file line="91">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="14">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6c632badea2664bc707979fac5e58072b6a2feba" resname="no image selected" approved="yes">
         <source>no image selected</source>
         <target state="translated">No Document selected</target>
-        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="307">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37031f99ac78580c9f82e04fa237d295ea10ca41" resname="non" approved="yes">
         <source>non</source>
@@ -10951,10 +10967,10 @@
       <trans-unit id="a81b09d9521597ebcaf0cc8b49ad7a8be8e4cc61" resname="notice" approved="yes">
         <source>notice</source>
         <target state="translated">Caption</target>
-        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="77">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cafe5f11d6a3b26e59f28454d0ad90a951c64a6a" resname="nouveau" approved="yes">
         <source>nouveau</source>
@@ -11225,7 +11241,7 @@
       <trans-unit id="0259e4e17a1f2697d4f4f0108080276a5d7573de" resname="original logo" approved="yes">
         <source>original logo</source>
         <target state="translated">Original logo</target>
-        <jms:reference-file line="23">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5898fc860300e228dcd54c0b1045b5fa0dcda502" resname="oui" approved="yes">
         <source>oui</source>
@@ -11302,8 +11318,8 @@
       <trans-unit id="9069777ad6c5ece82d14a23d39082acba0873d60" resname="paniers::description du nouveau panier" approved="yes">
         <source>paniers::description du nouveau panier</source>
         <target state="translated">Caption</target>
-        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="647fb4052fcefc4f2cbbe79aa1a04e8acbd37f59" resname="par %user_name%" approved="yes">
         <source>par %user_name%</source>
@@ -11323,7 +11339,7 @@
       <trans-unit id="ead5a6379197deb9163d2101354822e6caaa30eb" resname="personalize logo" approved="yes">
         <source>personalize logo</source>
         <target state="translated">Customize logo</target>
-        <jms:reference-file line="24">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f16110620b1971f58336063cbdb64df7e0e0c7ac" resname="pertinence" approved="yes">
         <source>pertinence</source>
@@ -11333,7 +11349,7 @@
       <trans-unit id="da819bd8e531681e8cc8b0c5f30da694b7ffe03c" resname="php.ini path" approved="yes">
         <source>php.ini path</source>
         <target state="translated">php.ini filepath</target>
-        <jms:reference-file line="44">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4827b7c0fd9fb14fc29a808b020353c744b83978" resname="phraseanet:: Creer une base sur un serveur different de l'application box" approved="yes">
         <source>phraseanet:: Creer une base sur un serveur different de l'application box</source>
@@ -11374,11 +11390,11 @@
       <trans-unit id="8039b17c124d6907eb83dc8b705888769f45d82d" resname="phraseanet:: adresse" approved="yes">
         <source>phraseanet:: adresse</source>
         <target state="translated">Address</target>
-        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="31">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="89">web/admin/connected-users.html.twig</jms:reference-file>
-        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a934108e5aa19f91fafd6eb9ee20b00bc248bab9" resname="phraseanet:: aide" approved="yes">
         <source>phraseanet:: aide</source>
@@ -11467,8 +11483,8 @@
       <trans-unit id="da1f4cb9f98aef274dbb8f5992dedaf20e91ea71" resname="phraseanet:: preview" approved="yes">
         <source>phraseanet:: preview</source>
         <target state="translated">Preview</target>
-        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
         <jms:reference-file line="267">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2baca947f8536e2ff6bab1c45c1876c04706a6a0" resname="phraseanet:: propositions" approved="yes">
         <source>phraseanet:: propositions</source>
@@ -11485,19 +11501,19 @@
       <trans-unit id="99a70ecaddc20d59056e5d479c6fa9d0bc113a0e" resname="phraseanet:: sous definition" approved="yes">
         <source>phraseanet:: sous definition</source>
         <target state="translated">Subview</target>
-        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="93">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c33ce7e20779d5b34c1c812406e2f22b779a45d0" resname="phraseanet:: thesaurus" approved="yes">
         <source>phraseanet:: thesaurus</source>
         <target state="translated">Thesaurus</target>
-        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/index.html.twig</jms:reference-file>
         <jms:reference-file line="11">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
-        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b6022bf4291f5e9d7d7051fe6c3d6a6abbd92c1a" resname="phraseanet:: tri" approved="yes">
         <source>phraseanet:: tri</source>
@@ -11507,10 +11523,10 @@
       <trans-unit id="771634fc3ec89c0a08c7666e776fc5db3072f318" resname="phraseanet:: tri par date" approved="yes">
         <source>phraseanet:: tri par date</source>
         <target state="translated">Sort by date</target>
-        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="318">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="320">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="321">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db34986ff3eb1fd0e90f897a97eaf52ea6708600" resname="phraseanet:: tri par nom" approved="yes">
         <source>phraseanet:: tri par nom</source>
@@ -11584,9 +11600,9 @@
         <source>phraseanet::chargement</source>
         <target state="translated">Loading</target>
         <jms:reference-file line="48">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="278">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="34">admin/collection/suggested_value.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="70c4053d038cd11fa8fcb91bf79e580b89fad194" resname="phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible" approved="yes">
         <source>phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible</source>
@@ -11604,8 +11620,8 @@
         <source>phraseanet::erreur: Votre session est fermee, veuillez vous re-authentifier</source>
         <target state="translated">Your session is closed, please re-authentificate</target>
         <jms:reference-file line="38">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="754677fa0aa06c7f10237a728e6f33eaea06d42b" resname="phraseanet::erreur: echec du serveur de mail" approved="yes">
         <source>phraseanet::erreur: echec du serveur de mail</source>
@@ -11753,35 +11769,35 @@
       <trans-unit id="fdb5ea435d0e0d2d8e9dc7e2dc925c031406385c" resname="preview:: Description" approved="yes">
         <source>preview:: Description</source>
         <target state="translated">Caption</target>
-        <jms:reference-file line="954">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="963">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="424597224c5d2322b6e8db99037234f7b2641de0" resname="preview:: Historique" approved="yes">
         <source>preview:: Historique</source>
         <target state="translated">Timeline</target>
-        <jms:reference-file line="955">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="964">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="74e09022ffbf0d295142654902e9d7a007f209a5" resname="preview:: Popularite" approved="yes">
         <source>preview:: Popularite</source>
         <target state="translated">Statistics</target>
-        <jms:reference-file line="958">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="967">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9c61385964471a1171066ba2ba3622a98ffb84b" resname="preview:: arreter le diaporama" approved="yes">
         <source>preview:: arreter le diaporama</source>
         <target state="translated">Stop</target>
-        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="96">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="62">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77a36033b8fdccc947d744ae8e3120c7d8dafa46" resname="preview:: demarrer le diaporama" approved="yes">
         <source>preview:: demarrer le diaporama</source>
         <target state="translated">Slideshow</target>
-        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="94">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="60">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a5cc2b2cd9b0421d131185277e9005d8e616582c" resname="preview::date" approved="yes">
         <source>preview::date</source>
@@ -11810,7 +11826,7 @@
       <trans-unit id="2b03b2c44ce1a3c17af6b603d666344f64ebe942" resname="preview::tab:feedback" approved="yes">
         <source>preview::tab:feedback</source>
         <target state="translated">Feedback</target>
-        <jms:reference-file line="956">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="965">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7f27fe47e2d3556c660a6fade6ceba7e8e62c4c" resname="preview::tab:feedback closed" approved="yes">
         <source>preview::tab:feedback closed</source>
@@ -11978,20 +11994,20 @@
       <trans-unit id="98ab0e2a8cf4a7c9f6952361e6c750a8009b70a5" resname="prive" approved="yes">
         <source>prive</source>
         <target state="translated">Private</target>
-        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="79">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="039db3240f9c47314f5b8f05835c54795f45324e" resname="privé" approved="yes">
         <source>privé</source>
         <target state="translated">Private</target>
-        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="60">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6dd8429cc900b9460f1e9d4be6155a6ee1b6de42" resname="processing" approved="yes">
         <source>processing</source>
         <target state="translated">Processing...</target>
-        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="308">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f63658cad863dee4a5876278e836472380183ade" resname="prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble" approved="yes">
         <source>prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble</source>
@@ -12007,7 +12023,7 @@
       <trans-unit id="f8877a3e5fa41e324ef59243c175353144990647" resname="prod::action:property title" approved="yes">
         <source>prod::action:property title</source>
         <target state="translated">Properties</target>
-        <jms:reference-file line="1044">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1053">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef27ad74061e0e15683e84dec7f5559f7797637f" resname="prod::advancesearch:tooltips:datefield_restriction_explanation" approved="yes">
         <source>prod::advancesearch:tooltips:datefield_restriction_explanation</source>
@@ -12175,8 +12191,8 @@ Warning: The current values will be overwritten by these new values</target>
       <trans-unit id="021da4e7ad79ba6ef0855ecca3539db02b2d12f9" resname="prod::export: send mail notification" approved="yes">
         <source>prod::export: send mail notification</source>
         <target state="translated">Email sending request submitted</target>
+        <jms:reference-file line="1059">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="18">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="1050">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb08c63b1c016e31a255a38795c8e4cb66b0e66e" resname="prod::facet:base_label" approved="yes">
         <source>prod::facet:base_label</source>
@@ -12201,7 +12217,7 @@ Warning: The current values will be overwritten by these new values</target>
       <trans-unit id="47f76b5a8ec06b165c0d83ed447999def6f368e4" resname="prod::notification: notification title" approved="yes">
         <source>prod::notification: notification title</source>
         <target state="translated">Notifications</target>
-        <jms:reference-file line="1046">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1055">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd532704ccd19891fe39fc3e14235cbfa6b79abf" resname="prod::publication:title" approved="yes">
         <source>prod::publication:title</source>
@@ -12211,17 +12227,17 @@ Warning: The current values will be overwritten by these new values</target>
       <trans-unit id="5fa97d7a05eb572c80ae0ccf85be3a27dcddb943" resname="prod::push: List name can not be empty" approved="yes">
         <source>prod::push: List name can not be empty</source>
         <target state="translated">List name is mandatory</target>
-        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1057">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2682250f21be2e6ce7e89ab678c50a394191206a" resname="prod::push: New list title" approved="yes">
         <source>prod::push: New list title</source>
         <target state="translated">New list</target>
-        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1056">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="19aeacc47cb48d5ae39c216aa0d456ac0f2ea55d" resname="prod::push: add" approved="yes">
         <source>prod::push: add</source>
         <target state="translated">Add</target>
-        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1058">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dee7c522bf9e0eea45e003fb4d0f736bc251a954" resname="prod::push:push_set_title" approved="yes">
         <source>prod::push:push_set_title</source>
@@ -12366,19 +12382,19 @@ Warning: The current values will be overwritten by these new values</target>
       <trans-unit id="6ad73c8fd370f62ccd3bf50cd9cc3563aed5273c" resname="prod::tools: document" approved="yes">
         <source>prod::tools: document</source>
         <target state="translated">Document</target>
-        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
         <jms:reference-file line="74">Controller/Prod/ToolsController.php</jms:reference-file>
+        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e36d93428a247d085ffbb974db21290395643463" resname="prod::videoTools:chapterTitle" approved="yes">
         <source>prod::videoTools:chapterTitle</source>
         <target state="translated">Chapter title</target>
-        <jms:reference-file line="1042">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1051">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4dc1d766c992fbd57317a321602272b20469a64" resname="prod::workzone:Actions" approved="yes">
         <source>prod::workzone:Actions</source>
         <target state="translated">Actions</target>
-        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6140f86d00814c5627728413d43421ce867c11db" resname="prod::workzone:feedback add user" approved="yes">
         <source>prod::workzone:feedback add user</source>
@@ -12594,8 +12610,8 @@ Warning: The current values will be overwritten by these new values</target>
       <trans-unit id="a2a8888f67982de346cedbe03b5884757de77925" resname="prod:expose:publication:Parent Publication" approved="yes">
         <source>prod:expose:publication:Parent Publication</source>
         <target state="translated">Parent Publication</target>
-        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/ExposeNew.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="41">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d190364e0bc239d60124d5a906249199fcedbcf7" resname="prod:expose:publication:Password" approved="yes">
@@ -12932,13 +12948,18 @@ It is possible to place several search areas</target>
         <target state="translated">Remove filter</target>
         <jms:reference-file line="218">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="9fb38743f0e67ac389f4d31a55eff4ec5acac703" resname="prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)">
+        <source>prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</source>
+        <target state="new">prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</target>
+        <jms:reference-file line="59">Elastic/Search/FacetsResponse.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="61c9b2b17db77a27841bbeeabff923448b0f6388" resname="public" approved="yes">
         <source>public</source>
         <target state="translated">Public</target>
-        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="64">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9647ab4603346566d2218fda731606baafcbe408" resname="publication : autheur" approved="yes">
         <source>publication : autheur</source>
@@ -13046,11 +13067,11 @@ It is possible to place several search areas</target>
       <trans-unit id="1d740fd7fe206b5e6e57bef828e876a1bc484dd5" resname="rafraichir" approved="yes">
         <source>rafraichir</source>
         <target state="translated">Refresh</target>
+        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/results/feeds.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/results/feeds.html.twig</jms:reference-file>
-        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
-        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0dea865dcd106d77e52ea8bffe6f87e2add0ac53" resname="recordtype" approved="yes">
         <source>recordtype</source>
@@ -13239,8 +13260,8 @@ It is possible to place several search areas</target>
         <source>report:: Connexion</source>
         <target state="translated">Connections</target>
         <jms:reference-file line="666">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="afa9685c95f7dff29cb2ad048da368c6e3dbadbc" resname="report:: Databox content" approved="yes">
         <source>report:: Databox content</source>
@@ -13315,14 +13336,14 @@ It is possible to place several search areas</target>
       <trans-unit id="48808e405192603e079ef1ccbbc1a1df98e317bd" resname="report:: collections" approved="yes">
         <source>report:: collections</source>
         <target state="translated">Collections</target>
-        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="96">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a1193a920be0725a4560344ca10db36147ffd34" resname="report:: commentaire" approved="yes">
         <source>report:: commentaire</source>
         <target state="translated">Comments</target>
-        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="99">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="51f822380b654c4fc5adb28eb0643f37aac0d89b" resname="report:: copyright" approved="yes">
         <source>report:: copyright</source>
@@ -13332,9 +13353,9 @@ It is possible to place several search areas</target>
       <trans-unit id="cf3a5321aa85f0706b89021206bd8cd1ad57da54" resname="report:: date" approved="yes">
         <source>report:: date</source>
         <target state="translated">Date</target>
+        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="669">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="670">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e125eaf6fca2110f86b6ebba60371a4875c87e03" resname="report:: document ajoute" approved="yes">
         <source>report:: document ajoute</source>
@@ -13385,21 +13406,21 @@ It is possible to place several search areas</target>
       <trans-unit id="26d00286d5aecf7cfda0e1395c4208440409b8c0" resname="report:: non-renseigne" approved="yes">
         <source>report:: non-renseigne</source>
         <target state="translated">Not filled</target>
-        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
-        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
+        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
+        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
         <jms:reference-file line="117">module/report/validate.php</jms:reference-file>
+        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
+        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="411">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="508">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="520">module/report/activity.php</jms:reference-file>
-        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
         <jms:reference-file line="117">module/report/sent.php</jms:reference-file>
-        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
         <jms:reference-file line="161">module/report/download.php</jms:reference-file>
-        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
-        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
         <jms:reference-file line="110">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="118">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="123">module/report/connexion.php</jms:reference-file>
+        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="07c06c0cac8bd3e3507a72d6cb7fa1ee23a6bf13" resname="report:: page d'accueil" approved="yes">
         <source>report:: page d'accueil</source>
@@ -13431,9 +13452,9 @@ It is possible to place several search areas</target>
       <trans-unit id="8df95f5dffb705018ebae64a4850f1f93bafc098" resname="report:: question" approved="yes">
         <source>report:: question</source>
         <target state="translated">Query</target>
-        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="43">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b9ef4ecd16724b3218cf46f9956b8b157498c3a1" resname="report:: questions" approved="yes">
         <source>report:: questions</source>
@@ -13453,8 +13474,8 @@ It is possible to place several search areas</target>
       <trans-unit id="8fb18670b89f5cefede425401428a70189f654ea" resname="report:: record id" approved="yes">
         <source>report:: record id</source>
         <target state="translated">recordId</target>
-        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="90">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a11e1e1373aae28668cdf7a08486e767283bbaa2" resname="report:: resolution" approved="yes">
         <source>report:: resolution</source>
@@ -13734,7 +13755,7 @@ It is possible to place several search areas</target>
       <trans-unit id="44a5de1cdcf30547c937f197cd3d58e143de62a6" resname="setup::custom-link:help-menu" approved="yes">
         <source>setup::custom-link:help-menu</source>
         <target state="translated">Help Menu</target>
-        <jms:reference-file line="58">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0286ea45f1074802cfe8fbf84b7c439fb287d0de" resname="setup::custom-link:language-link" approved="yes">
         <source>setup::custom-link:language-link</source>
@@ -13749,7 +13770,7 @@ It is possible to place several search areas</target>
       <trans-unit id="2de3bc78c6fb26b56dd934a81dc76afdba8c79ab" resname="setup::custom-link:location" approved="yes">
         <source>setup::custom-link:location</source>
         <target state="translated">Select a position</target>
-        <jms:reference-file line="57">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4db79dfecabb4b9acb44a4b49e9b6b433b28d04" resname="setup::custom-link:location-link" approved="yes">
         <source>setup::custom-link:location-link</source>
@@ -13759,13 +13780,13 @@ It is possible to place several search areas</target>
       <trans-unit id="ccfe45428ee9769a865d3d90c0e4dc50a6b68e9c" resname="setup::custom-link:name-link" approved="yes">
         <source>setup::custom-link:name-link</source>
         <target state="translated">Name of link</target>
-        <jms:reference-file line="23">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="97">web/admin/setup.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fdecb6454c7adeaeb05bac7f574ee70884900ca2" resname="setup::custom-link:navigation-bar" approved="yes">
         <source>setup::custom-link:navigation-bar</source>
         <target state="translated">Navigation Bar</target>
-        <jms:reference-file line="59">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4696021003b181f9acc9261382e07364c6b83036" resname="setup::custom-link:order-link" approved="yes">
         <source>setup::custom-link:order-link</source>
@@ -13775,12 +13796,12 @@ It is possible to place several search areas</target>
       <trans-unit id="1b09a3a0a8b0205f23b3fe59074f8dfd72d0b0ae" resname="setup::custom-link:placeholder-link-url" approved="yes">
         <source>setup::custom-link:placeholder-link-url</source>
         <target state="translated">eg: https://docs.phraseanet.com</target>
-        <jms:reference-file line="47">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="52">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a1380c70f5190d6c0c38214fe24ac99272ef7bd2" resname="setup::custom-link:select-language" approved="yes">
         <source>setup::custom-link:select-language</source>
         <target state="translated">Select Language</target>
-        <jms:reference-file line="34">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67572283912404fe90681e8566d880e1fd10d58e" resname="setup::custom-link:title-custom-link" approved="yes">
         <source>setup::custom-link:title-custom-link</source>
@@ -13820,8 +13841,8 @@ It is possible to place several search areas</target>
       <trans-unit id="9fef1c0f1a70c8bc024e6691f1584083c27d2b13" resname="status:: numero de bit" approved="yes">
         <source>status:: numero de bit</source>
         <target state="translated">Status N°</target>
-        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="802c606a20e093fac7d2b5a45d947a4dff96e628" resname="status:: retrouver sous forme de filtre dans la recherche" approved="yes">
         <source>status:: retrouver sous forme de filtre dans la recherche</source>
@@ -13986,8 +14007,8 @@ It is possible to place several search areas</target>
       <trans-unit id="c8eadb101df19fb4960c791cf1afaa49d3516feb" resname="task::ftp:proxy" approved="yes">
         <source>task::ftp:proxy</source>
         <target state="translated">Proxy</target>
-        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="5">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d50701eb37a2e5b7dfe3358ba91ff9a1cc6f10ef" resname="task::ftp:proxy password" approved="yes">
         <source>task::ftp:proxy password</source>
@@ -13997,8 +14018,8 @@ It is possible to place several search areas</target>
       <trans-unit id="a7e5c84ff2404f76423afe64d0f5b8fbea07c024" resname="task::ftp:proxy port" approved="yes">
         <source>task::ftp:proxy port</source>
         <target state="translated">Port</target>
-        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="11">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d927a070b462263321072111c64cc0505c9d14" resname="task::ftp:proxy user" approved="yes">
         <source>task::ftp:proxy user</source>
@@ -14100,8 +14121,8 @@ It is possible to place several search areas</target>
       <trans-unit id="416134a1966f12f8d23f9f54f3cc32ea43ef3e46" resname="thesaurus:: Lier la branche de thesaurus au champ" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ</source>
         <target state="translated">Link thesaurus branch to field</target>
-        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="213a599ea75e45b7e28a260a71b032b3e3601e2b" resname="thesaurus:: Lier la branche de thesaurus au champ %branch%" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ %branch%</source>
@@ -14111,9 +14132,9 @@ It is possible to place several search areas</target>
       <trans-unit id="227338ab622537da92490cedc6709de0b9122e56" resname="thesaurus:: Nouveau synonyme" approved="yes">
         <source>thesaurus:: Nouveau synonyme</source>
         <target state="translated">New Synonym</target>
+        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
         <jms:reference-file line="1050">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6bec8860c3453260869cea4fb043fac543cf724" resname="thesaurus:: Nouveau terme" approved="yes">
         <source>thesaurus:: Nouveau terme</source>
@@ -14123,8 +14144,8 @@ It is possible to place several search areas</target>
       <trans-unit id="ef0a054e6da228e6ad009d469c4bdf31b1de7999" resname="thesaurus:: Nouveau terme specifique" approved="yes">
         <source>thesaurus:: Nouveau terme specifique</source>
         <target state="translated">New specific term</target>
-        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="261cd0e03ca27d32466be99d5cd9a0426d3a508c" resname="thesaurus:: Proprietes" approved="yes">
         <source>thesaurus:: Proprietes</source>
@@ -14146,8 +14167,8 @@ It is possible to place several search areas</target>
       <trans-unit id="f56e32a67c0a47d74d3441e499bfe64858ffee36" resname="thesaurus:: accepter..." approved="yes">
         <source>thesaurus:: accepter...</source>
         <target state="translated">Accept</target>
-        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="10">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c56e1002fd59b3fed0108426b7926f3252d9fc8d" resname="thesaurus:: afficher les termes refuses" approved="yes">
         <source>thesaurus:: afficher les termes refuses</source>
@@ -14262,15 +14283,15 @@ It is possible to place several search areas</target>
         <target state="translated">Text</target>
         <jms:reference-file line="5">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="85">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-text.html.twig</jms:reference-file>
+        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8ec3584a75e01816472150b1c24268c9612dd51" resname="thesaurus:: export en topics" approved="yes">
         <source>thesaurus:: export en topics</source>
         <target state="translated">Topics</target>
+        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="1233">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-topics.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a09dafb2a5c9c7200a3125cca1148346e7bc1843" resname="thesaurus:: exporter" approved="yes">
         <source>thesaurus:: exporter</source>
@@ -14665,8 +14686,8 @@ It is possible to place several search areas</target>
       <trans-unit id="1118f7e206d8ec4d92392f3e8c2804b156b3a082" resname="thumbnail validation" approved="yes">
         <source>thumbnail validation</source>
         <target state="translated">Confirm thumbnail</target>
-        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="309">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e96ed809b61066d6ea96ba9afc8747a042b361a" resname="tout le monde" approved="yes">
         <source>tout le monde</source>
@@ -14713,8 +14734,8 @@ It is possible to place several search areas</target>
         <source>upload:: Status :</source>
         <target state="translated">Apply status</target>
         <jms:reference-file line="80">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
         <jms:reference-file line="462">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4fea0574cc81b5fd40ab0537b0905cc4c3806039" resname="users rights have been reseted" approved="yes">
         <source>users rights have been reseted</source>
@@ -14724,11 +14745,11 @@ It is possible to place several search areas</target>
       <trans-unit id="e204d28a2874f6123747650d3e4003d4357d75eb" resname="validate" approved="yes">
         <source>validate</source>
         <target state="translated">Validate</target>
+        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="120">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="160">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="186">actions/Tools/index.html.twig</jms:reference-file>
-        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c02a2db6d6cdf30d37962e221624cc7661f4b892" resname="validation:: NON" approved="yes">
         <source>validation:: NON</source>
@@ -14794,128 +14815,128 @@ It is possible to place several search areas</target>
       <trans-unit id="ecbe1590a62c751a6bafe631fc5d05158d0962b4" resname="workzone:datepicker:april" approved="yes">
         <source>workzone:datepicker:april</source>
         <target state="translated">April</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="23ed9061fbf1a184658e05e57a121a72474b54eb" resname="workzone:datepicker:august" approved="yes">
         <source>workzone:datepicker:august</source>
         <target state="translated">August</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e55bc758f272d38198385584d6f50c2dd0eae13" resname="workzone:datepicker:december" approved="yes">
         <source>workzone:datepicker:december</source>
         <target state="translated">December</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db178b383e47bbe58670afd6a67528a4712444d7" resname="workzone:datepicker:february" approved="yes">
         <source>workzone:datepicker:february</source>
         <target state="translated">February</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4e3f12ef1defef487381a8339ea49840666414a" resname="workzone:datepicker:friday" approved="yes">
         <source>workzone:datepicker:friday</source>
         <target state="translated">Friday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="93f6bd6902114b73c225005188bce87569a3ac9c" resname="workzone:datepicker:january" approved="yes">
         <source>workzone:datepicker:january</source>
         <target state="translated">January</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0f1d297c3d3d9bc7cd800a9bd1a938904f4440ab" resname="workzone:datepicker:july" approved="yes">
         <source>workzone:datepicker:july</source>
         <target state="translated">July</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d860a667674628da86b76fb3be676370a61893c" resname="workzone:datepicker:june" approved="yes">
         <source>workzone:datepicker:june</source>
         <target state="translated">June</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2242d17f28dc262529688d688b5c2e128813ad8b" resname="workzone:datepicker:march" approved="yes">
         <source>workzone:datepicker:march</source>
         <target state="translated">March</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2ce30e1185f0f46df340ca727d4d9d89f42b6f5b" resname="workzone:datepicker:may" approved="yes">
         <source>workzone:datepicker:may</source>
         <target state="translated">May</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a7199e82486037293a2cfb17003ed9a30e2cfb2" resname="workzone:datepicker:monday" approved="yes">
         <source>workzone:datepicker:monday</source>
         <target state="translated">Monday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0bbaf1d4dbaa3b5eb27154fcc9579f89c848b091" resname="workzone:datepicker:nextText" approved="yes">
         <source>workzone:datepicker:nextText</source>
         <target state="translated">Next</target>
-        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="204">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ba391713621e89b5ecec7bc867e949e386332732" resname="workzone:datepicker:november" approved="yes">
         <source>workzone:datepicker:november</source>
         <target state="translated">November</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46727c5b9b3455e2cec4fc761568262af710f119" resname="workzone:datepicker:october" approved="yes">
         <source>workzone:datepicker:october</source>
         <target state="translated">October</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7eef21d25b8fa0b6940fe6c87640f82612d0393f" resname="workzone:datepicker:prevText" approved="yes">
         <source>workzone:datepicker:prevText</source>
         <target state="translated">Previous</target>
-        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="203">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d4fa7c1a1d4486201a760bcfb2f342ec8329f00" resname="workzone:datepicker:saturday" approved="yes">
         <source>workzone:datepicker:saturday</source>
         <target state="translated">Saturday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8aa1e4c6df39f7365a4fab8f3c70d3d8d4757ee" resname="workzone:datepicker:september" approved="yes">
         <source>workzone:datepicker:september</source>
         <target state="translated">September</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd48f23064201336fafcab46a34c085d5a886cb6" resname="workzone:datepicker:sunday" approved="yes">
         <source>workzone:datepicker:sunday</source>
         <target state="translated">Sunday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de522dc0285d55c95bb9af4aa39020ac35548353" resname="workzone:datepicker:thursday" approved="yes">
         <source>workzone:datepicker:thursday</source>
         <target state="translated">Thursday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d274289f8c48bcb43c06efe9386967b7f8fb56df" resname="workzone:datepicker:tuesday" approved="yes">
         <source>workzone:datepicker:tuesday</source>
         <target state="translated">Tuesday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="423742b6f616f9847ea24afec03e24b15f3ff10f" resname="workzone:datepicker:wednesday" approved="yes">
         <source>workzone:datepicker:wednesday</source>
         <target state="translated">Wednesday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbfb58c29147c5881e828d18a477f922211873a0" resname="workzone:feedback:expiration-closed" approved="yes">
         <source>workzone:feedback:expiration-closed</source>
@@ -14938,8 +14959,8 @@ It is possible to place several search areas</target>
         <source>yes</source>
         <target state="translated">Yes</target>
         <jms:reference-file line="89">web/common/technical_datas.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="580">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="76">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="646b0ebbe9829e44e9e99e9ab991a526f758001d" resname="you are about to change the  representation thumbnail of your video" approved="yes">
         <source>you are about to change the  representation thumbnail of your video</source>

--- a/resources/locales/messages.fr.xlf
+++ b/resources/locales/messages.fr.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:31:23Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:37Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,8 +9,8 @@
       <trans-unit id="da39a3ee5e6b4b0d3255bfef95601890afd80709" resname="">
         <source></source>
         <target state="new"></target>
-        <jms:reference-file line="47">Form/Configuration/EmailFormType.php</jms:reference-file>
-        <jms:reference-file line="60">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c03e9a1b443b7d9ac9a84e4d2cf55ebc016a9c5b" resname="                                Add" approved="yes">
         <source>                                Add</source>
@@ -20,73 +20,73 @@
       <trans-unit id="17b36ba11b9598e1ca72638a17637c71db031f8b" resname="#3567c6" approved="yes">
         <source>#3567c6</source>
         <target state="translated">#3567c6</target>
-        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="86">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c18097cf04c5f24e6b201e44603c26f000cbf266" resname="#4497d5" approved="yes">
         <source>#4497d5</source>
         <target state="translated">#4497d5</target>
-        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="654b7f2144322b13150ca53f8eb712644275fbbb" resname="#5aa53b" approved="yes">
         <source>#5aa53b</source>
         <target state="translated">#5aa53b</target>
-        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="81184afa6b2fb59a54a368a94c5af314882f4379" resname="#a1d0d0" approved="yes">
         <source>#a1d0d0</source>
         <target state="translated">#a1d0d0</target>
-        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="69760e828adabd5e543638f8b396d108e4e1c7f6" resname="#ad0800" approved="yes">
         <source>#ad0800</source>
         <target state="translated">#ad0800</target>
-        <jms:reference-file line="71">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
-        <jms:reference-file line="72">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8868030f047d29838dccd3ebd90a8cbcf5cf97b9" resname="#b151ee" approved="yes">
         <source>#b151ee</source>
         <target state="translated">#b151ee</target>
-        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="87">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df800d7d3f6bec2f0c48d7b18ad0f7515b4ed8a4" resname="#b8d84e" approved="yes">
         <source>#b8d84e</source>
         <target state="translated">#b8d84e</target>
-        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d3505d50f73a3440832d861060fc212eb2d929a" resname="#c875ea" approved="yes">
         <source>#c875ea</source>
         <target state="translated">#c875ea</target>
-        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="88">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cdd9fb48ed6b38bdf4cd732d30851062312f64b3" resname="#e46990" approved="yes">
         <source>#e46990</source>
         <target state="translated">#e46990</target>
-        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="89">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="22a0112b6eafc281d17f1b98fb8405847d01f04b" resname="#f06006" approved="yes">
         <source>#f06006</source>
         <target state="translated">#f06006</target>
-        <jms:reference-file line="73">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db6ca79114142b612eebf0ca5f80b94c80cbf453" resname="#f4ea5b" approved="yes">
         <source>#f4ea5b</source>
         <target state="translated">#f4ea5b</target>
-        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc4fad5f043fc9875dcdc532a296ec359a6c39e1" resname="#f5842b" approved="yes">
         <source>#f5842b</source>
         <target state="translated">#f5842b</target>
-        <jms:reference-file line="74">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="590b78bf59d578b0efdd1a7b1a385e8004fa88e8" resname="#ffc322" approved="yes">
         <source>#ffc322</source>
         <target state="translated">#ffc322</target>
-        <jms:reference-file line="75">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0cc996e2ae03790c84ef6edc0601ba0245d7cf1c" resname="#ffccd7" approved="yes">
         <source>#ffccd7</source>
         <target state="translated">#ffccd7</target>
-        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="90">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9378053eb7743587671aa830ffd2c9f1b13ad1a" resname="%ElementsCount% records" approved="yes">
         <source>%ElementsCount% records</source>
@@ -177,28 +177,28 @@
       <trans-unit id="24c43d6925295b9738f6fe69e4fb3dc7a2030f0f" resname="%nb_records% records" approved="yes">
         <source>%nb_records% records</source>
         <target state="translated">%nb_records% enregistrement(s)</target>
-        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Tooltip/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="107">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e39dc3a90b0674916ef22f19912638564f33e518" resname="%nb_view% vue" approved="yes">
         <source>%nb_view% vue</source>
         <target state="translated">%nb_view% vue</target>
-        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae7480d89dfd1ca0d1732014aee13f9958836bf8" resname="%nb_view% vues" approved="yes">
         <source>%nb_view% vues</source>
         <target state="translated">%nb_view% vues</target>
-        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="7">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de0804eb70c10b14d71df74292e45c6daa13d672" resname="%number% documents&lt;br/&gt;selectionnes" approved="yes">
         <source><![CDATA[%number% documents<br/>selectionnes]]></source>
         <target state="translated"><![CDATA[%number% documents<br/>sélectionnés]]></target>
-        <jms:reference-file line="268">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="263">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac5c6fe2979cfa2496c95dcb218f135fd916040d" resname="%quantity% Stories attached to the WorkZone" approved="yes">
         <source>%quantity% Stories attached to the WorkZone</source>
@@ -279,7 +279,7 @@
       <trans-unit id="f9b19aa0c7cf7aab245692450b473acff6a077e4" resname="%total% reponses" approved="yes">
         <source>%total% reponses</source>
         <target state="translated">%total% réponses</target>
-        <jms:reference-file line="316">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="311">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="99d2e1a7e8d0ba4a7132282b53b15e503b91c2cb" resname="%user% a envoye son rapport de validation de %title%" approved="yes">
         <source>%user% a envoye son rapport de validation de %title%</source>
@@ -384,7 +384,7 @@
       <trans-unit id="4412a659c3e1ca169796ab2f540a932ea7cbe2a4" resname="*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance" approved="yes">
         <source>*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance</source>
         <target state="translated">*Phraseanet Navigator* est une application mobile permettant à des utilisateurs de se connecter sur cette instance Phraseanet.</target>
-        <jms:reference-file line="28">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="356a192b7913b04c54574d18c28d46e6395428ab" resname="1" approved="yes">
         <source>1</source>
@@ -526,7 +526,7 @@
       <trans-unit id="62a3ad0fef668c4e2a220f6982de94942fbf1d1e" resname="AR" approved="yes">
         <source>AR</source>
         <target state="translated">AR</target>
-        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8887b473975b3b740e5afe559123403a6c219524" resname="About Roles :" approved="yes">
         <source>About Roles :</source>
@@ -625,17 +625,17 @@
       <trans-unit id="c3cd636a585b20c40ac2df5ffb403e83cb2eef51" resname="Actions" approved="yes">
         <source>Actions</source>
         <target state="translated">Actions</target>
-        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="26">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4a4f00323184bd750ee72b5c05e6e17d1584bfd" resname="Activate highlight" approved="yes">
         <source>Activate highlight</source>
         <target state="translated">Activer le surlignage (beta). Impacte les performances de recherche</target>
-        <jms:reference-file line="74">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="85">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="682">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a733b809d2f1233496ab516eed0f3ef75cf3791a" resname="Active" approved="yes">
@@ -668,10 +668,10 @@
       <trans-unit id="61cc55aa0453184734c3fa0b621eda6fa874bd83" resname="Add" approved="yes">
         <source>Add</source>
         <target state="translated">Ajouter</target>
-        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="514">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="515">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
+        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="983c5aed52d2f74bf36e97dc34dbce97fdd43f5b" resname="Add a&#10;                    new field" approved="yes">
         <source>Add a
@@ -733,7 +733,7 @@
       <trans-unit id="74ab95a4dbfaecbcd1fd586b71d97066ab7431c2" resname="Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only." approved="yes">
         <source>Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.</source>
         <target state="translated">Ajoute une option dans les formulaires d'envoi pour contraindre les destinataires d'un Push ou d'une Validation à s'authentifier.</target>
-        <jms:reference-file line="52">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="65">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e7afebcfbae000b22c7c85e5560f89a2a0280b4" resname="Admin" approved="yes">
         <source>Admin</source>
@@ -779,22 +779,22 @@
       <trans-unit id="a810fdb68ba89818cce5c607021256e40cf14170" resname="Afficher la fiche descriptive" approved="yes">
         <source>Afficher la fiche descriptive</source>
         <target state="translated">Afficher la notice</target>
-        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="946bf37a064ede9145bd8e3c7ce50e8608885518" resname="Afficher le titre" approved="yes">
         <source>Afficher le titre</source>
         <target state="translated">Afficher le titre</target>
-        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee793299aa2f135a4330889d59d362d1652fa577" resname="Afficher le type" approved="yes">
         <source>Afficher le type</source>
         <target state="translated">Afficher le type</target>
-        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1041">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7627cf7574df870b584ab3bd8a67d62d7ab4a18b" resname="Afficher les status" approved="yes">
         <source>Afficher les status</source>
         <target state="translated">Afficher les Status</target>
-        <jms:reference-file line="1005">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="47743dc906e82db1978c23daf01e4d5e727702bd" resname="Afficher une icone" approved="yes">
         <source>Afficher une icone</source>
@@ -829,16 +829,16 @@
       <trans-unit id="5e8a35671080dba23a7f84416dcf97fd975a33e6" resname="Ajouter a" approved="yes">
         <source>Ajouter a</source>
         <target state="translated">Ajouter à</target>
-        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6be348e8c91127640dc04e94dca7d5503ddb6c7d" resname="Ajouter ma selection courrante" approved="yes">
         <source>Ajouter ma selection courrante</source>
         <target state="translated">Ajouter ma sélection courante</target>
+        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
         <jms:reference-file line="15">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/orders/order_item.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d391a678bc6acf01f3f67c57b07853c5a588171" resname="Ajouter un nouvel utilisateur" approved="yes">
         <source>Ajouter un nouvel utilisateur</source>
@@ -858,7 +858,7 @@
       <trans-unit id="6a72085653e4c5be8c7640c868ef787cbcf063d1" resname="All" approved="yes">
         <source>All</source>
         <target state="translated">Tout</target>
-        <jms:reference-file line="35">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="189">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="199">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="209">actions/Feedback/list.html.twig</jms:reference-file>
@@ -882,7 +882,7 @@
       <trans-unit id="619eebecff3aef2d53d82536ebc2604fb07900e2" resname="Allow the website to be indexed by search engines like Google" approved="yes">
         <source>Allow the website to be indexed by search engines like Google</source>
         <target state="translated">Permettre l'indexation du site par des moteurs de recherche (comme Google)</target>
-        <jms:reference-file line="48">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77c7b4909d393bbb0e9e72d3dd008972625771b3" resname="Allowed" approved="yes">
         <source>Allowed</source>
@@ -955,13 +955,11 @@
       <trans-unit id="f0cf9a47c6b420dda55c973a12840600fc19b7fb" resname="An error occured" approved="yes">
         <source>An error occured</source>
         <target state="translated">Une erreur est survenue.</target>
-        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="164">Controller/Prod/MoveCollectionController.php</jms:reference-file>
-        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="251">Controller/Prod/BasketController.php</jms:reference-file>
-        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="218">Controller/Prod/StoryController.php</jms:reference-file>
+        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="71">Controller/Admin/DataboxesController.php</jms:reference-file>
         <jms:reference-file line="86">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="159">Controller/Admin/DataboxController.php</jms:reference-file>
@@ -983,12 +981,14 @@
         <jms:reference-file line="667">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="700">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="808">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="23">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="194">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
         <jms:reference-file line="19">admin/databox/databox.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a16a3255c311eccbe2471bfc5b5cd92f3b907654" resname="An error occured when wanting to change status!" approved="yes">
         <source>An error occured when wanting to change status!</source>
@@ -1029,13 +1029,13 @@
       <trans-unit id="98a5e115c36d45b5c1cb4ed3537f847a5210d1e7" resname="An error occurred" approved="yes">
         <source>An error occurred</source>
         <target state="translated">Une erreur est survenue</target>
-        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
-        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="2081">Controller/Api/V1Controller.php</jms:reference-file>
         <jms:reference-file line="2527">Controller/Api/V1Controller.php</jms:reference-file>
-        <jms:reference-file line="135">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="531">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="126">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="136">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
         <jms:reference-file line="81">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e861f79c8744b5cb0b59ce4f0100603952751b1" resname="An error occurred reading this file" approved="yes">
@@ -1056,7 +1056,7 @@
       <trans-unit id="3ad56f9f5a406f1c69267d4ac341168e3affa3e7" resname="Anonymous report" approved="yes">
         <source>Anonymous report</source>
         <target state="translated">Report anonyme</target>
-        <jms:reference-file line="34">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d7854118cda9d187ac6091c889576577aab8a36b" resname="Any time" approved="yes">
         <source>Any time</source>
@@ -1092,7 +1092,7 @@
       <trans-unit id="498778131fed5b01b06132a7c29c2d29829410c4" resname="Application description" approved="yes">
         <source>Application description</source>
         <target state="translated"><![CDATA[Contenu de la balise <META> Description]]></target>
-        <jms:reference-file line="36">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9ec030ab77d85f2493f1ebc5ab78e62e83fc383" resname="Application desktop" approved="yes">
         <source>Application desktop</source>
@@ -1102,7 +1102,7 @@
       <trans-unit id="ee3ac8b2def14068e5827dcd2499e831cb89712c" resname="Application title" approved="yes">
         <source>Application title</source>
         <target state="translated">Titre donné à l'instance Phraseanet</target>
-        <jms:reference-file line="30">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="866fef154cc77e6c30d7c9e97387dae0fb72dd08" resname="Application web" approved="yes">
         <source>Application web</source>
@@ -1133,8 +1133,8 @@
       <trans-unit id="b8fb717785e899f8e3bacfd74a395da7a434af9e" resname="Apply changes" approved="yes">
         <source>Apply changes</source>
         <target state="translated">Appliquer les modifications</target>
-        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="112">actions/Property/index.html.twig</jms:reference-file>
+        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e585e139fb6fc86d30e02ba78bdbb4dff6ac6b9" resname="Apply status on story children." approved="yes">
         <source>Apply status on story children.</source>
@@ -1274,8 +1274,8 @@
       <trans-unit id="d6caeca6303e9c722c929fbb58744a013a7ba7db" resname="Audio Codec" approved="yes">
         <source>Audio Codec</source>
         <target state="translated">Codec audio</target>
-        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="37">Media/Subdef/Audio.php</jms:reference-file>
+        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a80232c45008d73666e95544f7c9c8c0896536af" resname="Audio Samplerate" approved="yes">
         <source>Audio Samplerate</source>
@@ -1300,17 +1300,17 @@
       <trans-unit id="9e761dfcff90efcb07867accd3e8b109762fc596" resname="Auth_token directory path" approved="yes">
         <source>Auth_token directory path</source>
         <target state="translated">Chemin du répertoire Auth_token</target>
-        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77277d274230409567d5eaa8a27e1a1b8f08cef6" resname="Auth_token mount point" approved="yes">
         <source>Auth_token mount point</source>
         <target state="translated">Point de montage Auth_token</target>
-        <jms:reference-file line="34">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ef5e08e2db8aa52ae7a50b9d9f0bd6920b69a37" resname="Auth_token passphrase" approved="yes">
         <source>Auth_token passphrase</source>
         <target state="translated">Passphrase Auth_token</target>
-        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb7b626329225c9775b113922aa0d1662b5901a2" resname="Authoriser l'access" approved="yes">
         <source>Authoriser l'access</source>
@@ -1336,27 +1336,27 @@
       <trans-unit id="d5f364d5d9a0a95fdba37f29a65a9ba61d6329ef" resname="Authorize *Phraseanet Navigator*" approved="yes">
         <source>Authorize *Phraseanet Navigator*</source>
         <target state="translated">OBSOLETE Autoriser *Phraseanet Navigator*</target>
-        <jms:reference-file line="27">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b85de40822e66ce4309b94ccad5bb731f2a89373" resname="Authorize Adobe cc Plugin to connect." approved="yes">
         <source>Authorize Adobe cc Plugin to connect.</source>
         <target state="translated">Autoriser la connexion du plugin Adobe CC</target>
-        <jms:reference-file line="36">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e1ead524b95ba3b45281df7ba45d2addbbf1a79" resname="Authorize Microsoft Office Plugin to connect." approved="yes">
         <source>Authorize Microsoft Office Plugin to connect.</source>
         <target state="translated">Autoriser la connexion d'un plugin Microsoft Office</target>
-        <jms:reference-file line="32">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c614ba7c453cdcd4d21b20e8286c6266c891e0c6" resname="Auto" approved="yes">
         <source>Auto</source>
         <target state="translated">Auto</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e57297a1b1a46f4190603240a211144dde456ffe" resname="Auto select databases" approved="yes">
         <source>Auto select databases</source>
         <target state="translated">Sélection automatique des bases de données</target>
-        <jms:reference-file line="22">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7c91a8c4806cffc223b40523b3233bd23412ad4" resname="AutoRegister information" approved="yes">
         <source>AutoRegister information</source>
@@ -1384,7 +1384,7 @@
       <trans-unit id="45fc87c2d0ade465c57c00f7aa434a4d0bebe106" resname="Available in multi-export tab" approved="yes">
         <source>Available in multi-export tab</source>
         <target state="translated">Rendre disponible dans les onglets de la fenêtre d'export.</target>
-        <jms:reference-file line="23">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="37940d53912d9cc9ab0441c09c3754d6e83c438b" resname="Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes." approved="yes">
         <source>Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes.</source>
@@ -1394,11 +1394,11 @@
       <trans-unit id="b52b36b7269fbfc58ec24bb724691951a3decbe8" resname="Back" approved="yes">
         <source>Back</source>
         <target state="translated">Retour</target>
-        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
         <jms:reference-file line="69">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="92">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="134">mobile/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="738444fb7badaeb28467562ed8af8e1311e42eac" resname="Back to Feedback" approved="yes">
         <source>Back to Feedback</source>
@@ -1419,9 +1419,9 @@
         <source>Bad request format, only JSON is allowed</source>
         <target state="translated">Mauvais format de requête. Seul JSON est autorisé.</target>
         <jms:reference-file line="191">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="61">Controller/Admin/RootController.php</jms:reference-file>
         <jms:reference-file line="223">Controller/Admin/RootController.php</jms:reference-file>
-        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa0d7d2cb29f1ca72b4108bfaa0bf5686d3910ff" resname="Bad request, please contact an admin" approved="yes">
         <source>Bad request, please contact an admin</source>
@@ -1530,7 +1530,7 @@
       <trans-unit id="54a2cf5e634dbba0be2bf8a55f79252f5c790bdb" resname="Browser" approved="yes">
         <source>Browser</source>
         <target state="translated">Navigateur</target>
-        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d90cbe9431fb9e8d6013b651c2fb46a598de9eb" resname="Business Fields" approved="yes">
         <source>Business Fields</source>
@@ -1548,7 +1548,7 @@
       <trans-unit id="4a9b7a5a8f68ffe693f4205fc0d2916e373e4b64" resname="By default it is available for admins" approved="yes">
         <source>By default it is available for admins</source>
         <target state="translated">Par défaut, cette option est disponible pour les administrateurs.</target>
-        <jms:reference-file line="27">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a8e6c2695279fb4760d299974903123f751b3bf" resname="By field" approved="yes">
         <source>By field</source>
@@ -1576,12 +1576,12 @@
         <target state="translated">Annuler</target>
         <jms:reference-file line="131">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="28">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
-        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="114">actions/Property/index.html.twig</jms:reference-file>
-        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
+        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
+        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
         <jms:reference-file line="68">admin/fields/templates.html.twig</jms:reference-file>
         <jms:reference-file line="42">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae1f9ef7dc1cee4760e7f208f36c225e3ab1aa1f" resname="Cancel all" approved="yes">
         <source>Cancel all</source>
@@ -1602,14 +1602,14 @@
       <trans-unit id="f1f842e1950136f97e6b449b2ee8ee2a88c9d214" resname="Carousel" approved="yes">
         <source>Carousel</source>
         <target state="translated">Carrousel</target>
-        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="790d9876f3745353f60eb4d5232b26bb597ca5a3" resname="Categorie" approved="yes">
         <source>Categorie</source>
         <target state="translated">Catégorie</target>
-        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="38">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bf1584669680e7841bf069b9495ea2f012bff60b" resname="Ce champ est decrit comme element du %DublinCoreElementSet%" approved="yes">
         <source>Ce champ est decrit comme element du %DublinCoreElementSet%</source>
@@ -1639,14 +1639,14 @@
       <trans-unit id="17061b6a22c3d9f7255c7f6208394911623ea1cd" resname="Ce champ est obligatoire" approved="yes">
         <source>Ce champ est obligatoire</source>
         <target state="translated">Ce champ est obligatoire</target>
-        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="798">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="823">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="691">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="713">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e821f6f0c9613624f82ae880c01573ab0c0a0eac" resname="Ce champ est relie a une branche de thesaurus" approved="yes">
         <source>Ce champ est relie a une branche de thesaurus</source>
@@ -1667,12 +1667,12 @@
       <trans-unit id="9fb36da9009b1be61fc35e5de8ef5ea79ceca1c1" resname="Ce champ est trop long %length% caracteres max" approved="yes">
         <source>Ce champ est trop long %length% caracteres max</source>
         <target state="translated">Ce champ est trop long (%length% caractères max.)</target>
-        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="801">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="826">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="694">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="716">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a436b2b01f08a63284006c23ac3b38c9a699cbd" resname="Ce champ est utilise en titre a l'affichage" approved="yes">
         <source>Ce champ est utilise en titre a l'affichage</source>
@@ -1748,8 +1748,8 @@
       <trans-unit id="b030d590c21c95efe2ba71da1d0f1198a7e655b4" resname="Choisir" approved="yes">
         <source>Choisir</source>
         <target state="translated">Choisir</target>
-        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="150">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="168">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="368">web/admin/subdefs.html.twig</jms:reference-file>
@@ -1761,13 +1761,13 @@
       <trans-unit id="3f657f29e68346624be98bea3924a6748900a66c" resname="Choose a new password" approved="yes">
         <source>Choose a new password</source>
         <target state="translated">Choisissez un nouveau mot de passe</target>
-        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="15">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ad9476afb3cde04fd01e41ab85a0180eabfdb1c" resname="Choose the title of the document to export" approved="yes">
         <source>Choose the title of the document to export</source>
         <target state="translated">Choix du nom de fichier à l'export du document</target>
-        <jms:reference-file line="40">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0506773f181511d306efe57b7d20af4ea44fa1b3" resname="Civility" approved="yes">
         <source>Civility</source>
@@ -1777,8 +1777,8 @@
       <trans-unit id="719ea396ad92e01b4757ec2b93bb1e5f270f771d" resname="Clear" approved="yes">
         <source>Clear</source>
         <target state="translated">Effacer</target>
-        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/log_scheduler.html.twig</jms:reference-file>
+        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7135ee5eaed0e404c4fcf48d6eb7d2808f8e55f2" resname="Clear list" approved="yes">
         <source>Clear list</source>
@@ -1825,8 +1825,8 @@
       <trans-unit id="30c54a96f8011b39819ba18bcb53fcbb092d650d" resname="Collection" approved="yes">
         <source>Collection</source>
         <target state="translated">Collection</target>
-        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="446">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/databox/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="814cd4d896d0d93eac2f4d71dc24c91a46cd5e28" resname="Collection %collection%" approved="yes">
@@ -1896,10 +1896,10 @@
       <trans-unit id="f7853f027e327a9ddf52dd60f8d1719ae6904333" resname="Confidentialite" approved="yes">
         <source>Confidentialite</source>
         <target state="translated">Confidentialité</target>
-        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="56">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e9445beaddb548587c6f275e49da38e9fc7b785" resname="Confidentialite : privee" approved="yes">
         <source>Confidentialite : privee</source>
@@ -1990,7 +1990,7 @@
       <trans-unit id="da54a34bad5b32178cd5a344200f3beb72b8b214" resname="Cooliris" approved="yes">
         <source>Cooliris</source>
         <target state="translated">Cooliris</target>
-        <jms:reference-file line="55">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a1757945390259d3dbb7c551d01c23638463d39" resname="Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :" approved="yes">
         <source>Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :</source>
@@ -2046,7 +2046,7 @@
       <trans-unit id="26a9831600fb0e895035038bcac30cc389b393e0" resname="Create index" approved="yes">
         <source>Create index</source>
         <target state="translated">Créer les index</target>
-        <jms:reference-file line="56">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="67">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c175379b0389b2d6057b0b7db996720f1fb92fc7" resname="Creation date" approved="yes">
         <source>Creation date</source>
@@ -2066,9 +2066,9 @@
       <trans-unit id="2bd00521d39c34d7b8a4a42573e1cf42fb319036" resname="Creer" approved="yes">
         <source>Creer</source>
         <target state="translated">Créer</target>
-        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e0c179a64761a8abdbd1a1ef499e6aa7fd41b516" resname="Creer la tache d'ecriture des metadonnees" approved="yes">
         <source>Creer la tache d'ecriture des metadonnees</source>
@@ -2113,8 +2113,8 @@
       <trans-unit id="6a2b9fb6f6a60bde44a1bbe5e058c013cb1004ea" resname="Creer une playlist" approved="yes">
         <source>Creer une playlist</source>
         <target state="translated">Créer une liste de lecture</target>
-        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c26eb5f5ded79caa39c9dd44376bf3556f6466" resname="Creez une application pour commencer a utiliser l'API Phraseanet" approved="yes">
         <source>Creez une application pour commencer a utiliser l'API Phraseanet</source>
@@ -2145,12 +2145,12 @@
       <trans-unit id="19dff4dad0a7214ece14624f8c4c9fb206a1cfdd" resname="Current password" approved="yes">
         <source>Current password</source>
         <target state="translated">Mot de passe actuel</target>
-        <jms:reference-file line="26">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e8ae2dcb43aa1748c5f5facbb8bcc2b52a627059" resname="Current session" approved="yes">
         <source>Current session</source>
         <target state="translated">Session en cours</target>
-        <jms:reference-file line="43">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="46">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="081ae3fdc403609cf6e760849ebb14117b7a50cb" resname="Custom" approved="yes">
         <source>Custom</source>
@@ -2166,12 +2166,12 @@
       <trans-unit id="ce3e4bed2954adbf05f8edfaf1a4c0cc0cea70e9" resname="DE" approved="yes">
         <source>DE</source>
         <target state="translated">DE</target>
-        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="129bcdb9bbdbd9bba49b7e1eb1ec49698604f0b0" resname="DU" approved="yes">
         <source>DU</source>
         <target state="translated">DU</target>
-        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e2dc4518235e7567a3d68c45cb6165ec116fa3c" resname="Danger zone !" approved="yes">
         <source>Danger zone !</source>
@@ -2253,13 +2253,13 @@
       <trans-unit id="910c2f8e114bda3eef68b7f17eee5e864be52dc4" resname="Date de connexion" approved="yes">
         <source>Date de connexion</source>
         <target state="translated">Date de connexion</target>
-        <jms:reference-file line="22">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d5e8d1af5f3c137fb998b7afa347eeea683a7229" resname="Date de création" approved="yes">
         <source>Date de création</source>
         <target state="translated">Date de création</target>
-        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a13dfa9c55746372090d1ffbd465703786b7f90" resname="Date de demande" approved="yes">
         <source>Date de demande</source>
@@ -2271,8 +2271,8 @@
       <trans-unit id="c004345fde85bded2c74513e29c8cd58d74b594f" resname="Date de modification" approved="yes">
         <source>Date de modification</source>
         <target state="translated">Date de modification</target>
-        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="11">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce084029e351b4bfa9f425ae70e8aaa14a8904e5" resname="Date(s) from field(s)" approved="yes">
         <source>Date(s) from field(s)</source>
@@ -2315,7 +2315,7 @@
       <trans-unit id="7f4c92d36ad39747b7393498e20a21e3898d5ea6" resname="Default TTL in seconds of sub-definition url" approved="yes">
         <source>Default TTL in seconds of sub-definition url</source>
         <target state="translated">Durée de validité, en secondes, des URL JWT pour les sous-définitions et documents</target>
-        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="21cec17f6cd9c992f10804a71ea6d286a56c456a" resname="Default basket" approved="yes">
         <source>Default basket</source>
@@ -2325,27 +2325,27 @@
       <trans-unit id="1747ef3d688685c5844db2dc7c98aafd78ce3893" resname="Default export title" approved="yes">
         <source>Default export title</source>
         <target state="translated">Nom de fichier attribué par défaut</target>
-        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0865e6ae43db7711e100ad36595c2b38742f0b9f" resname="Default mail sender address" approved="yes">
         <source>Default mail sender address</source>
         <target state="translated">Adresse par défaut de l'expéditeur</target>
-        <jms:reference-file line="22">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1ad516bc09a2a902e2bf2d738bed0236b5a61c5e" resname="Default query" approved="yes">
         <source>Default query</source>
         <target state="translated">Requête par défaut</target>
-        <jms:reference-file line="26">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27cbd98bc854aa8480d4c436e762e9f30a00474e" resname="Default searched type" approved="yes">
         <source>Default searched type</source>
         <target state="translated">Type de média recherché par défaut</target>
-        <jms:reference-file line="29">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ccd20794e5c5f8f28ac9b0b2f57b29bcd31ddfc6" resname="Default validation links duration" approved="yes">
         <source>Default validation links duration</source>
         <target state="translated">Durée de validité (en jours) des liens générés pour les process de Push et de Validation</target>
-        <jms:reference-file line="29">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="332c9d57e19e2419cf5246fc9283f182eb316b8d" resname="Define a webhook URL" approved="yes">
         <source>Define a webhook URL</source>
@@ -2360,7 +2360,7 @@
       <trans-unit id="3b6bf506a535e9bf22431eace58b8f2f704dbd2a" resname="Defined in Apache configuration" approved="yes">
         <source>Defined in Apache configuration</source>
         <target state="translated">Défini dans la configuration de Apache.</target>
-        <jms:reference-file line="41">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a147677ac3ad9bbeaa766ccee9b2f2d3c7e1d59" resname="Delai depasse lors du contact avec le serveur WEB" approved="yes">
         <source>Delai depasse lors du contact avec le serveur WEB</source>
@@ -2430,20 +2430,20 @@
       <trans-unit id="57ec2e2addbd6a4117f16c1fff5f491fe3c5642c" resname="Deplacement %n_element% elements" approved="yes">
         <source>Deplacement %n_element% elements</source>
         <target state="translated">Déplacement de %n_element% documents</target>
-        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17c91ee147631da4f5aacabed0e198eb02955790" resname="Dernier access" approved="yes">
         <source>Dernier access</source>
         <target state="translated">Dernier accès</target>
-        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="821ed4c906c76220f9dc83eba5e0b861e22baa04" resname="Derniere mise a jour le %updated_on%" approved="yes">
         <source>Derniere mise a jour le %updated_on%</source>
         <target state="translated">Dernière mise à jour le %updated_on%</target>
-        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="45">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dcce9368ad626fe4addfa719b7a16807d464aa9b" resname="Derniers envois" approved="yes">
         <source>Derniers envois</source>
@@ -2459,29 +2459,29 @@
       <trans-unit id="55f8ebc805e65b5b71ddafdae390e3be2bcd69af" resname="Description" approved="yes">
         <source>Description</source>
         <target state="translated">Description</target>
-        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/Tooltip/DCESFieldInfo.html.twig</jms:reference-file>
-        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="31">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85cce1e14782f67cb830f74002ebe5603783c674" resname="Deselect all" approved="yes">
         <source>Deselect all</source>
         <target state="translated">Tout désélectionner</target>
-        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="60">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="225">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd281ce85e6f98a7dad0aa31a2e493a85ef178ca" resname="Design of personalization logo section" approved="yes">
         <source>Design of personalization logo section</source>
         <target state="translated">Logo</target>
-        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac930a136ebd04a19bc5f2ce1769fc065efb7bdf" resname="Detailed view URL" approved="yes">
         <source>Detailed view URL</source>
@@ -2507,8 +2507,8 @@
       <trans-unit id="45e147abd920eeb1aca320340e18cf67b4c77252" resname="Dimension" approved="yes">
         <source>Dimension</source>
         <target state="translated">Dimensions</target>
-        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Unknown.php</jms:reference-file>
+        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Image.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8b6613d50c2d8718fd7cab023e1530ce11650736" resname="Disable document type sharing" approved="yes">
@@ -2519,12 +2519,12 @@
       <trans-unit id="f4f4473df8cb59f0a369aebee3d1509adc0151c6" resname="Disabled" approved="yes">
         <source>Disabled</source>
         <target state="translated">Désactivé</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e304849daf61291daab688ef3154c851694909e6" resname="Disallow the possibility for the end user to disable push authentication" approved="yes">
         <source>Disallow the possibility for the end user to disable push authentication</source>
         <target state="translated">Supprime le choix des options d'authentification dans les formulaires d'envoi</target>
-        <jms:reference-file line="55">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="68">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa9fd169cd55f0433c6e7a4b5d758f90d0847411" resname="Display &amp; action settings" approved="yes">
         <source><![CDATA[Display & action settings]]></source>
@@ -2564,7 +2564,7 @@
       <trans-unit id="1dc1290f2dcd49c014e5cae4004924885fbd68ed" resname="Do you really want to end the activity of this session?" approved="yes">
         <source>Do you really want to end the activity of this session?</source>
         <target state="translated">Voulez-vous vraiment mettre fin à l'activité de cette session ?</target>
-        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="017fd7aedf39f509d51ce202368e4f0ea943de4e" resname="Do you want to send your report ?" approved="yes">
         <source>Do you want to send your report ?</source>
@@ -2600,12 +2600,12 @@
       <trans-unit id="3859bdaa8c6ffa767307d2ebc130439c543819c8" resname="Document title" approved="yes">
         <source>Document title</source>
         <target state="translated">Le titre du document</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="687c82861c956e47456186f6522cfc8dbadb8ef6" resname="Documents" approved="yes">
         <source>Documents</source>
         <target state="translated">Documents</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1096d02ee2e62ae8ea5873c92b391094d9f9516e" resname="Documents indisponibles" approved="yes">
         <source>Documents indisponibles</source>
@@ -2643,7 +2643,7 @@
       <trans-unit id="4e4528018d1a0aa11f7dc17b5425174a7436d334" resname="Drop index" approved="yes">
         <source>Drop index</source>
         <target state="translated">Supprimer les index</target>
-        <jms:reference-file line="49">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a9c043f68c147a7c8d8c2fa14ddfaba6e05da62" resname="Duree" approved="yes">
         <source>Duree</source>
@@ -2658,8 +2658,8 @@
       <trans-unit id="0d01e2e86669e98441ab4dce5520696c318b7098" resname="E-mail" approved="yes">
         <source>E-mail</source>
         <target state="translated">E-mail</target>
-        <jms:reference-file line="23">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="37">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9cf2896f8b2e9e6a28f9b151e8be31f220a5d256" resname="E-mail domain" approved="yes">
         <source>E-mail domain</source>
@@ -2669,7 +2669,7 @@
       <trans-unit id="734a78cd06d0929c433f487754d18bf073e43bf6" resname="EN" approved="yes">
         <source>EN</source>
         <target state="translated">EN</target>
-        <jms:reference-file line="37">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a908567d2c0292366061394efd6d40b139e033c5" resname="ERREUR : La classe de subdef est necessaire et egal a &quot;thumbnail&quot;,&quot;preview&quot; ou &quot;document&quot;" approved="yes">
         <source>ERREUR : La classe de subdef est necessaire et egal a "thumbnail","preview" ou "document"</source>
@@ -2689,7 +2689,7 @@
       <trans-unit id="9debabbaa01a190fabe8324c5e6e2f2808052099" resname="ES" approved="yes">
         <source>ES</source>
         <target state="translated">ES</target>
-        <jms:reference-file line="38">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5301648dcf6b53cefc9ed52999aaa92d4603cae0" resname="Edit" approved="yes">
         <source>Edit</source>
@@ -2714,9 +2714,9 @@
       <trans-unit id="5184ecbec7829b91dda100c703ea3fa284c7f5e8" resname="Edition de 1 element" approved="yes">
         <source>Edition de 1 element</source>
         <target state="translated">Edition de 1 document</target>
-        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="10">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99ead0eb32b2089a9933db5ccc262e2fc35fd0a6" resname="Edition des droits de %display_name%" approved="yes">
         <source>Edition des droits de %display_name%</source>
@@ -2751,19 +2751,19 @@
       <trans-unit id="201b9ab150a2ab3e5641814c373f8db1949199d0" resname="ElasticSearch index name" approved="yes">
         <source>ElasticSearch index name</source>
         <target state="translated">Nom de l'index Elasticsearch</target>
-        <jms:reference-file line="44">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="55">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="666">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b89586db0b00163ce75ae7426f06aa2e2a57b223" resname="ElasticSearch server host" approved="yes">
         <source>ElasticSearch server host</source>
         <target state="translated">Hôte du serveur Elasticsearch</target>
-        <jms:reference-file line="37">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="48">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="654">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18fd7d0c79d71cd9317190ae98dccdb1f7cf8b76" resname="ElasticSearch service port" approved="yes">
         <source>ElasticSearch service port</source>
         <target state="translated">Port de service Elasticsearch</target>
-        <jms:reference-file line="40">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="51">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="658">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="84add5b2952787581cb9a8851eef63d1ec75d22b" resname="Email" approved="yes">
@@ -2844,7 +2844,7 @@
       <trans-unit id="16edbca430dbc855d01b65c634474ae1648e1890" resname="Empty if not used" approved="yes">
         <source>Empty if not used</source>
         <target state="translated">Vider si non utilisé.</target>
-        <jms:reference-file line="45">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c90ec9c48fe61ec12eff0a4e00b6d74780aa38" resname="Empty quarantine" approved="yes">
         <source>Empty quarantine</source>
@@ -2876,8 +2876,8 @@
       <trans-unit id="0413c20ae2fd31e0a1eef73e7768c8e1c68558d9" resname="En cours d'encodage" approved="yes">
         <source>En cours d'encodage</source>
         <target state="translated">En cours d'encodage</target>
-        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="531">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="56">actions/Bridge/records_list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="43494e363213dc176e0699b914ccf966ccbd994d" resname="En cours d'envoi" approved="yes">
@@ -2888,42 +2888,42 @@
       <trans-unit id="4b4a90ee07557c5f8d1a9aedaed0fafacc4cc58f" resname="Enable FTP export" approved="yes">
         <source>Enable FTP export</source>
         <target state="translated">Activer l'export FTP</target>
-        <jms:reference-file line="22">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4f48c8f3f90677271cd196305954c1bc820a420" resname="Enable FTP for users" approved="yes">
         <source>Enable FTP for users</source>
         <target state="translated">Activer l'export FTP pour les utilisateurs</target>
-        <jms:reference-file line="26">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="25b38d3df5918f72187522a9cf74625c729ac6ad" resname="Enable Forcing authentication to see push content" approved="yes">
         <source>Enable Forcing authentication to see push content</source>
         <target state="translated">Rendre disponible l'option d'authentification forcée pour le Push et la Validation</target>
-        <jms:reference-file line="51">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e2edcbbb1c6aa26ccce6fbf04bec121c904dcec" resname="Enable H264 stream mode" approved="yes">
         <source>Enable H264 stream mode</source>
         <target state="translated">Activer H264 en mode flux continu (lecture en streaming)</target>
-        <jms:reference-file line="30">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc15a5aec96be87d7fec6a07972f8ac99693b265" resname="Enable HD substitution" approved="yes">
         <source>Enable HD substitution</source>
         <target state="translated">Activer la substitution de documents sources</target>
-        <jms:reference-file line="28">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="344fc3edd6987653de543b2ecd2d31aec2f3cca0" resname="Enable Phraseanet Web API" approved="yes">
         <source>Enable Phraseanet Web API</source>
         <target state="translated">Autoriser l'accès par l'API</target>
-        <jms:reference-file line="22">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee98e71194d6f532c3c777fa20a957c3ba490089" resname="Enable SMTP authentication" approved="yes">
         <source>Enable SMTP authentication</source>
         <target state="translated">Activer l'authentification SMTP</target>
-        <jms:reference-file line="31">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1abba66821d3efad3698297ceac2c3fc0e985faf" resname="Enable auto registration" approved="yes">
         <source>Enable auto registration</source>
         <target state="translated">Activer l'inscription automatique</target>
-        <jms:reference-file line="26">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84aa616ef0b3e29513430631bf82c50c9cde7406" resname="Enable document type sharing" approved="yes">
         <source>Enable document type sharing</source>
@@ -2933,43 +2933,43 @@
       <trans-unit id="af559a0c4023968d8723bcdfe3337ce72eca48eb" resname="Enable maintenance message broadcast" approved="yes">
         <source>Enable maintenance message broadcast</source>
         <target state="translated">Diffuser le message de maintenance</target>
-        <jms:reference-file line="25">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2b8f6db16b5583a7d9ef39a74fe471390d73bd74" resname="Enable multi-doc mode" approved="yes">
         <source>Enable multi-doc mode</source>
         <target state="translated">Activer le mode multi-doc</target>
-        <jms:reference-file line="25">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="af54ffee479b01e950445015c81b8e68c1347a66" resname="Enable possibility to notify users when publishing a new feed entry" approved="yes">
         <source>Enable possibility to notify users when publishing a new feed entry</source>
         <target state="translated">A la publication, permettre de notifier les utilisateurs d'une nouvelle entrée dans un flux</target>
-        <jms:reference-file line="58">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="35a2e4d551405a7ce8cdf754de5a47c8922b52d7" resname="Enable thesaurus" approved="yes">
         <source>Enable thesaurus</source>
         <target state="translated">Activer le thésaurus</target>
-        <jms:reference-file line="22">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="56848224e379e98e9a4cbcad0b51a0e99f7980f0" resname="Enable this setting to share on Facebook and Twitter" approved="yes">
         <source>Enable this setting to share on Facebook and Twitter</source>
         <target state="translated">Activer le partage par permalien et/ou sur les réseaux sociaux Facebook, Twitter, etc ...</target>
-        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8c91cee722569eccd85bf170aff83c6b8e3b4d1" resname="Enable thumbnail substitution" approved="yes">
         <source>Enable thumbnail substitution</source>
         <target state="translated">Activer la substitution de vignettes</target>
-        <jms:reference-file line="31">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df174a3f2faa31814e06540acda7af8825403fac" resname="Enabled" approved="yes">
         <source>Enabled</source>
         <target state="translated">Activé</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c2951dce186cc543b533d553a40cd64c767c6d7b" resname="End Activity" approved="yes">
         <source>End Activity</source>
         <target state="translated">Mettre fin à la session</target>
         <jms:reference-file line="13">web/account/sessions.html.twig</jms:reference-file>
-        <jms:reference-file line="41">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61983e17f966924dc25febd5756e710e2102d38f" resname="End Range" approved="yes">
         <source>End Range</source>
@@ -2979,7 +2979,7 @@
       <trans-unit id="b5d90b80b452e4c8e3f1840c23372475d8861803" resname="End session activity" approved="yes">
         <source>End session activity</source>
         <target state="translated">Clore la session</target>
-        <jms:reference-file line="69">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="42f2df94366ecaac40f51500a7583ecc8c6d424b" resname="Enter your e-mail address to retrieve your password" approved="yes">
         <source>Enter your e-mail address to retrieve your password</source>
@@ -3124,8 +3124,8 @@
       <trans-unit id="40019ae278d51a265b82e37738989bf1b22157b7" resname="Etendue de la publication" approved="yes">
         <source>Etendue de la publication</source>
         <target state="translated">Etendue de la publication</target>
-        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="255f8b2705b27e25acc23428730bfd7a32d9a0db" resname="Etes vous sur de supprimer %number% photos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% photos ?</source>
@@ -3140,14 +3140,14 @@
       <trans-unit id="e7f864e2cef6464cd4342b0a0b607c6b53fd8263" resname="Etes vous sur de supprimer %number% playlists ?" approved="yes">
         <source>Etes vous sur de supprimer %number% playlists ?</source>
         <target state="translated">Etes vous certain de vouloir supprimer %number% liste(s) de lecture ?</target>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0181b1da6f09b84ae46efce781899eb57ec74b8" resname="Etes vous sur de supprimer %number% videos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% videos ?</source>
         <target state="translated">Etes vous certain de vouloir supprimer %number% vidéo(s )?</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46a1884f7b083976b0fd0678f10b8f00ee93cde9" resname="Ex : Paris, bleu, montagne" approved="yes">
         <source>Ex : Paris, bleu, montagne</source>
@@ -3172,9 +3172,9 @@
       <trans-unit id="f3e4fadb9e370a1e2c0c622c01fc8c77daf93a2c" resname="Export" approved="yes">
         <source>Export</source>
         <target state="translated">Exporter</target>
+        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="75">Controller/Prod/DoDownloadController.php</jms:reference-file>
         <jms:reference-file line="76">Controller/Prod/DoDownloadController.php</jms:reference-file>
-        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c26d273867dffc55d40f46e6a163067c75969f5" resname="Export ranges" approved="yes">
         <source>Export ranges</source>
@@ -3189,7 +3189,7 @@
       <trans-unit id="6d2830b1e76dc7300fce6745176601827d233de8" resname="FR" approved="yes">
         <source>FR</source>
         <target state="translated">FR</target>
-        <jms:reference-file line="36">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="acb28212fba0272ee990cebd571ebe09b463312e" resname="FTP" approved="yes">
         <source>FTP</source>
@@ -3215,10 +3215,10 @@
         <source>Feedback</source>
         <target state="translated">Validation</target>
         <jms:reference-file line="122">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="54">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="90d95d818c456d269d000b3d82579506f6e34c5f" resname="Feedback:: Requested by %initiator% on %createdDate%" approved="yes">
         <source>Feedback:: Requested by %initiator% on %createdDate%</source>
@@ -3278,11 +3278,11 @@
       <trans-unit id="aadf78d4b7c7c7341aa891adca70897c4f978cb6" resname="File is not present in quarantine anymore, please refresh" approved="yes">
         <source>File is not present in quarantine anymore, please refresh</source>
         <target state="translated">Ce fichier n'est plus en quarantaine, rafraîchissez la page</target>
+        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="56">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="136">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="157">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
-        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3491d2e44dd1896af3411bb1a048847c13647feb" resname="File is too big : 64k max" approved="yes">
         <source>File is too big : 64k max</source>
@@ -3427,7 +3427,7 @@
       <trans-unit id="a5ec616668f5ea6fa47eec00bbe6e31964599856" resname="GD" approved="yes">
         <source>GD</source>
         <target state="translated">Bibliothèque GD</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a45e2e1fd0f0cb30474f4cfd3d8fbdc9fd7fb9" resname="GOP size" approved="yes">
         <source>GOP size</source>
@@ -3437,7 +3437,7 @@
       <trans-unit id="9c30a3485a5887f1ba5abd2a291d304a01863e55" resname="Gallery" approved="yes">
         <source>Gallery</source>
         <target state="translated">Galerie</target>
-        <jms:reference-file line="57">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="259242b8cd71adbfc416f01eaef816dacc0d8384" resname="General configuration" approved="yes">
         <source>General configuration</source>
@@ -3493,7 +3493,7 @@
       <trans-unit id="efd1f5fd46c31701d2e70555e9ab45efe27b4048" resname="Geonames server address" approved="yes">
         <source>Geonames server address</source>
         <target state="translated">Adresse du serveur de Géolocalisation Geonames</target>
-        <jms:reference-file line="35">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5334c3c15248b80aba72d8a192cb45256f6de263" resname="Get a notification when a mail export fails" approved="yes">
         <source>Get a notification when a mail export fails</source>
@@ -3503,7 +3503,7 @@
       <trans-unit id="05a07cd950e4b273afdde28fa0b591cc75524121" resname="Get setting form index" approved="yes">
         <source>Get setting form index</source>
         <target state="translated">Obtenir les réglages de l'index</target>
-        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="92">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee485ef50d127d2c51fe0091051d8c390d03ed59" resname="Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side." approved="yes">
         <source>Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side.</source>
@@ -3538,7 +3538,7 @@
       <trans-unit id="442bee77a51f11ee32ca32751c4e244e80de6e3d" resname="Google Analytics identifier" approved="yes">
         <source>Google Analytics identifier</source>
         <target state="translated">Identifiant Google Analytics</target>
-        <jms:reference-file line="39">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="362c03cff3bb37904f552194e92e5f13c721882f" resname="Grant rights" approved="yes">
         <source>Grant rights</source>
@@ -3558,7 +3558,7 @@
       <trans-unit id="cd6d6f27b3e16afd7cdd573b85b3cc5bfd22e8db" resname="GraphicsMagick" approved="yes">
         <source>GraphicsMagick</source>
         <target state="translated">GraphicsMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="779f61efcfe62182d0052c9526f3910378764758" resname="Graphiste (preview au rollover)" approved="yes">
         <source>Graphiste (preview au rollover)</source>
@@ -3610,8 +3610,8 @@
       <trans-unit id="d0d3632efe2a20cf1235aead5d817e03308131cc" resname="Hello %username%" approved="yes">
         <source>Hello %username%</source>
         <target state="translated">Bonjour %username%,</target>
-        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="82">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="62">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c47ae15370cfe1ed2781eedc1dc2547d12d9e972" resname="Help" approved="yes">
@@ -3627,21 +3627,21 @@
       <trans-unit id="78860a4e5b33556e6a8947485d8b042d9e58234e" resname="Hide information about users" approved="yes">
         <source>Hide information about users</source>
         <target state="translated">Masquer les informations à propos des utilisateurs</target>
-        <jms:reference-file line="35">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="70f8bb9a8a5393ef080507a89e4b98d139000d65" resname="Home" approved="yes">
         <source>Home</source>
         <target state="translated">Accueil</target>
-        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="3">login/include/language-block.html.twig</jms:reference-file>
-        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="49">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99f3b7dca04d6f354a9d2a3b633d9578a9ad8cac" resname="Homepage slideshow" approved="yes">
         <source>Homepage slideshow</source>
         <target state="translated">Diaporama de page d'accueil</target>
-        <jms:reference-file line="51">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8e41286dd8a6f03ef89a5aa958b1dad86ba4211f" resname="Hyperfocal distance" approved="yes">
         <source>Hyperfocal distance</source>
@@ -3651,13 +3651,13 @@
       <trans-unit id="f39bf9043aaeea61e7a0ba3949d854bd3997cb2a" resname="I have read the terms of use" approved="yes">
         <source>I have read the terms of use</source>
         <target state="translated">J'ai lu les conditions d'utilisation</target>
-        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
         <jms:reference-file line="68">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ea424d38af72dd1366a08aad1f47eca3e7ec3d24" resname="IP" approved="yes">
         <source>IP</source>
         <target state="translated">Adresse IP</target>
-        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f325d995b6d028ccc75771b1679537b623521c4" resname="ISO" approved="yes">
         <source>ISO</source>
@@ -3682,17 +3682,17 @@
       <trans-unit id="447a3b86a8a61425d5c46aed97eb2e7cf0bb769c" resname="If request is bigger, then mail is still available" approved="yes">
         <source>If request is bigger, then mail is still available</source>
         <target state="translated">Au-delà le téléchargement par E-mail reste disponible.</target>
-        <jms:reference-file line="23">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d9e4315a74579080394bc6a6fdb7f5eccbf41e8" resname="If set to 0, duration is permanent" approved="yes">
         <source>If set to 0, duration is permanent</source>
         <target state="translated">Indiquer 0 pour une durée de validité permanente.</target>
-        <jms:reference-file line="30">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="516e5bc94c0583cb8e632e13c36f77e514e0afc3" resname="If you notice any unfamiliar devices or locations, click on button %button% to end the session." approved="yes">
         <source>If you notice any unfamiliar devices or locations, click on button %button% to end the session.</source>
         <target state="translated">Si vous remarquez des périphériques ou des localisations inconnus, cliquer sur le bouton "Mettre fin à la session".</target>
-        <jms:reference-file line="15">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="17">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f91c7b9a3a35352f74a9fb8708e35ddbb36a852b" resname="If you plan to store large files, be sure it will fit in these directories." approved="yes">
         <source>If you plan to store large files, be sure it will fit in these directories.</source>
@@ -3722,7 +3722,7 @@
       <trans-unit id="57a8e563190f921afb876d6489bb40ed74f43a1a" resname="ImageMagick" approved="yes">
         <source>ImageMagick</source>
         <target state="translated">ImageMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3e38a20c1629a473809ea6a14c9cdf4204d3ac3b" resname="Images par secondes" approved="yes">
         <source>Images par secondes</source>
@@ -3738,7 +3738,7 @@
       <trans-unit id="bae76060aa0bb6aaf66ce914cf80b0786f965dc7" resname="Imagine driver" approved="yes">
         <source>Imagine driver</source>
         <target state="translated">"Imagine Driver"</target>
-        <jms:reference-file line="52">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca13920228ea59b30c40b8372f53df3bf4631520" resname="In the answer grid" approved="yes">
         <source>In the answer grid</source>
@@ -3775,9 +3775,9 @@
       <trans-unit id="54937b3a4f8cfa4576692882d3ff7b14c90c4ce5" resname="Informations" approved="yes">
         <source>Informations</source>
         <target state="translated">Informations</target>
-        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/account/base.html.twig</jms:reference-file>
+        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e1e0586141223b0143df16f7422dae5a43b77103" resname="Informations personnelles" approved="yes">
         <source>Informations personnelles</source>
@@ -3826,8 +3826,8 @@
         <source>Invalid file type, only (%supported_file_types%) file formats are supported</source>
         <target state="translated">Type de fichier non supportés. Seuls les types de fichiers %supported_file_types% sont supportés.</target>
         <jms:reference-file line="60">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
         <jms:reference-file line="199">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="65fd566280b15a384df25c73315b0dcbc6dacb69" resname="Invalid file type, only (%supported_file_types%) file formats are supported'" approved="yes">
         <source>Invalid file type, only (%supported_file_types%) file formats are supported'</source>
@@ -3864,8 +3864,8 @@
       <trans-unit id="8606f0ad87b5f92e01e46416cad301829571b7a7" resname="Inverser" approved="yes">
         <source>Inverser</source>
         <target state="translated">Inverser</target>
-        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3067f6d77794b736024c9a5594c1823612581e07" resname="It is not recommended to install Phraseanet without HTTPS support" approved="yes">
         <source>It is not recommended to install Phraseanet without HTTPS support</source>
@@ -3895,13 +3895,13 @@
       <trans-unit id="aa288d5bdc9be4c044885fa43c6f3758a1087d5a" resname="Keywords used for indexing purposes by search engines robots" approved="yes">
         <source>Keywords used for indexing purposes by search engines robots</source>
         <target state="translated"><![CDATA[Contenu de la balise <META> Keywords]]></target>
-        <jms:reference-file line="33">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e9f378dcffe600d99f66ba5fa74cd91d10b2256" resname="L'upload a echoue" approved="yes">
         <source>L'upload a echoue</source>
         <target state="translated">L'upload a échoué</target>
-        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="486">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="94fe10f78d9c8b531bbd609a20f373289599035c" resname="L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%" approved="yes">
         <source>L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%</source>
@@ -3945,20 +3945,20 @@
       <trans-unit id="cfa0120ab592ae2bc3198dbde15a7a87a0c792c4" resname="La taille maximale d'une video est de %duration% minutes." approved="yes">
         <source>La taille maximale d'une video est de %duration% minutes.</source>
         <target state="translated">La durée d'une vidéo est limitée à %duration% minutes.</target>
-        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="900">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dcfd86b957b9cf12ede165c6c2fa0acf12f3eeb" resname="La video a ete rejetee" approved="yes">
         <source>La video a ete rejetee</source>
         <target state="translated">La vidéo a été rejetée</target>
-        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="527">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="653e67f152ecc63ff3ee1014e86cc630a35dfe1a" resname="La video a ete supprimee" approved="yes">
         <source>La video a ete supprimee</source>
         <target state="translated">La vidéo a été supprimée</target>
-        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="525">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="da1c672d0d761ed5ac292335ed60e14ff3073265" resname="La video est restreinte" approved="yes">
         <source>La video est restreinte</source>
@@ -4054,16 +4054,16 @@
       <trans-unit id="b96ead6ab3add78d8448fcb2d18af281bb2cb278" resname="Le poids maximum d'un fichier est de %size%" approved="yes">
         <source>Le poids maximum d'un fichier est de %size%</source>
         <target state="translated">Le poids de fichier est limité à %size%</target>
-        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="906">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="814">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="13b9d7ef8e81663d7162d25b84cec1c24041e630" resname="Le record n'a pas de fichier physique" approved="yes">
         <source>Le record n'a pas de fichier physique</source>
         <target state="translated">L'enregistrement n'a pas de fichier physique</target>
-        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="896">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="808">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a596c989f20650068f6278338c1a966b7a8693f8" resname="Le token n'a pas encore ete genere" approved="yes">
         <source>Le token n'a pas encore ete genere</source>
@@ -4084,9 +4084,9 @@
       <trans-unit id="e330465da3182b7f6ed1b78217993edb4e22aacb" resname="Les elements ne peuvent etre uploades (problemes de type ou de droit)" approved="yes">
         <source>Les elements ne peuvent etre uploades (problemes de type ou de droit)</source>
         <target state="translated">Les documents ne peuvent être ajoutés (problème de type de fichiers ou de droits)</target>
-        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="15">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="72d3dbec389dce620bfa531d37c5f199ca2ccfda" resname="Les indications donnees ci dessous sont a titre informatif." approved="yes">
         <source>Les indications donnees ci dessous sont a titre informatif.</source>
@@ -4210,7 +4210,7 @@
       <trans-unit id="4e5a2893bdcc7d239c1db72e4c4ffbe4bea73174" resname="Login" approved="yes">
         <source>Login</source>
         <target state="translated">Identifiant</target>
-        <jms:reference-file line="32">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
         <jms:reference-file line="9">login/oauth/login.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/mapping.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/bind.html.twig</jms:reference-file>
@@ -4261,7 +4261,7 @@
       <trans-unit id="ca62571facf94a0b6b601235fa440be30c505b24" resname="Maintenance message" approved="yes">
         <source>Maintenance message</source>
         <target state="translated">Message de maintenance</target>
-        <jms:reference-file line="22">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb66e0bf5a145832586ceac41b71a4f95abcbc7e" resname="Maintenance state" approved="yes">
         <source>Maintenance state</source>
@@ -4321,22 +4321,22 @@
       <trans-unit id="bfceb124609fe75ad259082ced98a09429f02d2c" resname="Matomo Analytics identifier" approved="yes">
         <source>Matomo Analytics identifier</source>
         <target state="translated">Propriétés Matomo Analytics (site id)</target>
-        <jms:reference-file line="45">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d17f219ba947499e5a2f9b63a78d54deb821e1f8" resname="Matomo Analytics url" approved="yes">
         <source>Matomo Analytics url</source>
         <target state="translated">URL Matomo Analytics</target>
-        <jms:reference-file line="42">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28736b7711fa32497f69497b45453226c3bea0aa" resname="Maximum megabytes allowed for download" approved="yes">
         <source>Maximum megabytes allowed for download</source>
         <target state="translated">Limite maximale autorisée par téléchargement en Megaoctet (Mo)</target>
-        <jms:reference-file line="22">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e91bcca4090d4b36db511b03beb7800d72baa230" resname="Maximum number of pages to be extracted from PDF" approved="yes">
         <source>Maximum number of pages to be extracted from PDF</source>
         <target state="translated">Nombre maximum de pages à extraire depuis les documents PDF</target>
-        <jms:reference-file line="61">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="453c592dee2184bc6fb63b94d517cf1a6354590b" resname="Mes applications" approved="yes">
         <source>Mes applications</source>
@@ -4374,7 +4374,7 @@
       <trans-unit id="cb4f425374af2741715669ed8b541a666078b729" resname="Minimum number of letters before truncation" approved="yes">
         <source>Minimum number of letters before truncation</source>
         <target state="translated">Nombre minimal de caractères avant la troncature</target>
-        <jms:reference-file line="22">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="815d1b7d85075463e14c340ff9897a6c4af09ec3" resname="Missing &quot;structure&quot; parameter" approved="yes">
         <source>Missing "structure" parameter</source>
@@ -4544,14 +4544,14 @@
       <trans-unit id="d850ee188c7c55b64bc3624534de5c5051a57dc6" resname="New password" approved="yes">
         <source>New password</source>
         <target state="translated">Nouveau mot de passe</target>
-        <jms:reference-file line="47">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="39">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="49">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="572cfba6707b8e82f8c893b2188bede937e3f662" resname="New password (confirmation)" approved="yes">
         <source>New password (confirmation)</source>
         <target state="translated">Confirmer le nouveau mot de passe</target>
-        <jms:reference-file line="48">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="40">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17b2b838c5ce22c961a36736534a5029d6ba0087" resname="New task" approved="yes">
         <source>New task</source>
@@ -4568,8 +4568,8 @@
       <trans-unit id="816c52fd2bdd94a63cd0944823a6c0aa9384c103" resname="No" approved="yes">
         <source>No</source>
         <target state="translated">Non</target>
-        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="283">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c123d8ad43d08cc48c3d6a7676e65f71eea59df" resname="No URL available" approved="yes">
         <source>No URL available</source>
@@ -4691,19 +4691,19 @@
       <trans-unit id="22838b9a8bf000656dd4ff96d8ac904c8c33fade" resname="Nom du nouveau panier" approved="yes">
         <source>Nom du nouveau panier</source>
         <target state="translated">Nom du nouveau panier</target>
-        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c57d307e10f641b5b496db576d0dcd69d1daf25e" resname="Non-Restreinte (publique)" approved="yes">
         <source>Non-Restreinte (publique)</source>
         <target state="translated">Non restreinte (publique)</target>
-        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6eef6648406c333a4035cd5e60d0bf2ecf2606d7" resname="None" approved="yes">
         <source>None</source>
         <target state="translated">Aucun</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
         <jms:reference-file line="56">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="260">admin/user/registrations.html.twig</jms:reference-file>
       </trans-unit>
@@ -4735,8 +4735,8 @@
       <trans-unit id="a6633333760410e40ad92a50baade0b83afe8f7f" resname="Not aggregated" approved="yes">
         <source>Not aggregated</source>
         <target state="translated">Non agrégé</target>
-        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="241">admin/fields/templates.html.twig</jms:reference-file>
+        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc451929f50e088ffcff10e90dfe157d2319e753" resname="Notification par email" approved="yes">
         <source>Notification par email</source>
@@ -4797,25 +4797,25 @@
       <trans-unit id="997c69f6571530618bb38ac03f4cf2d236dcc15e" resname="Number of replicas" approved="yes">
         <source>Number of replicas</source>
         <target state="translated">Nombre de répliques (Replica Shards)</target>
-        <jms:reference-file line="66">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="77">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="674">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5c2a8aa4e676273c8d8f177856923ed9950e54bb" resname="Number of shards" approved="yes">
         <source>Number of shards</source>
         <target state="translated">Nombre de Shards Elastic</target>
-        <jms:reference-file line="62">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="73">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="670">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a44db49e9b745fe2a96ae2a2ef3595913e274b33" resname="Number of threads to use for FFMpeg" approved="yes">
         <source>Number of threads to use for FFMpeg</source>
         <target state="translated">Nombre de threads réservés à FFmpeg</target>
-        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ce3bd4224c8c1780db56b4125ecf3f24bf748b7" resname="OK" approved="yes">
         <source>OK</source>
         <target state="translated">OK</target>
-        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="535">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a98216a32426b9e66a4ac1eb6df2e96e1b495c" resname="Ok" approved="yes">
         <source>Ok</source>
@@ -4866,10 +4866,10 @@
       <trans-unit id="94946e4d2391ccf8ff24f984869ae8fcf9ede7c4" resname="Or login with" approved="yes">
         <source>Or login with</source>
         <target state="translated">Ou se connecter avec</target>
-        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
         <jms:reference-file line="103">web/login/index.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="91">login/oauth/login.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
+        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d75774c0f96b6ee44eb6643c9fea71b50b90ea8" resname="Order" approved="yes">
         <source>Order</source>
@@ -4909,7 +4909,7 @@
       <trans-unit id="77561f3d48cb738cc40f376dec4616a77da54ee1" resname="Original name" approved="yes">
         <source>Original name</source>
         <target state="translated">Le nom de fichier original</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="672c78971d44f4576ab54c347b873ad9dc98f5f1" resname="Oups ! something went wrong !" approved="yes">
         <source>Oups ! something went wrong !</source>
@@ -4929,9 +4929,9 @@
       <trans-unit id="fb06270f7c212baabc8749ffc36e49dc8f321548" resname="Page" approved="yes">
         <source>Page</source>
         <target state="translated">Page</target>
-        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="600584c2d5ccb97c0c0c424d9f32d6b102fcb040" resname="Pages" approved="yes">
         <source>Pages</source>
@@ -4941,31 +4941,31 @@
       <trans-unit id="fe42b90acc297644b70123354014701c49384489" resname="Paniers" approved="yes">
         <source>Paniers</source>
         <target state="translated">Paniers</target>
+        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="127">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="173">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="55">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="142">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="379c70ed96868079feece6d5c6a2b91545c2515b" resname="Par %author%" approved="yes">
         <source>Par %author%</source>
         <target state="translated">Par %author%</target>
-        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="25">mobile/lightbox/feed.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8be3c943b1609fffbfc51aad666d0a04adf83c9d" resname="Password" approved="yes">
         <source>Password</source>
         <target state="translated">Mot de passe</target>
-        <jms:reference-file line="41">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
-        <jms:reference-file line="52">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="81">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e3c007b7794e8f9fc4381136dfc7cdff5aa788a8" resname="Password (confirmation)" approved="yes">
         <source>Password (confirmation)</source>
         <target state="translated">Confirmer le mot de passe</target>
-        <jms:reference-file line="53">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e77cc0549ad99a9d3ba5c384f7f329db24d6d0c" resname="Password is empty at line %line%" approved="yes">
         <source>Password is empty at line %line%</source>
@@ -4995,7 +4995,7 @@
       <trans-unit id="102bbf0d1fb0a23cb8d8fb6eb03685b4509176c0" resname="Percent of the time left before the end of the validation to send a reminder email" approved="yes">
         <source>Percent of the time left before the end of the validation to send a reminder email</source>
         <target state="translated">Pourcentage de temps restant avant la fin de la validation pour envoyer un email de rappel</target>
-        <jms:reference-file line="26">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3d8de900b56813bb78e97afbf22578720d473219" resname="Periodically fetches an FTP repository content locally" approved="yes">
         <source>Periodically fetches an FTP repository content locally</source>
@@ -5061,14 +5061,14 @@
       <trans-unit id="cd95b41f85ddc0922e3fce8844279c55e9e3cdd9" resname="Playlist" approved="yes">
         <source>Playlist</source>
         <target state="translated">Liste de lecture</target>
-        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77b69f32c8780049ce0eec9782c3b77bb1e52bc3" resname="Playlists" approved="yes">
         <source>Playlists</source>
         <target state="translated">Listes de lecture</target>
-        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="183">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a79729c3f4563330799d576273950579e1ba3f5" resname="Please accept the terms of use to register." approved="yes">
         <source>Please accept the terms of use to register.</source>
@@ -5197,7 +5197,7 @@
       <trans-unit id="40c963556bf21635f163641ae0bbc354c6f8452c" resname="Prefix for notification emails" approved="yes">
         <source>Prefix for notification emails</source>
         <target state="translated">Préfixe pour les notifications adressées par e-mail</target>
-        <jms:reference-file line="25">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="29">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="474ae549026692693381925784cc30e5b706f330" resname="Prerequisite and Configuration" approved="yes">
         <source>Prerequisite and Configuration</source>
@@ -5212,7 +5212,7 @@
       <trans-unit id="be11dff872b14e749d330f920d6b159e107f277a" resname="Presentation de vignettes de panier" approved="yes">
         <source>Presentation de vignettes de panier</source>
         <target state="translated">Présentation des vignettes de panier</target>
-        <jms:reference-file line="998">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1007">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e709e76ff5425bd59879423588e80e67d778fa57" resname="Presets" approved="yes">
         <source>Presets</source>
@@ -5278,13 +5278,13 @@
       <trans-unit id="a255047b3f86eb4c0c79377f0725c89ceafe07ae" resname="Publique" approved="yes">
         <source>Publique</source>
         <target state="translated">Publique</target>
-        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="40">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107e7fab79b95c8f34990d625dd309e15996acba" resname="Publishers" approved="yes">
         <source>Publishers</source>
         <target state="translated">Editeurs</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f7f57b519fc9bc5683b4808641d3b33f53b6f9d" resname="Push" approved="yes">
         <source>Push</source>
@@ -5473,13 +5473,12 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <source>Re-initialiser</source>
         <target state="translated">Ré-initialiser</target>
         <jms:reference-file line="411">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca2a6abfc98ae1a46c15a6f8bbdc5fac25531462" resname="Re-ordonner" approved="yes">
         <source>Re-ordonner</source>
         <target state="translated">Ordonner</target>
-        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="13">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="211">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="212">prod/WorkZone/Macros.html.twig</jms:reference-file>
@@ -5487,6 +5486,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <jms:reference-file line="290">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="294">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="295">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9b19a5a212deb29444cc1b420ad81703205848be" resname="Read-only" approved="yes">
         <source>Read-only</source>
@@ -5496,12 +5496,12 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="8af84354a61a59531041ee67713997b84e7657ee" resname="Recaptcha private key" approved="yes">
         <source>Recaptcha private key</source>
         <target state="translated">Clé privée reCAPTCHA</target>
-        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c821a7953fa090cedb78553591582972bd8836e9" resname="Recaptcha public key" approved="yes">
         <source>Recaptcha public key</source>
         <target state="translated">Clé publique reCAPTCHA</target>
-        <jms:reference-file line="45">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="80f271a01202ec6ae47a6b61ad2bd75e4ccb4845" resname="Receive notification when I receive a push" approved="yes">
         <source>Receive notification when I receive a push</source>
@@ -5638,10 +5638,10 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="d672995a14650d0e018026b64f297663d8c71c8d" resname="Register" approved="yes">
         <source>Register</source>
         <target state="translated">Inscription</target>
-        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="10">login/include/register-link-block.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ab985702970c5012a1c1a2db7b65d95926aecaf" resname="Register approbation" approved="yes">
         <source>Register approbation</source>
@@ -5673,7 +5673,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="ced7b308a348567fbf21dd775ee496dd01207f24" resname="Remember me" approved="yes">
         <source>Remember me</source>
         <target state="translated">Se souvenir de moi</target>
-        <jms:reference-file line="51">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="55">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8005b356e3a4dba94a532df1deec4ebce882d13" resname="Reminder : validate '%title%'" approved="yes">
         <source>Reminder : validate '%title%'</source>
@@ -5710,8 +5710,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <source>Renew password</source>
         <target state="translated">Renouveler le mot de passe</target>
         <jms:reference-file line="58">Notification/Mail/MailRequestPasswordUpdate.php</jms:reference-file>
-        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee9dca727a184d24dd17095c1acacff79855df0d" resname="Reorder collections" approved="yes">
         <source>Reorder collections</source>
@@ -5721,8 +5721,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="fe8356db1811c518f0900dba0e65602c0fdcde3a" resname="Reordonner automatiquement" approved="yes">
         <source>Reordonner automatiquement</source>
         <target state="translated">Tri automatique</target>
-        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc5b6dcdaa76e91a51a264ce56aedb3ac385fc3b" resname="Repertoire de stockage des fichiers" approved="yes">
         <source>Repertoire de stockage des fichiers</source>
@@ -5753,7 +5753,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="0173481a881e3245000ec3fc5da8d26053ec2d37" resname="Require authentication to download documents" approved="yes">
         <source>Require authentication to download documents</source>
         <target state="translated">Exiger de s'authentifier pour télécharger des documents</target>
-        <jms:reference-file line="33">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c91dfa0024a9c65cb1f4cba0f4744e66fbcccba" resname="Require email validation to activate the account" approved="yes">
         <source>Require email validation to activate the account</source>
@@ -5915,32 +5915,32 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="741cd64a01685389e2fabdb7091a3b70f6be63ee" resname="SMTP encryption" approved="yes">
         <source>SMTP encryption</source>
         <target state="translated">Chiffrement SMTP (SMTP encryption)</target>
-        <jms:reference-file line="40">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d4a434baeeacaeeeb7e0ad914adfe6f76fb4fb6" resname="SMTP host" approved="yes">
         <source>SMTP host</source>
         <target state="translated">Serveur hôte SMTP</target>
-        <jms:reference-file line="34">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c0c4b23b7cf057f27996bf14973bc8778d0f86e" resname="SMTP password" approved="yes">
         <source>SMTP password</source>
         <target state="translated">Mot de passe SMTP</target>
-        <jms:reference-file line="53">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="65b5a10871b0ff8eb5019b42bd57ef00c06a45a8" resname="SMTP port" approved="yes">
         <source>SMTP port</source>
         <target state="translated">Port SMTP</target>
-        <jms:reference-file line="37">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aa18a4725d6a5fd47cfc64a79cfe902abb215068" resname="SMTP user" approved="yes">
         <source>SMTP user</source>
         <target state="translated">Utilisateur ou identifiant SMTP</target>
-        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="78bb8826fcc2504583e625386c238563e6207595" resname="SSL" approved="yes">
         <source>SSL</source>
         <target state="translated">SSL</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f40d195970d52ea94bbf5b0aa1dbe9822f10dd5" resname="SUBDEFS" approved="yes">
         <source>SUBDEFS</source>
@@ -5950,15 +5950,15 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="efc007a393f66cdb14d57d385822a3d9e36ef873" resname="Save" approved="yes">
         <source>Save</source>
         <target state="translated">Sauvegarder</target>
-        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
         <jms:reference-file line="41">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="108">actions/Feedback/list.html.twig</jms:reference-file>
+        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/worker-manager/worker_ftp.html.twig</jms:reference-file>
         <jms:reference-file line="75">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="3">admin/search-engine/elastic-search.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="960c9d85e9849fa58deb038c6c9bcf36ec973c99" resname="Save all changes" approved="yes">
         <source>Save all changes</source>
@@ -6014,8 +6014,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="ce3df4d818316dd10c7bca5ae8539c894dc07dbb" resname="See" approved="yes">
         <source>See</source>
         <target state="translated">Voir</target>
-        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="8">WorkZone/Browser/Browser.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a377f0dd2a261c8e46358dc8d0e8d9868bc6094f" resname="See documentation about structure manipulation." approved="yes">
         <source>See documentation about structure manipulation.</source>
@@ -6025,14 +6025,14 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="b5c208620e2d74920057e4d500f77788b86f41db" resname="See documentation at %url%" approved="yes">
         <source>See documentation at %url%</source>
         <target state="translated">Voir la documentation en ligne à l'adresse %url%</target>
-        <jms:reference-file line="38">Form/Configuration/WebservicesFormType.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b945126af2994e142e712b4e6f3c2cb2dd186a76" resname="See my order" approved="yes">
         <source>See my order</source>
         <target state="translated">Voir ma commande</target>
-        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
         <jms:reference-file line="74">Notification/Mail/MailInfoOrderDelivered.php</jms:reference-file>
+        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="369b9cb821dd6966e989359a1b8aadaf9c4db387" resname="See others" approved="yes">
         <source>See others</source>
@@ -6062,10 +6062,10 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="913afff1faf79724f1f685fe8b1e36a729123ca2" resname="Select all" approved="yes">
         <source>Select all</source>
         <target state="translated">Tout sélectionner</target>
-        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="57">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="224">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c83f0d10a0a04ab6ae1ceb098113b081e9bc4d5" resname="Select all collections" approved="yes">
         <source>Select all collections</source>
@@ -6099,10 +6099,10 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <target state="translated">Envoyer</target>
         <jms:reference-file line="101">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="46">web/login/forgot-password.html.twig</jms:reference-file>
-        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="113">prod/upload/upload.html.twig</jms:reference-file>
         <jms:reference-file line="110">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="185">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="220">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/admin/dashboard.html.twig</jms:reference-file>
@@ -6215,8 +6215,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="396c2137a0b503759e5d4930af8a16aa28ce3ee7" resname="Short description" approved="yes">
         <source>Short description</source>
         <target state="translated">Description brève</target>
-        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="18">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="32e50dd99f3b67dc93272aa6c904b83d37f4f48d" resname="Shutter speed" approved="yes">
         <source>Shutter speed</source>
@@ -6247,7 +6247,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="234bf52eb70433473b325e23026794557cca00d9" resname="Single image" approved="yes">
         <source>Single image</source>
         <target state="translated">Image seule</target>
-        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e78af337eef67e03f72ea26dbe1a69c326e3660" resname="Site web" approved="yes">
         <source>Site web</source>
@@ -6258,13 +6258,13 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <source>Size</source>
         <target state="translated">Taille</target>
         <jms:reference-file line="37">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
         <jms:reference-file line="116">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="000f280b111f7ab59b5f5f4462a40de0553664cc" resname="Slide show" approved="yes">
         <source>Slide show</source>
         <target state="translated">Diaporama</target>
-        <jms:reference-file line="54">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6412f8f76fca194e1e7e1c3b13556497ac125db" resname="Some files are being downloaded" approved="yes">
         <source>Some files are being downloaded</source>
@@ -6316,8 +6316,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="8657e88f4bf4b28dd29659361c70f11dea58efa5" resname="Sous-titre" approved="yes">
         <source>Sous-titre</source>
         <target state="translated">Sous-titre</target>
-        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="16">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="970f057325af27424f32675051fea5366873b007" resname="Space bar" approved="yes">
         <source>Space bar</source>
@@ -6332,8 +6332,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="952f375412e89ff213a8aca383d18e5691354347" resname="Start" approved="yes">
         <source>Start</source>
         <target state="translated">Démarrer</target>
-        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="15">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
@@ -6350,14 +6350,14 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="7ec5491e76522fe1687d799f35ab2ba39ae573fe" resname="Start validation" approved="yes">
         <source>Start validation</source>
         <target state="translated">Démarrer la validation</target>
+        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
         <jms:reference-file line="47">Notification/Mail/MailInfoReminderFeedback.php</jms:reference-file>
         <jms:reference-file line="70">Notification/Mail/MailInfoValidationReminder.php</jms:reference-file>
-        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="faa9e7e7ef5a264c58c68a4a0b9c8bd54241450a" resname="Started" approved="yes">
         <source>Started</source>
         <target state="translated">Démarré</target>
-        <jms:reference-file line="42">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="46">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e1c8377cce4ac872e1c3e8fc6bc760c5130946d" resname="Status des documents a rechercher" approved="yes">
         <source>Status des documents a rechercher</source>
@@ -6384,20 +6384,20 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <target state="translated">Arrêter</target>
         <jms:reference-file line="8">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/upload/lazaret.html.twig</jms:reference-file>
-        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="10">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="59">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51e9111b87116e60566740d13ba1c1eddb042333" resname="Stopped" approved="yes">
         <source>Stopped</source>
         <target state="translated">Arrêté</target>
-        <jms:reference-file line="43">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="47">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67b5fefd39cf2223cfc9023e91571fd2a87cd76a" resname="Stories" approved="yes">
         <source>Stories</source>
         <target state="translated">Reportages</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="315bc332aafca63cad8ac042c2e2f5111544fe9d" resname="Story Not Found" approved="yes">
@@ -6535,14 +6535,14 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="dd631af5459e2fae291effe51fbb608d13a75163" resname="Suppression de %n_element% playlists" approved="yes">
         <source>Suppression de %n_element% playlists</source>
         <target state="translated">Suppression de %n_element% liste(s) de lecture</target>
-        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="299c2796a0d682b2495627623e9f228410b8a84a" resname="Suppression de %n_element% videos" approved="yes">
         <source>Suppression de %n_element% videos</source>
         <target state="translated">Suppression de %n_element% vidéo(s)</target>
-        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1acfc1c7d761310db2e5e876c0cade4d522cfed2" resname="Supprimer" approved="yes">
         <source>Supprimer</source>
@@ -6568,7 +6568,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="d91e1888f2dc09f11a876e25966a6fbd32b9cd87" resname="TLS" approved="yes">
         <source>TLS</source>
         <target state="translated">TLS</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a524057f93fd59da6998f240a0602fabc16dfb02" resname="Tableau de bord" approved="yes">
         <source>Tableau de bord</source>
@@ -6578,11 +6578,11 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="848eed0fbd5429f556b2982dec3ea87136e33e44" resname="Tags" approved="yes">
         <source>Tags</source>
         <target state="translated">Tags</target>
-        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="49">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e98caed82acc9fa2f1ba9edeab7789e75e49c36" resname="Target Device" approved="yes">
         <source>Target Device</source>
@@ -6604,12 +6604,12 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="c78d2fc3a6668b4edc8cf013ce4c6cf8c269b1bf" resname="Task name" approved="yes">
         <source>Task name</source>
         <target state="translated">Nom de la tâche</target>
-        <jms:reference-file line="25">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="29">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b953a851b67dcb4e540270e49fe450d1d613eb1e" resname="Task period (in seconds)" approved="yes">
         <source>Task period (in seconds)</source>
         <target state="translated">Périodicité de la tâche (en secondes)</target>
-        <jms:reference-file line="32">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="36">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cf459f472a871f1b053e16008a15cd566921aab0" resname="Technical Informations" approved="yes">
         <source>Technical Informations</source>
@@ -6630,7 +6630,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="97738411d629b01052974cc98ddb83a2cb4f8182" resname="Terms of Use" approved="yes">
         <source>Terms of Use</source>
         <target state="translated">Conditions générales d'utilisation</target>
-        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="501">web/common/dialog_export.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a6a1d25b018c9318540556e3fe374fdf8b23aff8" resname="Terms of service" approved="yes">
@@ -6649,7 +6649,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="903b3a1a72b51b7b51f85ec8c81def53ed9c9b0c" resname="The Phraseanet Web API allows other web application to rely on this instance" approved="yes">
         <source>The Phraseanet Web API allows other web application to rely on this instance</source>
         <target state="translated">L'API Web Phraseanet permet à d'autres applications web de se reposer sur cette instance</target>
-        <jms:reference-file line="23">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2558cc2c887bbe4e2444ec6ef83b4982386e871a" resname="The URL you used is out of date, please login" approved="yes">
         <source>The URL you used is out of date, please login</source>
@@ -6763,7 +6763,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="d29ae57dd01be0f4c5b2e1993379c00443a9c937" resname="The task status" approved="yes">
         <source>The task status</source>
         <target state="translated">Etat de la tâche</target>
-        <jms:reference-file line="40">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="44">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2e77a8fce4b585aac7e3e493f08aa4d8f56bc7e2" resname="The upgrade is already started" approved="yes">
         <source>The upgrade is already started</source>
@@ -6803,7 +6803,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="3fc5195b4a6ff8dc205dbbad17104fa93db88281" resname="Thesaurus Min score" approved="yes">
         <source>Thesaurus Min score</source>
         <target state="translated">Hits minimum du Thésaurus</target>
-        <jms:reference-file line="70">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="678">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="163fc70a23cf29331bab9896c9a8a0cb0b113bd6" resname="Thesaurus branch" approved="yes">
@@ -6871,7 +6871,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="58e76d1cc6a26f43783774d888c3a260970f637b" resname="This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases." approved="yes">
         <source>This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases.</source>
         <target state="translated">Cette option désactive la sélection des bases et collections sur laquelle l'utilisateur fait une demande d'inscription. L'inscription est alors effectuée d'office sur toutes les bases et collections rendues disponibles.</target>
-        <jms:reference-file line="23">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="814c3298cccd06ad65ccac8a35e4f2104a4af17e" resname="This user does not participate to the validation but is only viewer." approved="yes">
         <source>This user does not participate to the validation but is only viewer.</source>
@@ -6912,19 +6912,19 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="eb97899aedcd5609782b5ccb4ffa390e0e66a3eb" resname="Titre" approved="yes">
         <source>Titre</source>
         <target state="translated">Titre</target>
-        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="24">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="9">prod/Baskets/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="01594f4dad04782844c8175778fdf66deabf580d" resname="Toggle loop" approved="yes">
         <source>Toggle loop</source>
@@ -7028,8 +7028,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="c2739616a133e476dda18386df0d2487d526766a" resname="URL de callback" approved="yes">
         <source>URL de callback</source>
         <target state="translated">Url de Callback</target>
-        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="102">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="268f900effee1beb15231a1504d02543e8827bb3" resname="Un document commande" approved="yes">
         <source>Un document commande</source>
@@ -7196,15 +7196,15 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <source>Upload</source>
         <target state="translated">Ajouter</target>
         <jms:reference-file line="94">web/common/menubar.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="16">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="83">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9ee782a49540357e87b6dc0dde09d8bec6507af" resname="Upload URL is not set, please contact an admin" approved="yes">
         <source>Upload URL is not set, please contact an admin</source>
@@ -7234,12 +7234,12 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="ea1fd4c4c366bf2e13d348b67b75e96039d7a1d7" resname="Use Google Chart API" approved="yes">
         <source>Use Google Chart API</source>
         <target state="translated">Utiliser Google Chart API</target>
-        <jms:reference-file line="32">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2023f20c3153f9d593dfe4e5447b24866e27bd34" resname="Use a SMTP server" approved="yes">
         <source>Use a SMTP server</source>
         <target state="translated">Utiliser un serveur SMTP</target>
-        <jms:reference-file line="28">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="32">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="337f9aa5d63611e88aedd8cc09ee1488fb9fe3a4" resname="Use an existing index" approved="yes">
         <source>Use an existing index</source>
@@ -7259,7 +7259,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="c42cc91c040b3c093f851494375a1be868018231" resname="Use recaptcha API" approved="yes">
         <source>Use recaptcha API</source>
         <target state="translated">Utiliser l'API reCAPTCHA</target>
-        <jms:reference-file line="41">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17a74b77867e7b3f4f5e5b2ad90be36cf800dfda" resname="Use the Flash uploader" approved="yes">
         <source>Use the Flash uploader</source>
@@ -7276,22 +7276,22 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="1d2b0439bd02b54c622696c45588eab8d051dfb9" resname="Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token" approved="yes">
         <source>Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token</source>
         <target state="translated">Utiliser avec mod_token (requiert les modules Apache mod_token, mod_auth_token et mod_h264_streaming).</target>
-        <jms:reference-file line="31">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="73e8bd6eff9e8b1460684911486ad731e3097ab2" resname="Used for guest account" approved="yes">
         <source>Used for guest account</source>
         <target state="translated">Utilisé pour le compte invité.</target>
-        <jms:reference-file line="34">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84e635021b5a8691329da2b22cbdbb7137ddc018" resname="Used in search engine" approved="yes">
         <source>Used in search engine</source>
         <target state="translated">Utilisé dans le moteur de recherche.</target>
-        <jms:reference-file line="23">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a54e4b6b720a84b428f0feda87f35d92cc219ee7" resname="Used when opening the application" approved="yes">
         <source>Used when opening the application</source>
         <target state="translated">Utilisé à l'ouverture de l'application.</target>
-        <jms:reference-file line="30">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5bb94bfadf4a04bc6b31a3298c5f19a7dead6769" resname="User already exists" approved="yes">
         <source>User already exists</source>
@@ -7346,7 +7346,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="3482565eef4d4cd1decb5ebfad6ecfc5943d30da" resname="Users must accept Terms of Use for each export" approved="yes">
         <source>Users must accept Terms of Use for each export</source>
         <target state="translated">Les utilisateurs doivent accepter les conditions générales d'utilisation à chaque export</target>
-        <jms:reference-file line="37">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28f4718f1cf2cd1f31d49c8bce276341ffe222bd" resname="Users suggestion" approved="yes">
         <source>Users suggestion</source>
@@ -7361,8 +7361,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="3b3e9155f69edf73caab337bf5f64231188b1e48" resname="VALIDATION" approved="yes">
         <source>VALIDATION</source>
         <target state="translated">Validation</target>
-        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="6">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e400a7eef4ab49bbe657b3e3c557d64e091a356" resname="Validate e-mail address" approved="yes">
         <source>Validate e-mail address</source>
@@ -7372,9 +7372,9 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="dd74d182c641e4c78502d863b44d0aeff1575e54" resname="Validation" approved="yes">
         <source>Validation</source>
         <target state="translated">Validation</target>
+        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validate.php</jms:reference-file>
         <jms:reference-file line="78">eventsmanager/notify/validate.php</jms:reference-file>
-        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="79">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="86">lightbox/IE6/validate.html.twig</jms:reference-file>
@@ -7392,9 +7392,9 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="6c259e54dcc7188e7cfe33403eca78cda53017fc" resname="Validations" approved="yes">
         <source>Validations</source>
         <target state="translated">Validations</target>
+        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="119">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="165">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="51">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="100">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
@@ -7411,7 +7411,7 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="0cedbcdb95addc9f8d1b024fcbaf3d87dc6d044b" resname="Validity period of the download links" approved="yes">
         <source>Validity period of the download links</source>
         <target state="translated">Durée de validité des liens de téléchargement</target>
-        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="74">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db671097785924a80ca79c2a37675116e90899e8" resname="Vers quel API voulez vous vous connecter ?" approved="yes">
         <source>Vers quel API voulez vous vous connecter ?</source>
@@ -7451,8 +7451,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="56b71e89fb1079caaadefd0889e9a22e8b0560e3" resname="Videos" approved="yes">
         <source>Videos</source>
         <target state="translated">Vidéos</target>
-        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="174">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="18af7efc4ef7f30783dbb1ad1bc0b9aed857a19c" resname="View on %title%" approved="yes">
         <source>View on %title%</source>
@@ -7604,10 +7604,10 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="12ee49ba726f4422d3dcc6bc7b92ab9de279d211" resname="Vous n'avez selectionne aucun element" approved="yes">
         <source>Vous n'avez selectionne aucun element</source>
         <target state="translated">Aucun document sélectionné</target>
+        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e8fd52d6c7e92e6907f1148d2e458871d17c1ae" resname="Vous ne pouvez pas editer plusieurs elements simultanement" approved="yes">
         <source>Vous ne pouvez pas editer plusieurs elements simultanement</source>
@@ -7653,8 +7653,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="94bfa418b59cf2b1d326f614666ece16ef9cbded" resname="Watch my access requests status" approved="yes">
         <source>Watch my access requests status</source>
         <target state="translated">Consulter l'état de ma demande d'accès</target>
-        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
         <jms:reference-file line="39">Notification/Mail/MailSuccessEmailConfirmationUnregistered.php</jms:reference-file>
+        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d67f8b5513fcc1166cb7086a07bf29144de7c879" resname="Watermark" approved="yes">
         <source>Watermark</source>
@@ -7694,8 +7694,8 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="ceffd5b622d10de1a19822471cb3804cb61cba28" resname="Which playlist you want to put you %number% elements into ?" approved="yes">
         <source>Which playlist you want to put you %number% elements into ?</source>
         <target state="translated">A quelle liste de lecture souhaitez vous ajouter les %number% documents</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e2507e568a039431c507b30f44aa72cbb1ed929" resname="Whoops, looks like something went wrong." approved="yes">
         <source>Whoops, looks like something went wrong.</source>
@@ -7740,9 +7740,9 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="5397e0583f14f6c88de06b1ef28f460a1fb5b0ae" resname="Yes" approved="yes">
         <source>Yes</source>
         <target state="translated">Oui</target>
+        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="33">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="13">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4de66b40cf0800d4a25cc75b4f3f593cfc44ef6c" resname="You are Admin" approved="yes">
         <source>You are Admin</source>
@@ -8056,85 +8056,85 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="162536d0e4aeccdde8b707acd6111800a25d549b" resname="action : bridge" approved="yes">
         <source>action : bridge</source>
         <target state="translated">Bridge</target>
-        <jms:reference-file line="1038">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3ffc763c6cf92695a7ce387f904bbe6e7a94bdbc" resname="action : collection" approved="yes">
         <source>action : collection</source>
         <target state="translated">Déplacer</target>
-        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="38">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddc3c6161fab39cbaf5d3f59af82090b32a2c36c" resname="action : editer" approved="yes">
         <source>action : editer</source>
         <target state="translated">Editer</target>
         <jms:reference-file line="10">prod/preview/caption.html.twig</jms:reference-file>
-        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="24">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b62efbefb9b0e40c14ac8218ac4257603c5b75c" resname="action : exporter" approved="yes">
         <source>action : exporter</source>
         <target state="translated">Exporter</target>
-        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="25">prod/preview/tools.html.twig</jms:reference-file>
-        <jms:reference-file line="1040">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="52">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="128">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="129">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="130">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0c9b7eb3d21f5a48ac5ecb0a0d969b8d3818e41" resname="action : outils" approved="yes">
         <source>action : outils</source>
         <target state="translated">Outils</target>
-        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="70">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="71e15cbcf85fd5fe848fe7fa210fa8318a09f842" resname="action : print" approved="yes">
         <source>action : print</source>
         <target state="translated">Imprimer</target>
         <jms:reference-file line="20">prod/preview/tools.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="138">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="139">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="140">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d222a71a73f44cb6bdf237790f350f0b1fb9eb1f" resname="action : publier" approved="yes">
         <source>action : publier</source>
         <target state="translated">Publier</target>
-        <jms:reference-file line="1039">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="63">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17948b21adfde1bf589b2a34a2c8253e2af91913" resname="action : push" approved="yes">
         <source>action : push</source>
         <target state="translated">Push</target>
-        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="47">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f22184cfa5be236b7193d80d5f8407a36b108b79" resname="action : status" approved="yes">
         <source>action : status</source>
         <target state="translated">Propriétés</target>
-        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="24ade348bc49c69cced4d173e31f7369aa466772" resname="action : supprimer" approved="yes">
         <source>action : supprimer</source>
         <target state="translated">Supprimer</target>
-        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="221">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="222">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b88ca5fbb2e89cb79b08c981283383361be312bf" resname="action:: nouveau panier" approved="yes">
         <source>action:: nouveau panier</source>
@@ -8547,21 +8547,21 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="df2642eaa7386518762050a368f5d2c49a3fe42a" resname="admin::compte-utilisateur activite" approved="yes">
         <source>admin::compte-utilisateur activite</source>
         <target state="translated">Activité</target>
-        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="312">Controller/Admin/UserController.php</jms:reference-file>
-        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="122">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10b0a44531159b40162fd9349abbe2bd21946c3e" resname="admin::compte-utilisateur adresse" approved="yes">
         <source>admin::compte-utilisateur adresse</source>
         <target state="translated">Adresse</target>
-        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="304">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="363">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="87">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e922f2ca7321d1d1f403e937dbf109db04bac722" resname="admin::compte-utilisateur changer mon mot de passe" approved="yes">
         <source>admin::compte-utilisateur changer mon mot de passe</source>
@@ -8571,11 +8571,11 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="218d3257842bd2817f0ba7bcd02f3729c60e591d" resname="admin::compte-utilisateur code postal" approved="yes">
         <source>admin::compte-utilisateur code postal</source>
         <target state="translated">Code postal</target>
-        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="306">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="370">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="94">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc2f858e3323d3baa8be27661724b11ce9c0a57b" resname="admin::compte-utilisateur confirmer la nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur confirmer la nouvelle adresse email</source>
@@ -8595,23 +8595,23 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="d79bdc62fa5ecc611e96fe7ab9f5cf4d4debabae" resname="admin::compte-utilisateur email" approved="yes">
         <source>admin::compte-utilisateur email</source>
         <target state="translated">E-mail</target>
-        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="301">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="335">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="112">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="22">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="452">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d194728e348f759c2a443df96338ba1e2c8adfb5" resname="admin::compte-utilisateur fax" approved="yes">
         <source>admin::compte-utilisateur fax</source>
         <target state="translated">Fax</target>
-        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="309">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="384">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="136">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6e2b9ddcaf97ba5258571cb54935f1ff6b581a2" resname="admin::compte-utilisateur id utilisateur" approved="yes">
         <source>admin::compte-utilisateur id utilisateur</source>
@@ -8623,34 +8623,34 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <target state="translated">Identifiant</target>
         <jms:reference-file line="36">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="19">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
-        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="35">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="188">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f5fe48877b8b43297cc3c999ab84bbe0bd60f5af" resname="admin::compte-utilisateur mot de passe" approved="yes">
         <source>admin::compte-utilisateur mot de passe</source>
         <target state="translated">Mot de passe</target>
-        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="195">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e2d7957bf48ebf857d73e4395e78fa73e193b5d" resname="admin::compte-utilisateur nom" approved="yes">
         <source>admin::compte-utilisateur nom</source>
         <target state="translated">Nom</target>
-        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="299">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="321">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="13">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="444">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dbac236fd2ee8bcce590e0cdc7c4a418885c52b" resname="admin::compte-utilisateur nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur nouvelle adresse email</source>
@@ -8666,42 +8666,42 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="28c517ddecdb662c767290d2e1fa53ef198307fa" resname="admin::compte-utilisateur poste" approved="yes">
         <source>admin::compte-utilisateur poste</source>
         <target state="translated">Poste</target>
-        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="310">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="356">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="108">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eadb6eaa53204a688e4059a35261b6878fda8b37" resname="admin::compte-utilisateur prenom" approved="yes">
         <source>admin::compte-utilisateur prenom</source>
         <target state="translated">Prénom</target>
-        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="300">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="328">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="67">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ee82fdcf687c10dd1e5040a5b84d9a90d079a9a" resname="admin::compte-utilisateur sexe" approved="yes">
         <source>admin::compte-utilisateur sexe</source>
         <target state="translated">Civilité</target>
         <jms:reference-file line="44">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="78b65792aca82024d5f1ff60dec83a501c01e15e" resname="admin::compte-utilisateur societe" approved="yes">
         <source>admin::compte-utilisateur societe</source>
         <target state="translated">Société</target>
-        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="311">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="349">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="107">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="16">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="493">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d15ba95c86a58884d598415b8f8a400ab636cd9" resname="admin::compte-utilisateur tel" approved="yes">
         <source>admin::compte-utilisateur tel</source>
@@ -8713,10 +8713,10 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
         <target state="translated">Téléphone</target>
         <jms:reference-file line="308">Controller/Admin/UserController.php</jms:reference-file>
         <jms:reference-file line="342">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="19">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="510">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="29d3952c833272679cb313988c698f11cb6bbb64" resname="admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer" approved="yes">
         <source>admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer</source>
@@ -8726,11 +8726,11 @@ Pour les utilisateurs authentifiés, la demande de validation est également dis
       <trans-unit id="00a39eeb4e86af2189a6080e16418d249d98a12b" resname="admin::compte-utilisateur ville" approved="yes">
         <source>admin::compte-utilisateur ville</source>
         <target state="translated">Ville</target>
-        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="305">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="377">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="101">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f752312fcd370b6547b296ca173da51487a2c5d" resname="admin::compte-utilisateur: L'email a correctement ete mis a jour" approved="yes">
         <source>admin::compte-utilisateur: L'email a correctement ete mis a jour</source>
@@ -8820,24 +8820,24 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <target state="translated">Mme</target>
         <jms:reference-file line="50">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="314">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="50">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7af00728508b30971b5cd3eb769433546ad9abfa" resname="admin::compte-utilisateur:sexe: mademoiselle" approved="yes">
         <source>admin::compte-utilisateur:sexe: mademoiselle</source>
         <target state="translated">Mlle</target>
         <jms:reference-file line="49">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="313">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="47">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db663dadd7bd9b045a68cafcfe2ca4e0c832e50a" resname="admin::compte-utilisateur:sexe: monsieur" approved="yes">
         <source>admin::compte-utilisateur:sexe: monsieur</source>
         <target state="translated">M.</target>
         <jms:reference-file line="51">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="315">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="53">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cfc904c9a87afe2d3986041a6bdb542298607880" resname="admin::monitor: bases sur lesquelles l'utilisateur est connecte :" approved="yes">
         <source>admin::monitor: bases sur lesquelles l'utilisateur est connecte :</source>
@@ -8920,10 +8920,10 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="14e4b19f7496c10dbb05e61dee0c436c0792235f" resname="admin::monitor: module validation" approved="yes">
         <source>admin::monitor: module validation</source>
         <target state="translated">Lightbox</target>
+        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="207">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="238">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="315">Phrasea/Controller/LightboxController.php</jms:reference-file>
-        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="85">lib/classes/phrasea.php</jms:reference-file>
         <jms:reference-file line="78">web/common/menubar.html.twig</jms:reference-file>
       </trans-unit>
@@ -9614,6 +9614,17 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <target state="translated">Test de connexion avec Expose (non implémenté)</target>
         <jms:reference-file line="69">admin/phraseanet-service/expose.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="6d3478b79db541608a0ba8e3877cba7c52256add" resname="admin:searchengine:aggregates:New field, please confirm setting.">
+        <source>admin:searchengine:aggregates:New field, please confirm setting.</source>
+        <target state="new">admin:searchengine:aggregates:New field, please confirm setting.</target>
+        <jms:reference-file line="146">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="157">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="b6dee9dc48adef7fe2f3a1e52b98e7a009fef83d" resname="admin:searchengine:aggregates:This field does not exists in current databoxes.">
+        <source>admin:searchengine:aggregates:This field does not exists in current databoxes.</source>
+        <target state="new">admin:searchengine:aggregates:This field does not exists in current databoxes.</target>
+        <jms:reference-file line="136">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8f3cd845b8adbcdf064486cdd24733f53bce8bb3" resname="admin:worker Retrieve configuration error" approved="yes">
         <source>admin:worker Retrieve configuration error</source>
         <target state="translated">Erreur lors de la récupération de la configuration des workers</target>
@@ -9622,8 +9633,8 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="8f1dba76b561684930a25a984046b3b4149785ca" resname="alert" approved="yes">
         <source>alert</source>
         <target state="translated">Alerte</target>
-        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="306">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="edde11c24ed5e6df4e416143e77248e908567faa" resname="all caches services have been flushed" approved="yes">
         <source>all caches services have been flushed</source>
@@ -9695,14 +9706,14 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="e2c1d05cc230f0bd66de9600c3304eaf374ffa24" resname="basket:action:delete record form basket" approved="yes">
         <source>basket:action:delete record form basket</source>
         <target state="translated">Retirer du panier</target>
-        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="378b261cf0bdda80ad072999d7bed4361180c838" resname="basket:action:delete record form database" approved="yes">
         <source>basket:action:delete record form database</source>
         <target state="translated">Supprimer l'enregistrement de la base</target>
-        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="79">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c501b5741b2a182f189a0ee99109f2a55fd2aaa8" resname="basket:feedback Delete item" approved="yes">
         <source>basket:feedback Delete item</source>
@@ -9745,48 +9756,48 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <jms:reference-file line="250">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="404">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="487">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
+        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
         <jms:reference-file line="119">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="69">web/thesaurus/import-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="228">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="653">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1054">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1173">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
-        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
-        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c6f716e883e5747e4bc8a8afc7a0ec1ccf44e0b5" resname="boutton::appliquer" approved="yes">
         <source>boutton::appliquer</source>
         <target state="translated">Appliquer</target>
-        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="40">WorkerManager/Form/WorkerConfigurationType.php</jms:reference-file>
+        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="43">WorkerManager/Form/WorkerPullAssetsType.php</jms:reference-file>
         <jms:reference-file line="77">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb7084f3be2ac7d8cf870a9bb83df976dc65ad5b" resname="boutton::chercher" approved="yes">
         <source>boutton::chercher</source>
         <target state="translated">Chercher</target>
-        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="126">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="61">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a71090794c12d5b26f62d9f0c68c0d894f7e00e" resname="boutton::choisir" approved="yes">
         <source>boutton::choisir</source>
@@ -9808,14 +9819,14 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="32e5c3419a0a410255ee44e462fd7329f708873f" resname="boutton::demarrer" approved="yes">
         <source>boutton::demarrer</source>
         <target state="translated">Diaporama</target>
-        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="9">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d49d2b52ce2f1912f7ada4a3f57ab39fd2e9904e" resname="boutton::editer" approved="yes">
         <source>boutton::editer</source>
         <target state="translated">Editer</target>
-        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="26">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6b126c214de4c40550d9dc32b02766809b1cac1a" resname="boutton::enregistrer" approved="yes">
         <source>boutton::enregistrer</source>
@@ -9843,16 +9854,16 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <target state="translated">Fermer</target>
         <jms:reference-file line="59">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="90">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="23">web/lightbox/sc_note.html.twig</jms:reference-file>
-        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
+        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
         <jms:reference-file line="45">web/thesaurus/link-field-step3.html.twig</jms:reference-file>
         <jms:reference-file line="115">web/thesaurus/accept.html.twig</jms:reference-file>
         <jms:reference-file line="129">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce91bb36902944da7788997865b8c482a59e80fe" resname="boutton::generer" approved="yes">
         <source>boutton::generer</source>
@@ -9867,9 +9878,9 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="1e4c65d295605a0e884818b5c06d32a63fd692d5" resname="boutton::modifier" approved="yes">
         <source>boutton::modifier</source>
         <target state="translated">Modifier</target>
-        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
-        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="1">Bridge/Dailymotion/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="65">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef6ccc2669466ac98a3d580bd7bab8f33d0e4bcc" resname="boutton::monter" approved="yes">
@@ -9880,22 +9891,22 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="a6083d9bc73ab5df12f4949b67577186f6e8c240" resname="boutton::pause" approved="yes">
         <source>boutton::pause</source>
         <target state="translated">Pause</target>
-        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="28bb622fa0fe835d89deb626494ce572cbd27072" resname="boutton::precedent" approved="yes">
         <source>boutton::precedent</source>
         <target state="translated">précédent</target>
+        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="426">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="516">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="629">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="696">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="754">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="866">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ac4cff651bd34d7b0f295259a0c0907d6af5cd1" resname="boutton::rechercher" approved="yes">
         <source>boutton::rechercher</source>
@@ -9926,26 +9937,26 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="e0af1d0d7872c48928d4faef76c45567426e62f9" resname="boutton::retour" approved="yes">
         <source>boutton::retour</source>
         <target state="translated">Retour</target>
-        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="28">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="20">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
+        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
+        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="223">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
         <jms:reference-file line="50">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
         <jms:reference-file line="162">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
+        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a7a9651d909792bcf98f2d1e96c43cb1d3a618e4" resname="boutton::retry" approved="yes">
         <source>boutton::retry</source>
@@ -9955,55 +9966,55 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="bd9ec3151bdf1eae02e402222d4e36949525a27f" resname="boutton::suivant" approved="yes">
         <source>boutton::suivant</source>
         <target state="translated">suivant</target>
+        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="365">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="429">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="519">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="632">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="699">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="757">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a83f74309cdfc79345f54eb1f4e4e2747316f820" resname="boutton::supprimer" approved="yes">
         <source>boutton::supprimer</source>
         <target state="translated">Supprimer</target>
         <jms:reference-file line="43">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
-        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
-        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="35">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
+        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="93">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="136">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="151">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="176">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="201">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="410">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="68b702f13ff62025c57948bf5c4a5b47af10dee9" resname="boutton::telecharger" approved="yes">
         <source>boutton::telecharger</source>
         <target state="translated">Télécharger</target>
         <jms:reference-file line="160">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="21">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4288c5788ee74d7fa3f325987a8e752687b43023" resname="boutton::telecharger tous les documents" approved="yes">
         <source>boutton::telecharger tous les documents</source>
         <target state="translated">Tout télécharger</target>
-        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="99">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a14c32cf4cd3784ed567e115f3ef016ad2ee2265" resname="boutton::tester" approved="yes">
         <source>boutton::tester</source>
@@ -10015,57 +10026,57 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <source>boutton::valider</source>
         <target state="translated">Valider</target>
         <jms:reference-file line="49">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="886">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="70">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="19">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
         <jms:reference-file line="351">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="373">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Update.html.twig</jms:reference-file>
+        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
         <jms:reference-file line="130">admin/collection/suggested_value.html.twig</jms:reference-file>
-        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="46">admin/collection/create.html.twig</jms:reference-file>
         <jms:reference-file line="58">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
-        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
-        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="41">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
         <jms:reference-file line="159">admin/statusbit/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
+        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
+        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
+        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="34">mobile/lightbox/note_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b27b98c3e0119082312d402ca0b89dd39f00f5c8" resname="boutton::vue graphique" approved="yes">
@@ -10260,8 +10271,8 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="dbfe8cf37a8d7b4941dd9f89e79302038b2bedef" resname="dans %feed_name%" approved="yes">
         <source>dans %feed_name%</source>
         <target state="translated">dans %feed_name%</target>
-        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="52">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aab7fdd9c18941cbc8d78fa0c690361ffd8c50bf" resname="date dajout" approved="yes">
         <source>date dajout</source>
@@ -10310,10 +10321,10 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="9ead47a82a0d25985f22f10651d1f93b3abba317" resname="edit" approved="yes">
         <source>edit</source>
         <target state="translated">Editer</target>
-        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="32">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="143">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="164">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd35f7126454c3af225a579bd27f89176be81c3d" resname="edit: chosiir limage du regroupement" approved="yes">
         <source>edit: chosiir limage du regroupement</source>
@@ -10637,12 +10648,12 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="0d25ab4ea387d19f49a120acb928c7f9500b0cf3" resname="index::advance_search: disable-facet" approved="yes">
         <source>index::advance_search: disable-facet</source>
         <target state="translated">Ne pas afficher les facettes contenant un seul résultat (expérimental)</target>
-        <jms:reference-file line="911">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="16b1c68bd21754876991dfc8df38b024383fbca4" resname="index::advance_search: facet" approved="yes">
         <source>index::advance_search: facet</source>
         <target state="translated">Préférences sur les facettes</target>
-        <jms:reference-file line="907">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="909">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f830d57f4cedb2a49c7b109f9b91b0f8ba83e8b" resname="index::advance_search: facet-order" approved="yes">
         <source>index::advance_search: facet-order</source>
@@ -10662,7 +10673,7 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="dfb02fcdeb804315cd6ad8388efcfb4ccc4abf38" resname="index::advance_search: hidden-facet-values-order" approved="yes">
         <source>index::advance_search: hidden-facet-values-order</source>
         <target state="translated">Facettes masquées</target>
-        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="921">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a35cc75d1072f7dad99c8e91596298f55f20a54" resname="index::advance_search: order-by-hits" approved="yes">
         <source>index::advance_search: order-by-hits</source>
@@ -10673,6 +10684,11 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <source>index::advance_search: order-by-hits-asc</source>
         <target state="translated">Par occurrences asc</target>
         <jms:reference-file line="256">web/prod/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ea214aed2c346724c9b874431706654f560585b6" resname="index::advance_search: show-unset-field-facet">
+        <source>index::advance_search: show-unset-field-facet</source>
+        <target state="new">index::advance_search: show-unset-field-facet</target>
+        <jms:reference-file line="918">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1039a002699408da4c4fe74638a6b44f60499069" resname="index:advanced-preferences:: use truncation" approved="yes">
         <source>index:advanced-preferences:: use truncation</source>
@@ -10727,9 +10743,9 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="49956c0a16703da1e642ef7ea5f5d56ddb026c9b" resname="lightbox::recaptitulatif" approved="yes">
         <source>lightbox::recaptitulatif</source>
         <target state="translated">Récapitulatif</target>
-        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
         <jms:reference-file line="96">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="95">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e96c3b316d4e505d764d209e1074dcd059e396c3" resname="lightbox::see_less_basket" approved="yes">
@@ -10841,8 +10857,8 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="46f7a3bb71222626147c7e64c6a59a3f4c3d8e42" resname="login::notification: Mise a jour du mot de passe avec succes" approved="yes">
         <source>login::notification: Mise a jour du mot de passe avec succes</source>
         <target state="translated">Mise à jour du mot de passe effectuée</target>
-        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
         <jms:reference-file line="67">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28dd2416483329c548279196d0c60f722578632f" resname="login::notification: demande de confirmation par mail envoyee" approved="yes">
         <source>login::notification: demande de confirmation par mail envoyee</source>
@@ -10932,15 +10948,15 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <source>no</source>
         <target state="translated">Non</target>
         <jms:reference-file line="91">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="14">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6c632badea2664bc707979fac5e58072b6a2feba" resname="no image selected" approved="yes">
         <source>no image selected</source>
         <target state="translated">Aucune image sélectionnée</target>
-        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="307">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37031f99ac78580c9f82e04fa237d295ea10ca41" resname="non" approved="yes">
         <source>non</source>
@@ -10951,10 +10967,10 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="a81b09d9521597ebcaf0cc8b49ad7a8be8e4cc61" resname="notice" approved="yes">
         <source>notice</source>
         <target state="translated">Notice</target>
-        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="77">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cafe5f11d6a3b26e59f28454d0ad90a951c64a6a" resname="nouveau" approved="yes">
         <source>nouveau</source>
@@ -11225,7 +11241,7 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="0259e4e17a1f2697d4f4f0108080276a5d7573de" resname="original logo" approved="yes">
         <source>original logo</source>
         <target state="translated">Logo d'origine</target>
-        <jms:reference-file line="23">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5898fc860300e228dcd54c0b1045b5fa0dcda502" resname="oui" approved="yes">
         <source>oui</source>
@@ -11302,8 +11318,8 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="9069777ad6c5ece82d14a23d39082acba0873d60" resname="paniers::description du nouveau panier" approved="yes">
         <source>paniers::description du nouveau panier</source>
         <target state="translated">Donner une description au nouveau panier</target>
-        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="647fb4052fcefc4f2cbbe79aa1a04e8acbd37f59" resname="par %user_name%" approved="yes">
         <source>par %user_name%</source>
@@ -11323,7 +11339,7 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="ead5a6379197deb9163d2101354822e6caaa30eb" resname="personalize logo" approved="yes">
         <source>personalize logo</source>
         <target state="translated">Personnaliser le logo</target>
-        <jms:reference-file line="24">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f16110620b1971f58336063cbdb64df7e0e0c7ac" resname="pertinence" approved="yes">
         <source>pertinence</source>
@@ -11333,7 +11349,7 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="da819bd8e531681e8cc8b0c5f30da694b7ffe03c" resname="php.ini path" approved="yes">
         <source>php.ini path</source>
         <target state="translated">Chemin du répertoire de fichier php.ini</target>
-        <jms:reference-file line="44">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4827b7c0fd9fb14fc29a808b020353c744b83978" resname="phraseanet:: Creer une base sur un serveur different de l'application box" approved="yes">
         <source>phraseanet:: Creer une base sur un serveur different de l'application box</source>
@@ -11374,11 +11390,11 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="8039b17c124d6907eb83dc8b705888769f45d82d" resname="phraseanet:: adresse" approved="yes">
         <source>phraseanet:: adresse</source>
         <target state="translated">Adresse</target>
-        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="31">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="89">web/admin/connected-users.html.twig</jms:reference-file>
-        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a934108e5aa19f91fafd6eb9ee20b00bc248bab9" resname="phraseanet:: aide" approved="yes">
         <source>phraseanet:: aide</source>
@@ -11467,8 +11483,8 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="da1f4cb9f98aef274dbb8f5992dedaf20e91ea71" resname="phraseanet:: preview" approved="yes">
         <source>phraseanet:: preview</source>
         <target state="translated">Prévisualisation</target>
-        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
         <jms:reference-file line="267">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2baca947f8536e2ff6bab1c45c1876c04706a6a0" resname="phraseanet:: propositions" approved="yes">
         <source>phraseanet:: propositions</source>
@@ -11485,19 +11501,19 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="99a70ecaddc20d59056e5d479c6fa9d0bc113a0e" resname="phraseanet:: sous definition" approved="yes">
         <source>phraseanet:: sous definition</source>
         <target state="translated">Sous-définition</target>
-        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="93">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c33ce7e20779d5b34c1c812406e2f22b779a45d0" resname="phraseanet:: thesaurus" approved="yes">
         <source>phraseanet:: thesaurus</source>
         <target state="translated">Thésaurus</target>
-        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/index.html.twig</jms:reference-file>
         <jms:reference-file line="11">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
-        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b6022bf4291f5e9d7d7051fe6c3d6a6abbd92c1a" resname="phraseanet:: tri" approved="yes">
         <source>phraseanet:: tri</source>
@@ -11507,10 +11523,10 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="771634fc3ec89c0a08c7666e776fc5db3072f318" resname="phraseanet:: tri par date" approved="yes">
         <source>phraseanet:: tri par date</source>
         <target state="translated">Tri par date</target>
-        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="318">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="320">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="321">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db34986ff3eb1fd0e90f897a97eaf52ea6708600" resname="phraseanet:: tri par nom" approved="yes">
         <source>phraseanet:: tri par nom</source>
@@ -11584,9 +11600,9 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <source>phraseanet::chargement</source>
         <target state="translated">Chargement</target>
         <jms:reference-file line="48">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="278">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="34">admin/collection/suggested_value.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="70c4053d038cd11fa8fcb91bf79e580b89fad194" resname="phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible" approved="yes">
         <source>phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible</source>
@@ -11604,8 +11620,8 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
         <source>phraseanet::erreur: Votre session est fermee, veuillez vous re-authentifier</source>
         <target state="translated">Votre session a expiré. Veuillez vous ré-authentifier</target>
         <jms:reference-file line="38">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="754677fa0aa06c7f10237a728e6f33eaea06d42b" resname="phraseanet::erreur: echec du serveur de mail" approved="yes">
         <source>phraseanet::erreur: echec du serveur de mail</source>
@@ -11753,35 +11769,35 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="fdb5ea435d0e0d2d8e9dc7e2dc925c031406385c" resname="preview:: Description" approved="yes">
         <source>preview:: Description</source>
         <target state="translated">Notice</target>
-        <jms:reference-file line="954">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="963">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="424597224c5d2322b6e8db99037234f7b2641de0" resname="preview:: Historique" approved="yes">
         <source>preview:: Historique</source>
         <target state="translated">Historique</target>
-        <jms:reference-file line="955">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="964">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="74e09022ffbf0d295142654902e9d7a007f209a5" resname="preview:: Popularite" approved="yes">
         <source>preview:: Popularite</source>
         <target state="translated">Popularité</target>
-        <jms:reference-file line="958">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="967">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9c61385964471a1171066ba2ba3622a98ffb84b" resname="preview:: arreter le diaporama" approved="yes">
         <source>preview:: arreter le diaporama</source>
         <target state="translated">Arrêter</target>
-        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="96">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="62">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77a36033b8fdccc947d744ae8e3120c7d8dafa46" resname="preview:: demarrer le diaporama" approved="yes">
         <source>preview:: demarrer le diaporama</source>
         <target state="translated">Diaporama</target>
-        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="94">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="60">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a5cc2b2cd9b0421d131185277e9005d8e616582c" resname="preview::date" approved="yes">
         <source>preview::date</source>
@@ -11810,7 +11826,7 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="2b03b2c44ce1a3c17af6b603d666344f64ebe942" resname="preview::tab:feedback" approved="yes">
         <source>preview::tab:feedback</source>
         <target state="translated">Validation</target>
-        <jms:reference-file line="956">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="965">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7f27fe47e2d3556c660a6fade6ceba7e8e62c4c" resname="preview::tab:feedback closed" approved="yes">
         <source>preview::tab:feedback closed</source>
@@ -11978,20 +11994,20 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="98ab0e2a8cf4a7c9f6952361e6c750a8009b70a5" resname="prive" approved="yes">
         <source>prive</source>
         <target state="translated">Privé</target>
-        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="79">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="039db3240f9c47314f5b8f05835c54795f45324e" resname="privé" approved="yes">
         <source>privé</source>
         <target state="translated">Privé</target>
-        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="60">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6dd8429cc900b9460f1e9d4be6155a6ee1b6de42" resname="processing" approved="yes">
         <source>processing</source>
         <target state="translated">En cours...</target>
-        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="308">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f63658cad863dee4a5876278e836472380183ade" resname="prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble" approved="yes">
         <source>prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble</source>
@@ -12007,7 +12023,7 @@ Si vous recevez cet e-mail sans l'avoir sollicité, merci de l'ignorer ou de le 
       <trans-unit id="f8877a3e5fa41e324ef59243c175353144990647" resname="prod::action:property title" approved="yes">
         <source>prod::action:property title</source>
         <target state="translated">Propriétés</target>
-        <jms:reference-file line="1044">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1053">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef27ad74061e0e15683e84dec7f5559f7797637f" resname="prod::advancesearch:tooltips:datefield_restriction_explanation" approved="yes">
         <source>prod::advancesearch:tooltips:datefield_restriction_explanation</source>
@@ -12175,8 +12191,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="021da4e7ad79ba6ef0855ecca3539db02b2d12f9" resname="prod::export: send mail notification" approved="yes">
         <source>prod::export: send mail notification</source>
         <target state="translated">Demande d'envois d'email soumise</target>
+        <jms:reference-file line="1059">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="18">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="1050">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb08c63b1c016e31a255a38795c8e4cb66b0e66e" resname="prod::facet:base_label" approved="yes">
         <source>prod::facet:base_label</source>
@@ -12201,7 +12217,7 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="47f76b5a8ec06b165c0d83ed447999def6f368e4" resname="prod::notification: notification title" approved="yes">
         <source>prod::notification: notification title</source>
         <target state="translated">Notifications</target>
-        <jms:reference-file line="1046">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1055">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd532704ccd19891fe39fc3e14235cbfa6b79abf" resname="prod::publication:title" approved="yes">
         <source>prod::publication:title</source>
@@ -12211,17 +12227,17 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="5fa97d7a05eb572c80ae0ccf85be3a27dcddb943" resname="prod::push: List name can not be empty" approved="yes">
         <source>prod::push: List name can not be empty</source>
         <target state="translated">Le nom de la liste doit être rempli</target>
-        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1057">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2682250f21be2e6ce7e89ab678c50a394191206a" resname="prod::push: New list title" approved="yes">
         <source>prod::push: New list title</source>
         <target state="translated">Nouvelle liste</target>
-        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1056">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="19aeacc47cb48d5ae39c216aa0d456ac0f2ea55d" resname="prod::push: add" approved="yes">
         <source>prod::push: add</source>
         <target state="translated">Ajouter</target>
-        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1058">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dee7c522bf9e0eea45e003fb4d0f736bc251a954" resname="prod::push:push_set_title" approved="yes">
         <source>prod::push:push_set_title</source>
@@ -12366,19 +12382,19 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="6ad73c8fd370f62ccd3bf50cd9cc3563aed5273c" resname="prod::tools: document" approved="yes">
         <source>prod::tools: document</source>
         <target state="translated">Document</target>
-        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
         <jms:reference-file line="74">Controller/Prod/ToolsController.php</jms:reference-file>
+        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e36d93428a247d085ffbb974db21290395643463" resname="prod::videoTools:chapterTitle" approved="yes">
         <source>prod::videoTools:chapterTitle</source>
         <target state="translated">Titre du chapitre</target>
-        <jms:reference-file line="1042">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1051">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4dc1d766c992fbd57317a321602272b20469a64" resname="prod::workzone:Actions" approved="yes">
         <source>prod::workzone:Actions</source>
         <target state="translated">Actions</target>
-        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6140f86d00814c5627728413d43421ce867c11db" resname="prod::workzone:feedback add user">
         <source>prod::workzone:feedback add user</source>
@@ -12594,8 +12610,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="a2a8888f67982de346cedbe03b5884757de77925" resname="prod:expose:publication:Parent Publication" approved="yes">
         <source>prod:expose:publication:Parent Publication</source>
         <target state="translated">Publication parente</target>
-        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/ExposeNew.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="41">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d190364e0bc239d60124d5a906249199fcedbcf7" resname="prod:expose:publication:Password" approved="yes">
@@ -12935,13 +12951,18 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
         <target state="translated">Supprimer le filtre</target>
         <jms:reference-file line="218">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="9fb38743f0e67ac389f4d31a55eff4ec5acac703" resname="prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)">
+        <source>prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</source>
+        <target state="new">prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</target>
+        <jms:reference-file line="59">Elastic/Search/FacetsResponse.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="61c9b2b17db77a27841bbeeabff923448b0f6388" resname="public" approved="yes">
         <source>public</source>
         <target state="translated">Public</target>
-        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="64">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9647ab4603346566d2218fda731606baafcbe408" resname="publication : autheur" approved="yes">
         <source>publication : autheur</source>
@@ -13049,11 +13070,11 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="1d740fd7fe206b5e6e57bef828e876a1bc484dd5" resname="rafraichir" approved="yes">
         <source>rafraichir</source>
         <target state="translated">Rafraîchir</target>
+        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/results/feeds.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/results/feeds.html.twig</jms:reference-file>
-        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
-        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0dea865dcd106d77e52ea8bffe6f87e2add0ac53" resname="recordtype" approved="yes">
         <source>recordtype</source>
@@ -13242,8 +13263,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
         <source>report:: Connexion</source>
         <target state="translated">Connexions</target>
         <jms:reference-file line="666">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="afa9685c95f7dff29cb2ad048da368c6e3dbadbc" resname="report:: Databox content" approved="yes">
         <source>report:: Databox content</source>
@@ -13318,14 +13339,14 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="48808e405192603e079ef1ccbbc1a1df98e317bd" resname="report:: collections" approved="yes">
         <source>report:: collections</source>
         <target state="translated">Collections</target>
-        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="96">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a1193a920be0725a4560344ca10db36147ffd34" resname="report:: commentaire" approved="yes">
         <source>report:: commentaire</source>
         <target state="translated">Commentaire</target>
-        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="99">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="51f822380b654c4fc5adb28eb0643f37aac0d89b" resname="report:: copyright" approved="yes">
         <source>report:: copyright</source>
@@ -13335,9 +13356,9 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="cf3a5321aa85f0706b89021206bd8cd1ad57da54" resname="report:: date" approved="yes">
         <source>report:: date</source>
         <target state="translated">Date</target>
+        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="669">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="670">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e125eaf6fca2110f86b6ebba60371a4875c87e03" resname="report:: document ajoute" approved="yes">
         <source>report:: document ajoute</source>
@@ -13388,21 +13409,21 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="26d00286d5aecf7cfda0e1395c4208440409b8c0" resname="report:: non-renseigne" approved="yes">
         <source>report:: non-renseigne</source>
         <target state="translated">Non-Renseigné</target>
-        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
-        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
+        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
+        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
         <jms:reference-file line="117">module/report/validate.php</jms:reference-file>
+        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
+        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="411">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="508">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="520">module/report/activity.php</jms:reference-file>
-        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
         <jms:reference-file line="117">module/report/sent.php</jms:reference-file>
-        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
         <jms:reference-file line="161">module/report/download.php</jms:reference-file>
-        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
-        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
         <jms:reference-file line="110">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="118">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="123">module/report/connexion.php</jms:reference-file>
+        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="07c06c0cac8bd3e3507a72d6cb7fa1ee23a6bf13" resname="report:: page d'accueil" approved="yes">
         <source>report:: page d'accueil</source>
@@ -13434,9 +13455,9 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="8df95f5dffb705018ebae64a4850f1f93bafc098" resname="report:: question" approved="yes">
         <source>report:: question</source>
         <target state="translated">Questions</target>
-        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="43">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b9ef4ecd16724b3218cf46f9956b8b157498c3a1" resname="report:: questions" approved="yes">
         <source>report:: questions</source>
@@ -13456,8 +13477,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="8fb18670b89f5cefede425401428a70189f654ea" resname="report:: record id" approved="yes">
         <source>report:: record id</source>
         <target state="translated">recordId</target>
-        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="90">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a11e1e1373aae28668cdf7a08486e767283bbaa2" resname="report:: resolution" approved="yes">
         <source>report:: resolution</source>
@@ -13737,7 +13758,7 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="44a5de1cdcf30547c937f197cd3d58e143de62a6" resname="setup::custom-link:help-menu" approved="yes">
         <source>setup::custom-link:help-menu</source>
         <target state="translated">Menu «Aide»</target>
-        <jms:reference-file line="58">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0286ea45f1074802cfe8fbf84b7c439fb287d0de" resname="setup::custom-link:language-link" approved="yes">
         <source>setup::custom-link:language-link</source>
@@ -13752,7 +13773,7 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="2de3bc78c6fb26b56dd934a81dc76afdba8c79ab" resname="setup::custom-link:location" approved="yes">
         <source>setup::custom-link:location</source>
         <target state="translated">Sélectionner un emplacement</target>
-        <jms:reference-file line="57">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4db79dfecabb4b9acb44a4b49e9b6b433b28d04" resname="setup::custom-link:location-link" approved="yes">
         <source>setup::custom-link:location-link</source>
@@ -13762,13 +13783,13 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="ccfe45428ee9769a865d3d90c0e4dc50a6b68e9c" resname="setup::custom-link:name-link" approved="yes">
         <source>setup::custom-link:name-link</source>
         <target state="translated">Nom du lien</target>
-        <jms:reference-file line="23">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="97">web/admin/setup.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fdecb6454c7adeaeb05bac7f574ee70884900ca2" resname="setup::custom-link:navigation-bar" approved="yes">
         <source>setup::custom-link:navigation-bar</source>
         <target state="translated">Barre de navigation</target>
-        <jms:reference-file line="59">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4696021003b181f9acc9261382e07364c6b83036" resname="setup::custom-link:order-link" approved="yes">
         <source>setup::custom-link:order-link</source>
@@ -13778,12 +13799,12 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="1b09a3a0a8b0205f23b3fe59074f8dfd72d0b0ae" resname="setup::custom-link:placeholder-link-url" approved="yes">
         <source>setup::custom-link:placeholder-link-url</source>
         <target state="translated">ex: https://docs.phraseanet.com</target>
-        <jms:reference-file line="47">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="52">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a1380c70f5190d6c0c38214fe24ac99272ef7bd2" resname="setup::custom-link:select-language" approved="yes">
         <source>setup::custom-link:select-language</source>
         <target state="translated">Choisir une langue d'affichage</target>
-        <jms:reference-file line="34">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67572283912404fe90681e8566d880e1fd10d58e" resname="setup::custom-link:title-custom-link" approved="yes">
         <source>setup::custom-link:title-custom-link</source>
@@ -13823,8 +13844,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="9fef1c0f1a70c8bc024e6691f1584083c27d2b13" resname="status:: numero de bit" approved="yes">
         <source>status:: numero de bit</source>
         <target state="translated">Status n°</target>
-        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="802c606a20e093fac7d2b5a45d947a4dff96e628" resname="status:: retrouver sous forme de filtre dans la recherche" approved="yes">
         <source>status:: retrouver sous forme de filtre dans la recherche</source>
@@ -13989,8 +14010,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="c8eadb101df19fb4960c791cf1afaa49d3516feb" resname="task::ftp:proxy" approved="yes">
         <source>task::ftp:proxy</source>
         <target state="translated">Proxy</target>
-        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="5">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d50701eb37a2e5b7dfe3358ba91ff9a1cc6f10ef" resname="task::ftp:proxy password" approved="yes">
         <source>task::ftp:proxy password</source>
@@ -14000,8 +14021,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="a7e5c84ff2404f76423afe64d0f5b8fbea07c024" resname="task::ftp:proxy port" approved="yes">
         <source>task::ftp:proxy port</source>
         <target state="translated">Port</target>
-        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="11">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d927a070b462263321072111c64cc0505c9d14" resname="task::ftp:proxy user" approved="yes">
         <source>task::ftp:proxy user</source>
@@ -14103,8 +14124,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="416134a1966f12f8d23f9f54f3cc32ea43ef3e46" resname="thesaurus:: Lier la branche de thesaurus au champ" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ</source>
         <target state="translated">Lier la branche de thesaurus au champ</target>
-        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="213a599ea75e45b7e28a260a71b032b3e3601e2b" resname="thesaurus:: Lier la branche de thesaurus au champ %branch%" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ %branch%</source>
@@ -14114,9 +14135,9 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="227338ab622537da92490cedc6709de0b9122e56" resname="thesaurus:: Nouveau synonyme" approved="yes">
         <source>thesaurus:: Nouveau synonyme</source>
         <target state="translated">Nouveau synonyme</target>
+        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
         <jms:reference-file line="1050">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6bec8860c3453260869cea4fb043fac543cf724" resname="thesaurus:: Nouveau terme" approved="yes">
         <source>thesaurus:: Nouveau terme</source>
@@ -14126,8 +14147,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="ef0a054e6da228e6ad009d469c4bdf31b1de7999" resname="thesaurus:: Nouveau terme specifique" approved="yes">
         <source>thesaurus:: Nouveau terme specifique</source>
         <target state="translated">Nouveau terme spécifique</target>
-        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="261cd0e03ca27d32466be99d5cd9a0426d3a508c" resname="thesaurus:: Proprietes" approved="yes">
         <source>thesaurus:: Proprietes</source>
@@ -14149,8 +14170,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="f56e32a67c0a47d74d3441e499bfe64858ffee36" resname="thesaurus:: accepter..." approved="yes">
         <source>thesaurus:: accepter...</source>
         <target state="translated">Accepter</target>
-        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="10">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c56e1002fd59b3fed0108426b7926f3252d9fc8d" resname="thesaurus:: afficher les termes refuses" approved="yes">
         <source>thesaurus:: afficher les termes refuses</source>
@@ -14265,15 +14286,15 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
         <target state="translated">Texte</target>
         <jms:reference-file line="5">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="85">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-text.html.twig</jms:reference-file>
+        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8ec3584a75e01816472150b1c24268c9612dd51" resname="thesaurus:: export en topics" approved="yes">
         <source>thesaurus:: export en topics</source>
         <target state="translated">Thèmes</target>
+        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="1233">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-topics.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a09dafb2a5c9c7200a3125cca1148346e7bc1843" resname="thesaurus:: exporter" approved="yes">
         <source>thesaurus:: exporter</source>
@@ -14668,8 +14689,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="1118f7e206d8ec4d92392f3e8c2804b156b3a082" resname="thumbnail validation" approved="yes">
         <source>thumbnail validation</source>
         <target state="translated">Validation de la vignette</target>
-        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="309">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e96ed809b61066d6ea96ba9afc8747a042b361a" resname="tout le monde" approved="yes">
         <source>tout le monde</source>
@@ -14716,8 +14737,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
         <source>upload:: Status :</source>
         <target state="translated">Appliquer les status</target>
         <jms:reference-file line="80">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
         <jms:reference-file line="462">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4fea0574cc81b5fd40ab0537b0905cc4c3806039" resname="users rights have been reseted" approved="yes">
         <source>users rights have been reseted</source>
@@ -14727,11 +14748,11 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="e204d28a2874f6123747650d3e4003d4357d75eb" resname="validate" approved="yes">
         <source>validate</source>
         <target state="translated">Valider</target>
+        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="120">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="160">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="186">actions/Tools/index.html.twig</jms:reference-file>
-        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c02a2db6d6cdf30d37962e221624cc7661f4b892" resname="validation:: NON" approved="yes">
         <source>validation:: NON</source>
@@ -14797,128 +14818,128 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
       <trans-unit id="ecbe1590a62c751a6bafe631fc5d05158d0962b4" resname="workzone:datepicker:april" approved="yes">
         <source>workzone:datepicker:april</source>
         <target state="translated">Avril</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="23ed9061fbf1a184658e05e57a121a72474b54eb" resname="workzone:datepicker:august" approved="yes">
         <source>workzone:datepicker:august</source>
         <target state="translated">Aout</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e55bc758f272d38198385584d6f50c2dd0eae13" resname="workzone:datepicker:december" approved="yes">
         <source>workzone:datepicker:december</source>
         <target state="translated">Décembre</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db178b383e47bbe58670afd6a67528a4712444d7" resname="workzone:datepicker:february" approved="yes">
         <source>workzone:datepicker:february</source>
         <target state="translated">Février</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4e3f12ef1defef487381a8339ea49840666414a" resname="workzone:datepicker:friday" approved="yes">
         <source>workzone:datepicker:friday</source>
         <target state="translated">Vendredi</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="93f6bd6902114b73c225005188bce87569a3ac9c" resname="workzone:datepicker:january" approved="yes">
         <source>workzone:datepicker:january</source>
         <target state="translated">Janvier</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0f1d297c3d3d9bc7cd800a9bd1a938904f4440ab" resname="workzone:datepicker:july" approved="yes">
         <source>workzone:datepicker:july</source>
         <target state="translated">Juillet</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d860a667674628da86b76fb3be676370a61893c" resname="workzone:datepicker:june" approved="yes">
         <source>workzone:datepicker:june</source>
         <target state="translated">Juin</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2242d17f28dc262529688d688b5c2e128813ad8b" resname="workzone:datepicker:march" approved="yes">
         <source>workzone:datepicker:march</source>
         <target state="translated">Mars</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2ce30e1185f0f46df340ca727d4d9d89f42b6f5b" resname="workzone:datepicker:may" approved="yes">
         <source>workzone:datepicker:may</source>
         <target state="translated">Mai</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a7199e82486037293a2cfb17003ed9a30e2cfb2" resname="workzone:datepicker:monday" approved="yes">
         <source>workzone:datepicker:monday</source>
         <target state="translated">Lundi</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0bbaf1d4dbaa3b5eb27154fcc9579f89c848b091" resname="workzone:datepicker:nextText" approved="yes">
         <source>workzone:datepicker:nextText</source>
         <target state="translated">Suivant</target>
-        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="204">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ba391713621e89b5ecec7bc867e949e386332732" resname="workzone:datepicker:november" approved="yes">
         <source>workzone:datepicker:november</source>
         <target state="translated">Novembre</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46727c5b9b3455e2cec4fc761568262af710f119" resname="workzone:datepicker:october" approved="yes">
         <source>workzone:datepicker:october</source>
         <target state="translated">Octobre</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7eef21d25b8fa0b6940fe6c87640f82612d0393f" resname="workzone:datepicker:prevText" approved="yes">
         <source>workzone:datepicker:prevText</source>
         <target state="translated">Précédent</target>
-        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="203">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d4fa7c1a1d4486201a760bcfb2f342ec8329f00" resname="workzone:datepicker:saturday" approved="yes">
         <source>workzone:datepicker:saturday</source>
         <target state="translated">Samedi</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8aa1e4c6df39f7365a4fab8f3c70d3d8d4757ee" resname="workzone:datepicker:september" approved="yes">
         <source>workzone:datepicker:september</source>
         <target state="translated">Septembre</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd48f23064201336fafcab46a34c085d5a886cb6" resname="workzone:datepicker:sunday" approved="yes">
         <source>workzone:datepicker:sunday</source>
         <target state="translated">Dimanche</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de522dc0285d55c95bb9af4aa39020ac35548353" resname="workzone:datepicker:thursday" approved="yes">
         <source>workzone:datepicker:thursday</source>
         <target state="translated">Jeudi</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d274289f8c48bcb43c06efe9386967b7f8fb56df" resname="workzone:datepicker:tuesday" approved="yes">
         <source>workzone:datepicker:tuesday</source>
         <target state="translated">Mardi</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="423742b6f616f9847ea24afec03e24b15f3ff10f" resname="workzone:datepicker:wednesday" approved="yes">
         <source>workzone:datepicker:wednesday</source>
         <target state="translated">Mercredi</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbfb58c29147c5881e828d18a477f922211873a0" resname="workzone:feedback:expiration-closed" approved="yes">
         <source>workzone:feedback:expiration-closed</source>
@@ -14941,8 +14962,8 @@ Attention: les valeurs actuellement en place seront écrasées par ces nouvelles
         <source>yes</source>
         <target state="translated">Oui</target>
         <jms:reference-file line="89">web/common/technical_datas.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="580">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="76">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="646b0ebbe9829e44e9e99e9ab991a526f758001d" resname="you are about to change the  representation thumbnail of your video" approved="yes">
         <source>you are about to change the  representation thumbnail of your video</source>

--- a/resources/locales/messages.nl.xlf
+++ b/resources/locales/messages.nl.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:31:42Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:55Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,8 +9,8 @@
       <trans-unit id="da39a3ee5e6b4b0d3255bfef95601890afd80709" resname="">
         <source></source>
         <target state="new"></target>
-        <jms:reference-file line="47">Form/Configuration/EmailFormType.php</jms:reference-file>
-        <jms:reference-file line="60">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c03e9a1b443b7d9ac9a84e4d2cf55ebc016a9c5b" resname="                                Add">
         <source>                                Add</source>
@@ -20,73 +20,73 @@
       <trans-unit id="17b36ba11b9598e1ca72638a17637c71db031f8b" resname="#3567c6">
         <source>#3567c6</source>
         <target state="new">#3567c6</target>
-        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="86">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c18097cf04c5f24e6b201e44603c26f000cbf266" resname="#4497d5">
         <source>#4497d5</source>
         <target state="new">#4497d5</target>
-        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="654b7f2144322b13150ca53f8eb712644275fbbb" resname="#5aa53b">
         <source>#5aa53b</source>
         <target state="new">#5aa53b</target>
-        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="81184afa6b2fb59a54a368a94c5af314882f4379" resname="#a1d0d0">
         <source>#a1d0d0</source>
         <target state="new">#a1d0d0</target>
-        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="69760e828adabd5e543638f8b396d108e4e1c7f6" resname="#ad0800">
         <source>#ad0800</source>
         <target state="new">#ad0800</target>
-        <jms:reference-file line="71">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
-        <jms:reference-file line="72">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8868030f047d29838dccd3ebd90a8cbcf5cf97b9" resname="#b151ee">
         <source>#b151ee</source>
         <target state="new">#b151ee</target>
-        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="87">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df800d7d3f6bec2f0c48d7b18ad0f7515b4ed8a4" resname="#b8d84e">
         <source>#b8d84e</source>
         <target state="new">#b8d84e</target>
-        <jms:reference-file line="77">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="82">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d3505d50f73a3440832d861060fc212eb2d929a" resname="#c875ea">
         <source>#c875ea</source>
         <target state="new">#c875ea</target>
-        <jms:reference-file line="83">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="88">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cdd9fb48ed6b38bdf4cd732d30851062312f64b3" resname="#e46990">
         <source>#e46990</source>
         <target state="new">#e46990</target>
-        <jms:reference-file line="84">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="89">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="22a0112b6eafc281d17f1b98fb8405847d01f04b" resname="#f06006">
         <source>#f06006</source>
         <target state="new">#f06006</target>
-        <jms:reference-file line="73">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="78">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db6ca79114142b612eebf0ca5f80b94c80cbf453" resname="#f4ea5b">
         <source>#f4ea5b</source>
         <target state="new">#f4ea5b</target>
-        <jms:reference-file line="76">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="81">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc4fad5f043fc9875dcdc532a296ec359a6c39e1" resname="#f5842b">
         <source>#f5842b</source>
         <target state="new">#f5842b</target>
-        <jms:reference-file line="74">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="79">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="590b78bf59d578b0efdd1a7b1a385e8004fa88e8" resname="#ffc322">
         <source>#ffc322</source>
         <target state="new">#ffc322</target>
-        <jms:reference-file line="75">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="80">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0cc996e2ae03790c84ef6edc0601ba0245d7cf1c" resname="#ffccd7">
         <source>#ffccd7</source>
         <target state="new">#ffccd7</target>
-        <jms:reference-file line="85">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="90">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9378053eb7743587671aa830ffd2c9f1b13ad1a" resname="%ElementsCount% records">
         <source>%ElementsCount% records</source>
@@ -177,28 +177,28 @@
       <trans-unit id="24c43d6925295b9738f6fe69e4fb3dc7a2030f0f" resname="%nb_records% records">
         <source>%nb_records% records</source>
         <target>%nb_records% records</target>
-        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Tooltip/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/Tooltip/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="107">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e39dc3a90b0674916ef22f19912638564f33e518" resname="%nb_view% vue" approved="yes">
         <source>%nb_view% vue</source>
         <target state="translated">%nb_view% weergave</target>
-        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae7480d89dfd1ca0d1732014aee13f9958836bf8" resname="%nb_view% vues" approved="yes">
         <source>%nb_view% vues</source>
         <target state="translated">%nb_view% weergaven</target>
-        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
-        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
         <jms:reference-file line="7">Bridge/Dailymotion/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Youtube/element_informations.html.twig</jms:reference-file>
+        <jms:reference-file line="7">Bridge/Flickr/element_informations.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de0804eb70c10b14d71df74292e45c6daa13d672" resname="%number% documents&lt;br/&gt;selectionnes">
         <source><![CDATA[%number% documents<br/>selectionnes]]></source>
         <target state="new"><![CDATA[%number% documents<br/>selectionnes]]></target>
-        <jms:reference-file line="268">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="263">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac5c6fe2979cfa2496c95dcb218f135fd916040d" resname="%quantity% Stories attached to the WorkZone">
         <source>%quantity% Stories attached to the WorkZone</source>
@@ -279,7 +279,7 @@
       <trans-unit id="f9b19aa0c7cf7aab245692450b473acff6a077e4" resname="%total% reponses">
         <source>%total% reponses</source>
         <target state="new">%total% reponses</target>
-        <jms:reference-file line="316">Controller/Prod/QueryController.php</jms:reference-file>
+        <jms:reference-file line="311">Controller/Prod/QueryController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="99d2e1a7e8d0ba4a7132282b53b15e503b91c2cb" resname="%user% a envoye son rapport de validation de %title%">
         <source>%user% a envoye son rapport de validation de %title%</source>
@@ -384,7 +384,7 @@
       <trans-unit id="4412a659c3e1ca169796ab2f540a932ea7cbe2a4" resname="*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance" approved="yes">
         <source>*Phraseanet Navigator* is a smartphone application that allow user to connect on this instance</source>
         <target state="translated">*Phraseanet Navigator* is ten smartphone applicatie waarmee de gebruiker verbinding maken met op deze instantie</target>
-        <jms:reference-file line="28">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="356a192b7913b04c54574d18c28d46e6395428ab" resname="1">
         <source>1</source>
@@ -526,7 +526,7 @@
       <trans-unit id="62a3ad0fef668c4e2a220f6982de94942fbf1d1e" resname="AR">
         <source>AR</source>
         <target state="new">AR</target>
-        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8887b473975b3b740e5afe559123403a6c219524" resname="About Roles :" approved="yes">
         <source>About Roles :</source>
@@ -625,17 +625,17 @@
       <trans-unit id="c3cd636a585b20c40ac2df5ffb403e83cb2eef51" resname="Actions" approved="yes">
         <source>Actions</source>
         <target state="translated">Acties</target>
-        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="26">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="12">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c4a4f00323184bd750ee72b5c05e6e17d1584bfd" resname="Activate highlight">
         <source>Activate highlight</source>
         <target state="new">Activate highlight</target>
-        <jms:reference-file line="74">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="85">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="682">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a733b809d2f1233496ab516eed0f3ef75cf3791a" resname="Active" approved="yes">
@@ -668,10 +668,10 @@
       <trans-unit id="61cc55aa0453184734c3fa0b621eda6fa874bd83" resname="Add" approved="yes">
         <source>Add</source>
         <target state="translated">Toevoegen</target>
-        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="514">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="515">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/User/Add.html.twig</jms:reference-file>
+        <jms:reference-file line="161">prod/actions/Push.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="983c5aed52d2f74bf36e97dc34dbce97fdd43f5b" resname="Add a&#10;                    new field">
         <source>Add a
@@ -734,7 +734,7 @@
       <trans-unit id="74ab95a4dbfaecbcd1fd586b71d97066ab7431c2" resname="Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.">
         <source>Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.</source>
         <target state="new">Adds an option to the push form submission to restrict push recipient(s) to Phraseanet users only.</target>
-        <jms:reference-file line="52">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="65">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e7afebcfbae000b22c7c85e5560f89a2a0280b4" resname="Admin">
         <source>Admin</source>
@@ -780,22 +780,22 @@
       <trans-unit id="a810fdb68ba89818cce5c607021256e40cf14170" resname="Afficher la fiche descriptive" approved="yes">
         <source>Afficher la fiche descriptive</source>
         <target state="translated">De beschrijvingsfiche tonen</target>
-        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="946bf37a064ede9145bd8e3c7ce50e8608885518" resname="Afficher le titre" approved="yes">
         <source>Afficher le titre</source>
         <target state="translated">De titel tonen</target>
-        <jms:reference-file line="1023">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee793299aa2f135a4330889d59d362d1652fa577" resname="Afficher le type">
         <source>Afficher le type</source>
         <target state="new">Afficher le type</target>
-        <jms:reference-file line="1032">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1041">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7627cf7574df870b584ab3bd8a67d62d7ab4a18b" resname="Afficher les status" approved="yes">
         <source>Afficher les status</source>
         <target state="translated">De statussen tonen</target>
-        <jms:reference-file line="1005">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1014">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="47743dc906e82db1978c23daf01e4d5e727702bd" resname="Afficher une icone" approved="yes">
         <source>Afficher une icone</source>
@@ -830,16 +830,16 @@
       <trans-unit id="5e8a35671080dba23a7f84416dcf97fd975a33e6" resname="Ajouter a" approved="yes">
         <source>Ajouter a</source>
         <target state="translated">Toevoegen aan</target>
-        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="5">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6be348e8c91127640dc04e94dca7d5503ddb6c7d" resname="Ajouter ma selection courrante" approved="yes">
         <source>Ajouter ma selection courrante</source>
         <target state="translated">Voeg mijn huidige selectie toe</target>
+        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
         <jms:reference-file line="15">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/orders/order_item.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/Baskets/Create.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d391a678bc6acf01f3f67c57b07853c5a588171" resname="Ajouter un nouvel utilisateur" approved="yes">
         <source>Ajouter un nouvel utilisateur</source>
@@ -859,7 +859,7 @@
       <trans-unit id="6a72085653e4c5be8c7640c868ef787cbcf063d1" resname="All" approved="yes">
         <source>All</source>
         <target state="translated">Alle</target>
-        <jms:reference-file line="35">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="189">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="199">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="209">actions/Feedback/list.html.twig</jms:reference-file>
@@ -883,7 +883,7 @@
       <trans-unit id="619eebecff3aef2d53d82536ebc2604fb07900e2" resname="Allow the website to be indexed by search engines like Google" approved="yes">
         <source>Allow the website to be indexed by search engines like Google</source>
         <target state="translated">Sta toe om de website te indexeren voor zoek robots zoals Google</target>
-        <jms:reference-file line="48">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77c7b4909d393bbb0e9e72d3dd008972625771b3" resname="Allowed" approved="yes">
         <source>Allowed</source>
@@ -956,13 +956,11 @@
       <trans-unit id="f0cf9a47c6b420dda55c973a12840600fc19b7fb" resname="An error occured" approved="yes">
         <source>An error occured</source>
         <target state="translated">Er is een fout opgetreden</target>
-        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="164">Controller/Prod/MoveCollectionController.php</jms:reference-file>
-        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="251">Controller/Prod/BasketController.php</jms:reference-file>
-        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="218">Controller/Prod/StoryController.php</jms:reference-file>
+        <jms:reference-file line="257">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="176">Controller/Prod/ToolsController.php</jms:reference-file>
         <jms:reference-file line="71">Controller/Admin/DataboxesController.php</jms:reference-file>
         <jms:reference-file line="86">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="159">Controller/Admin/DataboxController.php</jms:reference-file>
@@ -984,12 +982,14 @@
         <jms:reference-file line="667">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="700">Controller/Admin/CollectionController.php</jms:reference-file>
         <jms:reference-file line="808">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="120">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="239">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
+        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="23">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="656">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="194">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
         <jms:reference-file line="19">admin/databox/databox.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/admin/databases.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a16a3255c311eccbe2471bfc5b5cd92f3b907654" resname="An error occured when wanting to change status!">
         <source>An error occured when wanting to change status!</source>
@@ -1030,13 +1030,13 @@
       <trans-unit id="98a5e115c36d45b5c1cb4ed3537f847a5210d1e7" resname="An error occurred" approved="yes">
         <source>An error occurred</source>
         <target state="translated">Er is een fout opgetreden</target>
-        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
-        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="2081">Controller/Api/V1Controller.php</jms:reference-file>
         <jms:reference-file line="2527">Controller/Api/V1Controller.php</jms:reference-file>
-        <jms:reference-file line="135">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="223">Controller/Prod/BasketController.php</jms:reference-file>
         <jms:reference-file line="531">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="126">Controller/Admin/CollectionController.php</jms:reference-file>
+        <jms:reference-file line="136">Controller/Admin/SearchEngineController.php</jms:reference-file>
+        <jms:reference-file line="77">Order/Controller/ProdOrderController.php</jms:reference-file>
         <jms:reference-file line="81">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e861f79c8744b5cb0b59ce4f0100603952751b1" resname="An error occurred reading this file" approved="yes">
@@ -1057,7 +1057,7 @@
       <trans-unit id="3ad56f9f5a406f1c69267d4ac341168e3affa3e7" resname="Anonymous report" approved="yes">
         <source>Anonymous report</source>
         <target state="translated">Anoniem verslag</target>
-        <jms:reference-file line="34">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d7854118cda9d187ac6091c889576577aab8a36b" resname="Any time" approved="yes">
         <source>Any time</source>
@@ -1093,7 +1093,7 @@
       <trans-unit id="498778131fed5b01b06132a7c29c2d29829410c4" resname="Application description" approved="yes">
         <source>Application description</source>
         <target state="translated">Programma omschrijving</target>
-        <jms:reference-file line="36">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a9ec030ab77d85f2493f1ebc5ab78e62e83fc383" resname="Application desktop" approved="yes">
         <source>Application desktop</source>
@@ -1103,7 +1103,7 @@
       <trans-unit id="ee3ac8b2def14068e5827dcd2499e831cb89712c" resname="Application title" approved="yes">
         <source>Application title</source>
         <target state="translated">Programma naam</target>
-        <jms:reference-file line="30">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="866fef154cc77e6c30d7c9e97387dae0fb72dd08" resname="Application web" approved="yes">
         <source>Application web</source>
@@ -1134,8 +1134,8 @@
       <trans-unit id="b8fb717785e899f8e3bacfd74a395da7a434af9e" resname="Apply changes" approved="yes">
         <source>Apply changes</source>
         <target state="translated">Wijzigingen toepassen</target>
-        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="112">actions/Property/index.html.twig</jms:reference-file>
+        <jms:reference-file line="49">actions/Property/type.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e585e139fb6fc86d30e02ba78bdbb4dff6ac6b9" resname="Apply status on story children." approved="yes">
         <source>Apply status on story children.</source>
@@ -1275,8 +1275,8 @@
       <trans-unit id="d6caeca6303e9c722c929fbb58744a013a7ba7db" resname="Audio Codec">
         <source>Audio Codec</source>
         <target>Audio Codec</target>
-        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="37">Media/Subdef/Audio.php</jms:reference-file>
+        <jms:reference-file line="36">Media/Subdef/Video.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a80232c45008d73666e95544f7c9c8c0896536af" resname="Audio Samplerate">
         <source>Audio Samplerate</source>
@@ -1301,17 +1301,17 @@
       <trans-unit id="9e761dfcff90efcb07867accd3e8b109762fc596" resname="Auth_token directory path" approved="yes">
         <source>Auth_token directory path</source>
         <target state="translated">Auth_token folderpad</target>
-        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="77277d274230409567d5eaa8a27e1a1b8f08cef6" resname="Auth_token mount point">
         <source>Auth_token mount point</source>
         <target>Auth_token mount point</target>
-        <jms:reference-file line="34">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6ef5e08e2db8aa52ae7a50b9d9f0bd6920b69a37" resname="Auth_token passphrase" approved="yes">
         <source>Auth_token passphrase</source>
         <target state="translated">Auth_token toegangszin</target>
-        <jms:reference-file line="40">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fb7b626329225c9775b113922aa0d1662b5901a2" resname="Authoriser l'access" approved="yes">
         <source>Authoriser l'access</source>
@@ -1337,27 +1337,27 @@
       <trans-unit id="d5f364d5d9a0a95fdba37f29a65a9ba61d6329ef" resname="Authorize *Phraseanet Navigator*" approved="yes">
         <source>Authorize *Phraseanet Navigator*</source>
         <target state="translated">Sta *Phraseanet Navigator* toe</target>
-        <jms:reference-file line="27">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b85de40822e66ce4309b94ccad5bb731f2a89373" resname="Authorize Adobe cc Plugin to connect.">
         <source>Authorize Adobe cc Plugin to connect.</source>
         <target state="new">Authorize Adobe cc Plugin to connect.</target>
-        <jms:reference-file line="36">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e1ead524b95ba3b45281df7ba45d2addbbf1a79" resname="Authorize Microsoft Office Plugin to connect." approved="yes">
         <source>Authorize Microsoft Office Plugin to connect.</source>
         <target state="translated">Laat Microsoft Office Plugin toe om te connecteren.</target>
-        <jms:reference-file line="32">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c614ba7c453cdcd4d21b20e8286c6266c891e0c6" resname="Auto">
         <source>Auto</source>
         <target state="new">Auto</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e57297a1b1a46f4190603240a211144dde456ffe" resname="Auto select databases" approved="yes">
         <source>Auto select databases</source>
         <target state="translated">Auto select databanken</target>
-        <jms:reference-file line="22">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7c91a8c4806cffc223b40523b3233bd23412ad4" resname="AutoRegister information" approved="yes">
         <source>AutoRegister information</source>
@@ -1385,7 +1385,7 @@
       <trans-unit id="45fc87c2d0ade465c57c00f7aa434a4d0bebe106" resname="Available in multi-export tab" approved="yes">
         <source>Available in multi-export tab</source>
         <target state="translated">Actief in de multi-export tab</target>
-        <jms:reference-file line="23">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="37940d53912d9cc9ab0441c09c3754d6e83c438b" resname="Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes." approved="yes">
         <source>Avant de continuer, prenez connaissance des points ci-dessous. Vous pouvez continuer sans corriger ces problèmes.</source>
@@ -1395,11 +1395,11 @@
       <trans-unit id="b52b36b7269fbfc58ec24bb724691951a3decbe8" resname="Back" approved="yes">
         <source>Back</source>
         <target state="translated">Terug</target>
-        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
         <jms:reference-file line="69">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="92">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="134">mobile/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="46">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="34">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="738444fb7badaeb28467562ed8af8e1311e42eac" resname="Back to Feedback" approved="yes">
         <source>Back to Feedback</source>
@@ -1420,9 +1420,9 @@
         <source>Bad request format, only JSON is allowed</source>
         <target state="translated">Slecht verzoek formaat, enkel JSON is toegestaan</target>
         <jms:reference-file line="191">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
         <jms:reference-file line="61">Controller/Admin/RootController.php</jms:reference-file>
         <jms:reference-file line="223">Controller/Admin/RootController.php</jms:reference-file>
-        <jms:reference-file line="583">Controller/Admin/DataboxController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa0d7d2cb29f1ca72b4108bfaa0bf5686d3910ff" resname="Bad request, please contact an admin" approved="yes">
         <source>Bad request, please contact an admin</source>
@@ -1531,7 +1531,7 @@
       <trans-unit id="54a2cf5e634dbba0be2bf8a55f79252f5c790bdb" resname="Browser">
         <source>Browser</source>
         <target>Browser</target>
-        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d90cbe9431fb9e8d6013b651c2fb46a598de9eb" resname="Business Fields" approved="yes">
         <source>Business Fields</source>
@@ -1549,7 +1549,7 @@
       <trans-unit id="4a9b7a5a8f68ffe693f4205fc0d2916e373e4b64" resname="By default it is available for admins" approved="yes">
         <source>By default it is available for admins</source>
         <target state="translated">Standaard is dit voor de beheerders beschikbaar</target>
-        <jms:reference-file line="27">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a8e6c2695279fb4760d299974903123f751b3bf" resname="By field">
         <source>By field</source>
@@ -1577,12 +1577,12 @@
         <target state="translated">Annuleren</target>
         <jms:reference-file line="131">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="28">prod/User/Add.html.twig</jms:reference-file>
-        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
-        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
         <jms:reference-file line="114">actions/Property/index.html.twig</jms:reference-file>
-        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
+        <jms:reference-file line="50">actions/Property/type.html.twig</jms:reference-file>
+        <jms:reference-file line="34">prod/actions/delete_records_confirm_form.html.twig</jms:reference-file>
         <jms:reference-file line="68">admin/fields/templates.html.twig</jms:reference-file>
         <jms:reference-file line="42">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="77">task-manager/task-editor/task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ae1f9ef7dc1cee4760e7f208f36c225e3ab1aa1f" resname="Cancel all" approved="yes">
         <source>Cancel all</source>
@@ -1603,14 +1603,14 @@
       <trans-unit id="f1f842e1950136f97e6b449b2ee8ee2a88c9d214" resname="Carousel">
         <source>Carousel</source>
         <target>Carousel</target>
-        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="790d9876f3745353f60eb4d5232b26bb597ca5a3" resname="Categorie">
         <source>Categorie</source>
         <target>Categorie</target>
-        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="38">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="45">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="58">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bf1584669680e7841bf069b9495ea2f012bff60b" resname="Ce champ est decrit comme element du %DublinCoreElementSet%" approved="yes">
         <source>Ce champ est decrit comme element du %DublinCoreElementSet%</source>
@@ -1640,14 +1640,14 @@
       <trans-unit id="17061b6a22c3d9f7255c7f6208394911623ea1cd" resname="Ce champ est obligatoire" approved="yes">
         <source>Ce champ est obligatoire</source>
         <target state="translated">Dit veld is verplicht</target>
-        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="798">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="823">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="691">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="713">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="905">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="908">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="931">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="934">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e821f6f0c9613624f82ae880c01573ab0c0a0eac" resname="Ce champ est relie a une branche de thesaurus" approved="yes">
         <source>Ce champ est relie a une branche de thesaurus</source>
@@ -1668,12 +1668,12 @@
       <trans-unit id="9fb36da9009b1be61fc35e5de8ef5ea79ceca1c1" resname="Ce champ est trop long %length% caracteres max">
         <source>Ce champ est trop long %length% caracteres max</source>
         <target state="new">Ce champ est trop long %length% caracteres max</target>
-        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
-        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="801">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="826">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="694">Bridge/Api/Flickr.php</jms:reference-file>
         <jms:reference-file line="716">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="911">Bridge/Api/Youtube.php</jms:reference-file>
+        <jms:reference-file line="937">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a436b2b01f08a63284006c23ac3b38c9a699cbd" resname="Ce champ est utilise en titre a l'affichage" approved="yes">
         <source>Ce champ est utilise en titre a l'affichage</source>
@@ -1750,8 +1750,8 @@
       <trans-unit id="b030d590c21c95efe2ba71da1d0f1198a7e655b4" resname="Choisir" approved="yes">
         <source>Choisir</source>
         <target state="translated">Kiezen</target>
-        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="150">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="168">web/admin/subdefs.html.twig</jms:reference-file>
         <jms:reference-file line="368">web/admin/subdefs.html.twig</jms:reference-file>
@@ -1763,13 +1763,13 @@
       <trans-unit id="3f657f29e68346624be98bea3924a6748900a66c" resname="Choose a new password" approved="yes">
         <source>Choose a new password</source>
         <target state="translated">Kies een nieuw paswoord</target>
-        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="15">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="14">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ad9476afb3cde04fd01e41ab85a0180eabfdb1c" resname="Choose the title of the document to export" approved="yes">
         <source>Choose the title of the document to export</source>
         <target state="translated">Kies een naam voor het document bij de export</target>
-        <jms:reference-file line="40">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="53">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0506773f181511d306efe57b7d20af4ea44fa1b3" resname="Civility" approved="yes">
         <source>Civility</source>
@@ -1779,8 +1779,8 @@
       <trans-unit id="719ea396ad92e01b4757ec2b93bb1e5f270f771d" resname="Clear" approved="yes">
         <source>Clear</source>
         <target state="translated">Wis</target>
-        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/log_scheduler.html.twig</jms:reference-file>
+        <jms:reference-file line="20">admin/task-manager/log_task.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7135ee5eaed0e404c4fcf48d6eb7d2808f8e55f2" resname="Clear list" approved="yes">
         <source>Clear list</source>
@@ -1827,8 +1827,8 @@
       <trans-unit id="30c54a96f8011b39819ba18bcb53fcbb092d650d" resname="Collection" approved="yes">
         <source>Collection</source>
         <target state="translated">Collectie</target>
-        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="446">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/Story/Create.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/databox/details.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="814cd4d896d0d93eac2f4d71dc24c91a46cd5e28" resname="Collection %collection%" approved="yes">
@@ -1898,10 +1898,10 @@
       <trans-unit id="f7853f027e327a9ddf52dd60f8d1719ae6904333" resname="Confidentialite" approved="yes">
         <source>Confidentialite</source>
         <target state="translated">Vertrouwelijk</target>
-        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="56">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="75">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="56">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="87">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e9445beaddb548587c6f275e49da38e9fc7b785" resname="Confidentialite : privee" approved="yes">
         <source>Confidentialite : privee</source>
@@ -1992,7 +1992,7 @@
       <trans-unit id="da54a34bad5b32178cd5a344200f3beb72b8b214" resname="Cooliris">
         <source>Cooliris</source>
         <target state="new">Cooliris</target>
-        <jms:reference-file line="55">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a1757945390259d3dbb7c551d01c23638463d39" resname="Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :">
         <source>Copiez le code ci-dessous, retournez dans votre application et collez-le a l'endroit requis :</source>
@@ -2048,7 +2048,7 @@
       <trans-unit id="26a9831600fb0e895035038bcac30cc389b393e0" resname="Create index">
         <source>Create index</source>
         <target state="new">Create index</target>
-        <jms:reference-file line="56">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="67">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c175379b0389b2d6057b0b7db996720f1fb92fc7" resname="Creation date" approved="yes">
         <source>Creation date</source>
@@ -2068,9 +2068,9 @@
       <trans-unit id="2bd00521d39c34d7b8a4a42573e1cf42fb319036" resname="Creer" approved="yes">
         <source>Creer</source>
         <target state="translated">Maken</target>
-        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e0c179a64761a8abdbd1a1ef499e6aa7fd41b516" resname="Creer la tache d'ecriture des metadonnees" approved="yes">
         <source>Creer la tache d'ecriture des metadonnees</source>
@@ -2115,8 +2115,8 @@
       <trans-unit id="6a2b9fb6f6a60bde44a1bbe5e058c013cb1004ea" resname="Creer une playlist" approved="yes">
         <source>Creer une playlist</source>
         <target state="translated">Maak een playlist</target>
-        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="4">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="4">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c26eb5f5ded79caa39c9dd44376bf3556f6466" resname="Creez une application pour commencer a utiliser l'API Phraseanet" approved="yes">
         <source>Creez une application pour commencer a utiliser l'API Phraseanet</source>
@@ -2148,12 +2148,12 @@
       <trans-unit id="19dff4dad0a7214ece14624f8c4c9fb206a1cfdd" resname="Current password" approved="yes">
         <source>Current password</source>
         <target state="translated">Huidig wachtwoord</target>
-        <jms:reference-file line="26">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e8ae2dcb43aa1748c5f5facbb8bcc2b52a627059" resname="Current session" approved="yes">
         <source>Current session</source>
         <target state="translated">Huidige sessie</target>
-        <jms:reference-file line="43">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="46">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="081ae3fdc403609cf6e760849ebb14117b7a50cb" resname="Custom">
         <source>Custom</source>
@@ -2169,12 +2169,12 @@
       <trans-unit id="ce3e4bed2954adbf05f8edfaf1a4c0cc0cea70e9" resname="DE">
         <source>DE</source>
         <target state="new">DE</target>
-        <jms:reference-file line="40">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="129bcdb9bbdbd9bba49b7e1eb1ec49698604f0b0" resname="DU">
         <source>DU</source>
         <target state="new">DU</target>
-        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e2dc4518235e7567a3d68c45cb6165ec116fa3c" resname="Danger zone !">
         <source>Danger zone !</source>
@@ -2256,13 +2256,13 @@
       <trans-unit id="910c2f8e114bda3eef68b7f17eee5e864be52dc4" resname="Date de connexion" approved="yes">
         <source>Date de connexion</source>
         <target state="translated">Datum van de verbinding</target>
-        <jms:reference-file line="22">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d5e8d1af5f3c137fb998b7afa347eeea683a7229" resname="Date de création">
         <source>Date de création</source>
         <target state="new">Date de création</target>
-        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a13dfa9c55746372090d1ffbd465703786b7f90" resname="Date de demande" approved="yes">
         <source>Date de demande</source>
@@ -2274,8 +2274,8 @@
       <trans-unit id="c004345fde85bded2c74513e29c8cd58d74b594f" resname="Date de modification">
         <source>Date de modification</source>
         <target state="new">Date de modification</target>
-        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="11">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce084029e351b4bfa9f425ae70e8aaa14a8904e5" resname="Date(s) from field(s)">
         <source>Date(s) from field(s)</source>
@@ -2318,7 +2318,7 @@
       <trans-unit id="7f4c92d36ad39747b7393498e20a21e3898d5ea6" resname="Default TTL in seconds of sub-definition url">
         <source>Default TTL in seconds of sub-definition url</source>
         <target state="new">Default TTL in seconds of sub-definition url</target>
-        <jms:reference-file line="61">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="21cec17f6cd9c992f10804a71ea6d286a56c456a" resname="Default basket" approved="yes">
         <source>Default basket</source>
@@ -2328,27 +2328,27 @@
       <trans-unit id="1747ef3d688685c5844db2dc7c98aafd78ce3893" resname="Default export title" approved="yes">
         <source>Default export title</source>
         <target state="translated">Standaard export naam</target>
-        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0865e6ae43db7711e100ad36595c2b38742f0b9f" resname="Default mail sender address" approved="yes">
         <source>Default mail sender address</source>
         <target state="translated">Standaard mail adres</target>
-        <jms:reference-file line="22">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1ad516bc09a2a902e2bf2d738bed0236b5a61c5e" resname="Default query" approved="yes">
         <source>Default query</source>
         <target state="translated">Standaard vraag</target>
-        <jms:reference-file line="26">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27cbd98bc854aa8480d4c436e762e9f30a00474e" resname="Default searched type" approved="yes">
         <source>Default searched type</source>
         <target state="translated">Standaard gezocht type</target>
-        <jms:reference-file line="29">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ccd20794e5c5f8f28ac9b0b2f57b29bcd31ddfc6" resname="Default validation links duration" approved="yes">
         <source>Default validation links duration</source>
         <target state="translated">Standaard tijd voor de validatie links</target>
-        <jms:reference-file line="29">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="332c9d57e19e2419cf5246fc9283f182eb316b8d" resname="Define a webhook URL">
         <source>Define a webhook URL</source>
@@ -2363,7 +2363,7 @@
       <trans-unit id="3b6bf506a535e9bf22431eace58b8f2f704dbd2a" resname="Defined in Apache configuration" approved="yes">
         <source>Defined in Apache configuration</source>
         <target state="translated">Gedefinieerd in de Apache configuratie</target>
-        <jms:reference-file line="41">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2a147677ac3ad9bbeaa766ccee9b2f2d3c7e1d59" resname="Delai depasse lors du contact avec le serveur WEB" approved="yes">
         <source>Delai depasse lors du contact avec le serveur WEB</source>
@@ -2433,20 +2433,20 @@
       <trans-unit id="57ec2e2addbd6a4117f16c1fff5f491fe3c5642c" resname="Deplacement %n_element% elements" approved="yes">
         <source>Deplacement %n_element% elements</source>
         <target state="translated">%n_element% elementen verplaatsen</target>
-        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17c91ee147631da4f5aacabed0e198eb02955790" resname="Dernier access" approved="yes">
         <source>Dernier access</source>
         <target state="translated">Laatste verbinding</target>
-        <jms:reference-file line="25">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="821ed4c906c76220f9dc83eba5e0b861e22baa04" resname="Derniere mise a jour le %updated_on%" approved="yes">
         <source>Derniere mise a jour le %updated_on%</source>
         <target state="translated">Laatste update %updated_on%</target>
-        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="45">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="41">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dcce9368ad626fe4addfa719b7a16807d464aa9b" resname="Derniers envois">
         <source>Derniers envois</source>
@@ -2462,29 +2462,29 @@
       <trans-unit id="55f8ebc805e65b5b71ddafdae390e3be2bcd69af" resname="Description" approved="yes">
         <source>Description</source>
         <target state="translated">Beschrijving</target>
-        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/Tooltip/DCESFieldInfo.html.twig</jms:reference-file>
-        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="31">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="43">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="44">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="31">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="52">Bridge/Flickr/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">web/developers/application_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="85cce1e14782f67cb830f74002ebe5603783c674" resname="Deselect all" approved="yes">
         <source>Deselect all</source>
         <target state="translated">Alles deselecteren</target>
-        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="60">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="225">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd281ce85e6f98a7dad0aa31a2e493a85ef178ca" resname="Design of personalization logo section">
         <source>Design of personalization logo section</source>
         <target state="new">Design of personalization logo section</target>
-        <jms:reference-file line="66">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac930a136ebd04a19bc5f2ce1769fc065efb7bdf" resname="Detailed view URL" approved="yes">
         <source>Detailed view URL</source>
@@ -2510,8 +2510,8 @@
       <trans-unit id="45e147abd920eeb1aca320340e18cf67b4c77252" resname="Dimension" approved="yes">
         <source>Dimension</source>
         <target state="translated">Afmeting</target>
-        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Unknown.php</jms:reference-file>
+        <jms:reference-file line="32">Media/Subdef/Video.php</jms:reference-file>
         <jms:reference-file line="32">Media/Subdef/Image.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8b6613d50c2d8718fd7cab023e1530ce11650736" resname="Disable document type sharing">
@@ -2522,12 +2522,12 @@
       <trans-unit id="f4f4473df8cb59f0a369aebee3d1509adc0151c6" resname="Disabled" approved="yes">
         <source>Disabled</source>
         <target state="translated">Uitgeschakeld</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e304849daf61291daab688ef3154c851694909e6" resname="Disallow the possibility for the end user to disable push authentication">
         <source>Disallow the possibility for the end user to disable push authentication</source>
         <target state="new">Disallow the possibility for the end user to disable push authentication</target>
-        <jms:reference-file line="55">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="68">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa9fd169cd55f0433c6e7a4b5d758f90d0847411" resname="Display &amp; action settings" approved="yes">
         <source><![CDATA[Display & action settings]]></source>
@@ -2567,7 +2567,7 @@
       <trans-unit id="1dc1290f2dcd49c014e5cae4004924885fbd68ed" resname="Do you really want to end the activity of this session?" approved="yes">
         <source>Do you really want to end the activity of this session?</source>
         <target state="translated">Wilt u werkelijk de activiteit van deze sessie stoppen?</target>
-        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="017fd7aedf39f509d51ce202368e4f0ea943de4e" resname="Do you want to send your report ?" approved="yes">
         <source>Do you want to send your report ?</source>
@@ -2603,12 +2603,12 @@
       <trans-unit id="3859bdaa8c6ffa767307d2ebc130439c543819c8" resname="Document title" approved="yes">
         <source>Document title</source>
         <target state="translated">Document naam</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="687c82861c956e47456186f6522cfc8dbadb8ef6" resname="Documents" approved="yes">
         <source>Documents</source>
         <target state="translated">Documenten</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1096d02ee2e62ae8ea5873c92b391094d9f9516e" resname="Documents indisponibles" approved="yes">
         <source>Documents indisponibles</source>
@@ -2646,7 +2646,7 @@
       <trans-unit id="4e4528018d1a0aa11f7dc17b5425174a7436d334" resname="Drop index">
         <source>Drop index</source>
         <target state="new">Drop index</target>
-        <jms:reference-file line="49">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3a9c043f68c147a7c8d8c2fa14ddfaba6e05da62" resname="Duree" approved="yes">
         <source>Duree</source>
@@ -2661,8 +2661,8 @@
       <trans-unit id="0d01e2e86669e98441ab4dce5520696c318b7098" resname="E-mail" approved="yes">
         <source>E-mail</source>
         <target state="translated">Email</target>
-        <jms:reference-file line="23">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="37">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Login/PhraseaForgotPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9cf2896f8b2e9e6a28f9b151e8be31f220a5d256" resname="E-mail domain">
         <source>E-mail domain</source>
@@ -2672,7 +2672,7 @@
       <trans-unit id="734a78cd06d0929c433f487754d18bf073e43bf6" resname="EN">
         <source>EN</source>
         <target state="new">EN</target>
-        <jms:reference-file line="37">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a908567d2c0292366061394efd6d40b139e033c5" resname="ERREUR : La classe de subdef est necessaire et egal a &quot;thumbnail&quot;,&quot;preview&quot; ou &quot;document&quot;">
         <source>ERREUR : La classe de subdef est necessaire et egal a "thumbnail","preview" ou "document"</source>
@@ -2692,7 +2692,7 @@
       <trans-unit id="9debabbaa01a190fabe8324c5e6e2f2808052099" resname="ES">
         <source>ES</source>
         <target state="new">ES</target>
-        <jms:reference-file line="38">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5301648dcf6b53cefc9ed52999aaa92d4603cae0" resname="Edit" approved="yes">
         <source>Edit</source>
@@ -2717,9 +2717,9 @@
       <trans-unit id="5184ecbec7829b91dda100c703ea3fa284c7f5e8" resname="Edition de 1 element" approved="yes">
         <source>Edition de 1 element</source>
         <target state="translated">Editie van het 1 element</target>
-        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="10">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="10">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99ead0eb32b2089a9933db5ccc262e2fc35fd0a6" resname="Edition des droits de %display_name%" approved="yes">
         <source>Edition des droits de %display_name%</source>
@@ -2754,19 +2754,19 @@
       <trans-unit id="201b9ab150a2ab3e5641814c373f8db1949199d0" resname="ElasticSearch index name">
         <source>ElasticSearch index name</source>
         <target state="new">ElasticSearch index name</target>
-        <jms:reference-file line="44">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="55">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="666">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b89586db0b00163ce75ae7426f06aa2e2a57b223" resname="ElasticSearch server host">
         <source>ElasticSearch server host</source>
         <target state="new">ElasticSearch server host</target>
-        <jms:reference-file line="37">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="48">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="654">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="18fd7d0c79d71cd9317190ae98dccdb1f7cf8b76" resname="ElasticSearch service port">
         <source>ElasticSearch service port</source>
         <target state="new">ElasticSearch service port</target>
-        <jms:reference-file line="40">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="51">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="658">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="84add5b2952787581cb9a8851eef63d1ec75d22b" resname="Email">
@@ -2850,7 +2850,7 @@
       <trans-unit id="16edbca430dbc855d01b65c634474ae1648e1890" resname="Empty if not used" approved="yes">
         <source>Empty if not used</source>
         <target state="translated">Leeg als niet wordt gebruikt</target>
-        <jms:reference-file line="45">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="27c90ec9c48fe61ec12eff0a4e00b6d74780aa38" resname="Empty quarantine" approved="yes">
         <source>Empty quarantine</source>
@@ -2882,8 +2882,8 @@
       <trans-unit id="0413c20ae2fd31e0a1eef73e7768c8e1c68558d9" resname="En cours d'encodage" approved="yes">
         <source>En cours d'encodage</source>
         <target state="translated">Bezig met coderen</target>
-        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="531">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="495">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="56">actions/Bridge/records_list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="43494e363213dc176e0699b914ccf966ccbd994d" resname="En cours d'envoi" approved="yes">
@@ -2894,42 +2894,42 @@
       <trans-unit id="4b4a90ee07557c5f8d1a9aedaed0fafacc4cc58f" resname="Enable FTP export" approved="yes">
         <source>Enable FTP export</source>
         <target state="translated">Schakel FPT export in</target>
-        <jms:reference-file line="22">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4f48c8f3f90677271cd196305954c1bc820a420" resname="Enable FTP for users" approved="yes">
         <source>Enable FTP for users</source>
         <target state="translated">Schakel FTP in voor gebruikers</target>
-        <jms:reference-file line="26">Form/Configuration/FtpExportFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/FtpExportFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="25b38d3df5918f72187522a9cf74625c729ac6ad" resname="Enable Forcing authentication to see push content">
         <source>Enable Forcing authentication to see push content</source>
         <target state="new">Enable Forcing authentication to see push content</target>
-        <jms:reference-file line="51">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e2edcbbb1c6aa26ccce6fbf04bec121c904dcec" resname="Enable H264 stream mode" approved="yes">
         <source>Enable H264 stream mode</source>
         <target state="translated">Maak H264 stream mode actief</target>
-        <jms:reference-file line="30">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc15a5aec96be87d7fec6a07972f8ac99693b265" resname="Enable HD substitution" approved="yes">
         <source>Enable HD substitution</source>
         <target state="translated">Maak de HD substitutie actief</target>
-        <jms:reference-file line="28">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="344fc3edd6987653de543b2ecd2d31aec2f3cca0" resname="Enable Phraseanet Web API">
         <source>Enable Phraseanet Web API</source>
         <target state="new">Enable Phraseanet Web API</target>
-        <jms:reference-file line="22">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee98e71194d6f532c3c777fa20a957c3ba490089" resname="Enable SMTP authentication" approved="yes">
         <source>Enable SMTP authentication</source>
         <target state="translated">SMTP-verificatie inschakelen</target>
-        <jms:reference-file line="31">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1abba66821d3efad3698297ceac2c3fc0e985faf" resname="Enable auto registration" approved="yes">
         <source>Enable auto registration</source>
         <target state="translated">Schakel automatisch registreren in</target>
-        <jms:reference-file line="26">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84aa616ef0b3e29513430631bf82c50c9cde7406" resname="Enable document type sharing">
         <source>Enable document type sharing</source>
@@ -2939,43 +2939,43 @@
       <trans-unit id="af559a0c4023968d8723bcdfe3337ce72eca48eb" resname="Enable maintenance message broadcast" approved="yes">
         <source>Enable maintenance message broadcast</source>
         <target state="translated">Onderhoud mededling van de uitzending inschakelen</target>
-        <jms:reference-file line="25">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2b8f6db16b5583a7d9ef39a74fe471390d73bd74" resname="Enable multi-doc mode" approved="yes">
         <source>Enable multi-doc mode</source>
         <target state="translated">Maak de multi-doc mode actief</target>
-        <jms:reference-file line="25">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="af54ffee479b01e950445015c81b8e68c1347a66" resname="Enable possibility to notify users when publishing a new feed entry">
         <source>Enable possibility to notify users when publishing a new feed entry</source>
         <target state="new">Enable possibility to notify users when publishing a new feed entry</target>
-        <jms:reference-file line="58">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="35a2e4d551405a7ce8cdf754de5a47c8922b52d7" resname="Enable thesaurus" approved="yes">
         <source>Enable thesaurus</source>
         <target state="translated">Maak de thesaurus actief</target>
-        <jms:reference-file line="22">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="33">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="56848224e379e98e9a4cbcad0b51a0e99f7980f0" resname="Enable this setting to share on Facebook and Twitter" approved="yes">
         <source>Enable this setting to share on Facebook and Twitter</source>
         <target state="translated">Gebruik deze instellingen voor het delen op Facebook en Twitter</target>
-        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="60">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8c91cee722569eccd85bf170aff83c6b8e3b4d1" resname="Enable thumbnail substitution" approved="yes">
         <source>Enable thumbnail substitution</source>
         <target state="translated">Maak de thumbnail substitutie actief</target>
-        <jms:reference-file line="31">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="df174a3f2faa31814e06540acda7af8825403fac" resname="Enabled" approved="yes">
         <source>Enabled</source>
         <target state="translated">Ingeschakeld</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c2951dce186cc543b533d553a40cd64c767c6d7b" resname="End Activity" approved="yes">
         <source>End Activity</source>
         <target state="translated">Einde activiteit</target>
         <jms:reference-file line="13">web/account/sessions.html.twig</jms:reference-file>
-        <jms:reference-file line="41">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61983e17f966924dc25febd5756e710e2102d38f" resname="End Range">
         <source>End Range</source>
@@ -2985,7 +2985,7 @@
       <trans-unit id="b5d90b80b452e4c8e3f1840c23372475d8861803" resname="End session activity" approved="yes">
         <source>End session activity</source>
         <target state="translated">Einde sessie activiteit</target>
-        <jms:reference-file line="69">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="72">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="42f2df94366ecaac40f51500a7583ecc8c6d424b" resname="Enter your e-mail address to retrieve your password" approved="yes">
         <source>Enter your e-mail address to retrieve your password</source>
@@ -3130,8 +3130,8 @@
       <trans-unit id="40019ae278d51a265b82e37738989bf1b22157b7" resname="Etendue de la publication" approved="yes">
         <source>Etendue de la publication</source>
         <target state="translated">Omvang van de publicatie</target>
-        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="105">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="255f8b2705b27e25acc23428730bfd7a32d9a0db" resname="Etes vous sur de supprimer %number% photos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% photos ?</source>
@@ -3146,14 +3146,14 @@
       <trans-unit id="e7f864e2cef6464cd4342b0a0b607c6b53fd8263" resname="Etes vous sur de supprimer %number% playlists ?" approved="yes">
         <source>Etes vous sur de supprimer %number% playlists ?</source>
         <target state="translated">Bent u zeker om %number% playlists te verwijderen ?</target>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f0181b1da6f09b84ae46efce781899eb57ec74b8" resname="Etes vous sur de supprimer %number% videos ?" approved="yes">
         <source>Etes vous sur de supprimer %number% videos ?</source>
         <target state="translated">Bent u zeker om %number% videos te verwijderen ?</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46a1884f7b083976b0fd0678f10b8f00ee93cde9" resname="Ex : Paris, bleu, montagne">
         <source>Ex : Paris, bleu, montagne</source>
@@ -3178,9 +3178,9 @@
       <trans-unit id="f3e4fadb9e370a1e2c0c622c01fc8c77daf93a2c" resname="Export" approved="yes">
         <source>Export</source>
         <target state="translated">Exporteer</target>
+        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="75">Controller/Prod/DoDownloadController.php</jms:reference-file>
         <jms:reference-file line="76">Controller/Prod/DoDownloadController.php</jms:reference-file>
-        <jms:reference-file line="118">Controller/Prod/LanguageController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9c26d273867dffc55d40f46e6a163067c75969f5" resname="Export ranges">
         <source>Export ranges</source>
@@ -3195,7 +3195,7 @@
       <trans-unit id="6d2830b1e76dc7300fce6745176601827d233de8" resname="FR">
         <source>FR</source>
         <target state="new">FR</target>
-        <jms:reference-file line="36">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="acb28212fba0272ee990cebd571ebe09b463312e" resname="FTP">
         <source>FTP</source>
@@ -3221,10 +3221,10 @@
         <source>Feedback</source>
         <target>Feedback</target>
         <jms:reference-file line="122">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="54">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="19">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="51">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="103">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="90d95d818c456d269d000b3d82579506f6e34c5f" resname="Feedback:: Requested by %initiator% on %createdDate%">
         <source>Feedback:: Requested by %initiator% on %createdDate%</source>
@@ -3284,11 +3284,11 @@
       <trans-unit id="aadf78d4b7c7c7341aa891adca70897c4f978cb6" resname="File is not present in quarantine anymore, please refresh" approved="yes">
         <source>File is not present in quarantine anymore, please refresh</source>
         <target state="translated">Bestand is niet meer in de quarantiane aanwezig, gelieve te vernieuwen</target>
+        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
+        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
         <jms:reference-file line="56">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="136">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
         <jms:reference-file line="157">Model/Manipulator/LazaretManipulator.php</jms:reference-file>
-        <jms:reference-file line="78">Controller/Prod/LazaretController.php</jms:reference-file>
-        <jms:reference-file line="207">Controller/Prod/LazaretController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3491d2e44dd1896af3411bb1a048847c13647feb" resname="File is too big : 64k max" approved="yes">
         <source>File is too big : 64k max</source>
@@ -3433,7 +3433,7 @@
       <trans-unit id="a5ec616668f5ea6fa47eec00bbe6e31964599856" resname="GD">
         <source>GD</source>
         <target state="new">GD</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a45e2e1fd0f0cb30474f4cfd3d8fbdc9fd7fb9" resname="GOP size" approved="yes">
         <source>GOP size</source>
@@ -3443,7 +3443,7 @@
       <trans-unit id="9c30a3485a5887f1ba5abd2a291d304a01863e55" resname="Gallery" approved="yes">
         <source>Gallery</source>
         <target state="translated">Galerij</target>
-        <jms:reference-file line="57">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="259242b8cd71adbfc416f01eaef816dacc0d8384" resname="General configuration">
         <source>General configuration</source>
@@ -3499,7 +3499,7 @@
       <trans-unit id="efd1f5fd46c31701d2e70555e9ab45efe27b4048" resname="Geonames server address" approved="yes">
         <source>Geonames server address</source>
         <target state="translated">Geonames server adres</target>
-        <jms:reference-file line="35">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5334c3c15248b80aba72d8a192cb45256f6de263" resname="Get a notification when a mail export fails" approved="yes">
         <source>Get a notification when a mail export fails</source>
@@ -3509,7 +3509,7 @@
       <trans-unit id="05a07cd950e4b273afdde28fa0b591cc75524121" resname="Get setting form index">
         <source>Get setting form index</source>
         <target state="new">Get setting form index</target>
-        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="92">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee485ef50d127d2c51fe0091051d8c390d03ed59" resname="Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side.">
         <source>Gives the option to your application to communicate with Phraseanet. This webhook can be used to trigger some actions on your application side.</source>
@@ -3544,7 +3544,7 @@
       <trans-unit id="442bee77a51f11ee32ca32751c4e244e80de6e3d" resname="Google Analytics identifier" approved="yes">
         <source>Google Analytics identifier</source>
         <target state="translated">Google Analytics-id</target>
-        <jms:reference-file line="39">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="362c03cff3bb37904f552194e92e5f13c721882f" resname="Grant rights" approved="yes">
         <source>Grant rights</source>
@@ -3564,7 +3564,7 @@
       <trans-unit id="cd6d6f27b3e16afd7cdd573b85b3cc5bfd22e8db" resname="GraphicsMagick">
         <source>GraphicsMagick</source>
         <target state="new">GraphicsMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="779f61efcfe62182d0052c9526f3910378764758" resname="Graphiste (preview au rollover)" approved="yes">
         <source>Graphiste (preview au rollover)</source>
@@ -3616,8 +3616,8 @@
       <trans-unit id="d0d3632efe2a20cf1235aead5d817e03308131cc" resname="Hello %username%" approved="yes">
         <source>Hello %username%</source>
         <target state="translated">Hallo %username%</target>
-        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="82">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="45">api/auth/native_app_access_token.html.twig</jms:reference-file>
         <jms:reference-file line="62">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c47ae15370cfe1ed2781eedc1dc2547d12d9e972" resname="Help">
@@ -3633,21 +3633,21 @@
       <trans-unit id="78860a4e5b33556e6a8947485d8b042d9e58234e" resname="Hide information about users" approved="yes">
         <source>Hide information about users</source>
         <target state="translated">Verberg de informatie over gebruikers</target>
-        <jms:reference-file line="35">Form/Configuration/ModulesFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ModulesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="70f8bb9a8a5393ef080507a89e4b98d139000d65" resname="Home" approved="yes">
         <source>Home</source>
         <target state="translated">Startpagina</target>
-        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="3">login/include/language-block.html.twig</jms:reference-file>
-        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="67">login/layout/base-layout.html.twig</jms:reference-file>
         <jms:reference-file line="49">mobile/lightbox/basket_element.html.twig</jms:reference-file>
+        <jms:reference-file line="17">mobile/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="36">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="99f3b7dca04d6f354a9d2a3b633d9578a9ad8cac" resname="Homepage slideshow" approved="yes">
         <source>Homepage slideshow</source>
         <target state="translated">Startpagina diavoorstelling</target>
-        <jms:reference-file line="51">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="56">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8e41286dd8a6f03ef89a5aa958b1dad86ba4211f" resname="Hyperfocal distance" approved="yes">
         <source>Hyperfocal distance</source>
@@ -3657,13 +3657,13 @@
       <trans-unit id="f39bf9043aaeea61e7a0ba3949d854bd3997cb2a" resname="I have read the terms of use" approved="yes">
         <source>I have read the terms of use</source>
         <target state="translated">Ik heb de gebruiksvoorwaarden gelezen</target>
-        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
         <jms:reference-file line="68">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="65">web/login/register-classic.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ea424d38af72dd1366a08aad1f47eca3e7ec3d24" resname="IP">
         <source>IP</source>
         <target>IP</target>
-        <jms:reference-file line="28">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="31">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4f325d995b6d028ccc75771b1679537b623521c4" resname="ISO">
         <source>ISO</source>
@@ -3688,17 +3688,17 @@
       <trans-unit id="447a3b86a8a61425d5c46aed97eb2e7cf0bb769c" resname="If request is bigger, then mail is still available" approved="yes">
         <source>If request is bigger, then mail is still available</source>
         <target state="translated">Als de aanvraag groter is, dan is de mail nog steeds beschikbaar</target>
-        <jms:reference-file line="23">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d9e4315a74579080394bc6a6fdb7f5eccbf41e8" resname="If set to 0, duration is permanent" approved="yes">
         <source>If set to 0, duration is permanent</source>
         <target state="translated">Als waar gelijk is aan 0, altijd beschikbaar</target>
-        <jms:reference-file line="30">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="516e5bc94c0583cb8e632e13c36f77e514e0afc3" resname="If you notice any unfamiliar devices or locations, click on button %button% to end the session.">
         <source>If you notice any unfamiliar devices or locations, click on button %button% to end the session.</source>
         <target state="new">If you notice any unfamiliar devices or locations, click on button %button% to end the session.</target>
-        <jms:reference-file line="15">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="17">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f91c7b9a3a35352f74a9fb8708e35ddbb36a852b" resname="If you plan to store large files, be sure it will fit in these directories." approved="yes">
         <source>If you plan to store large files, be sure it will fit in these directories.</source>
@@ -3728,7 +3728,7 @@
       <trans-unit id="57a8e563190f921afb876d6489bb40ed74f43a1a" resname="ImageMagick">
         <source>ImageMagick</source>
         <target state="new">ImageMagick</target>
-        <jms:reference-file line="54">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3e38a20c1629a473809ea6a14c9cdf4204d3ac3b" resname="Images par secondes" approved="yes">
         <source>Images par secondes</source>
@@ -3744,7 +3744,7 @@
       <trans-unit id="bae76060aa0bb6aaf66ce914cf80b0786f965dc7" resname="Imagine driver">
         <source>Imagine driver</source>
         <target>Imagine driver</target>
-        <jms:reference-file line="52">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca13920228ea59b30c40b8372f53df3bf4631520" resname="In the answer grid">
         <source>In the answer grid</source>
@@ -3781,9 +3781,9 @@
       <trans-unit id="54937b3a4f8cfa4576692882d3ff7b14c90c4ce5" resname="Informations" approved="yes">
         <source>Informations</source>
         <target state="translated">Informatie</target>
-        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/account/base.html.twig</jms:reference-file>
+        <jms:reference-file line="195">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="33">web/admin/dashboard.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e1e0586141223b0143df16f7422dae5a43b77103" resname="Informations personnelles" approved="yes">
         <source>Informations personnelles</source>
@@ -3832,8 +3832,8 @@
         <source>Invalid file type, only (%supported_file_types%) file formats are supported</source>
         <target state="translated">Ongeldig bestandsformaat, enkel (%supported_file_types%)  bestandsformaten worden ondersteund</target>
         <jms:reference-file line="60">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
         <jms:reference-file line="199">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="424">admin/databox/databox.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="65fd566280b15a384df25c73315b0dcbc6dacb69" resname="Invalid file type, only (%supported_file_types%) file formats are supported'">
         <source>Invalid file type, only (%supported_file_types%) file formats are supported'</source>
@@ -3870,8 +3870,8 @@
       <trans-unit id="8606f0ad87b5f92e01e46416cad301829571b7a7" resname="Inverser" approved="yes">
         <source>Inverser</source>
         <target state="translated">Omkeren</target>
-        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="14">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="13">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3067f6d77794b736024c9a5594c1823612581e07" resname="It is not recommended to install Phraseanet without HTTPS support" approved="yes">
         <source>It is not recommended to install Phraseanet without HTTPS support</source>
@@ -3901,13 +3901,13 @@
       <trans-unit id="aa288d5bdc9be4c044885fa43c6f3758a1087d5a" resname="Keywords used for indexing purposes by search engines robots" approved="yes">
         <source>Keywords used for indexing purposes by search engines robots</source>
         <target state="translated">Sleutelwoorden die gebruikt worden voor het indexeren bij zoek robots</target>
-        <jms:reference-file line="33">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e9f378dcffe600d99f66ba5fa74cd91d10b2256" resname="L'upload a echoue" approved="yes">
         <source>L'upload a echoue</source>
         <target state="translated">De upload is mislukt</target>
-        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="486">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="493">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="94fe10f78d9c8b531bbd609a20f373289599035c" resname="L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%">
         <source>L'upload concernant le record %title% sur le compte %bridge_name% a echoue pour les raisons suivantes : %reason%</source>
@@ -3951,20 +3951,20 @@
       <trans-unit id="cfa0120ab592ae2bc3198dbde15a7a87a0c792c4" resname="La taille maximale d'une video est de %duration% minutes.">
         <source>La taille maximale d'une video est de %duration% minutes.</source>
         <target state="new">La taille maximale d'une video est de %duration% minutes.</target>
-        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="900">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="1014">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dcfd86b957b9cf12ede165c6c2fa0acf12f3eeb" resname="La video a ete rejetee" approved="yes">
         <source>La video a ete rejetee</source>
         <target state="translated">De video werd verworpen</target>
-        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="527">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="491">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="653e67f152ecc63ff3ee1014e86cc630a35dfe1a" resname="La video a ete supprimee" approved="yes">
         <source>La video a ete supprimee</source>
         <target state="translated">De video werd verwijderd</target>
-        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="525">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="489">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="da1c672d0d761ed5ac292335ed60e14ff3073265" resname="La video est restreinte" approved="yes">
         <source>La video est restreinte</source>
@@ -4060,16 +4060,16 @@
       <trans-unit id="b96ead6ab3add78d8448fcb2d18af281bb2cb278" resname="Le poids maximum d'un fichier est de %size%">
         <source>Le poids maximum d'un fichier est de %size%</source>
         <target state="new">Le poids maximum d'un fichier est de %size%</target>
-        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="906">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="814">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1020">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="13b9d7ef8e81663d7162d25b84cec1c24041e630" resname="Le record n'a pas de fichier physique" approved="yes">
         <source>Le record n'a pas de fichier physique</source>
         <target state="translated">Het record heeft geen fisieke documenten</target>
-        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="896">Bridge/Api/Dailymotion.php</jms:reference-file>
         <jms:reference-file line="808">Bridge/Api/Flickr.php</jms:reference-file>
+        <jms:reference-file line="1010">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a596c989f20650068f6278338c1a966b7a8693f8" resname="Le token n'a pas encore ete genere" approved="yes">
         <source>Le token n'a pas encore ete genere</source>
@@ -4090,9 +4090,9 @@
       <trans-unit id="e330465da3182b7f6ed1b78217993edb4e22aacb" resname="Les elements ne peuvent etre uploades (problemes de type ou de droit)" approved="yes">
         <source>Les elements ne peuvent etre uploades (problemes de type ou de droit)</source>
         <target state="translated">De elementen kunnen niet worden geuploaded (problemen met het type of met de rechten)</target>
-        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="15">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="15">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="16">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="72d3dbec389dce620bfa531d37c5f199ca2ccfda" resname="Les indications donnees ci dessous sont a titre informatif." approved="yes">
         <source>Les indications donnees ci dessous sont a titre informatif.</source>
@@ -4216,7 +4216,7 @@
       <trans-unit id="4e5a2893bdcc7d239c1db72e4c4ffbe4bea73174" resname="Login">
         <source>Login</source>
         <target>Login</target>
-        <jms:reference-file line="32">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
         <jms:reference-file line="9">login/oauth/login.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/mapping.html.twig</jms:reference-file>
         <jms:reference-file line="7">login/providers/bind.html.twig</jms:reference-file>
@@ -4267,7 +4267,7 @@
       <trans-unit id="ca62571facf94a0b6b601235fa440be30c505b24" resname="Maintenance message" approved="yes">
         <source>Maintenance message</source>
         <target state="translated">Mededeling van onderhoud</target>
-        <jms:reference-file line="22">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
+        <jms:reference-file line="24">Form/Configuration/MaintenanceFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb66e0bf5a145832586ceac41b71a4f95abcbc7e" resname="Maintenance state" approved="yes">
         <source>Maintenance state</source>
@@ -4327,22 +4327,22 @@
       <trans-unit id="bfceb124609fe75ad259082ced98a09429f02d2c" resname="Matomo Analytics identifier">
         <source>Matomo Analytics identifier</source>
         <target state="new">Matomo Analytics identifier</target>
-        <jms:reference-file line="45">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d17f219ba947499e5a2f9b63a78d54deb821e1f8" resname="Matomo Analytics url">
         <source>Matomo Analytics url</source>
         <target state="new">Matomo Analytics url</target>
-        <jms:reference-file line="42">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28736b7711fa32497f69497b45453226c3bea0aa" resname="Maximum megabytes allowed for download" approved="yes">
         <source>Maximum megabytes allowed for download</source>
         <target state="translated">Maximum toegestaan megabytes voor de download</target>
-        <jms:reference-file line="22">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e91bcca4090d4b36db511b03beb7800d72baa230" resname="Maximum number of pages to be extracted from PDF" approved="yes">
         <source>Maximum number of pages to be extracted from PDF</source>
         <target state="translated">Maximum aantal pagina's die uit een PDF kunnen worden gedownload</target>
-        <jms:reference-file line="61">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="66">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="453c592dee2184bc6fb63b94d517cf1a6354590b" resname="Mes applications" approved="yes">
         <source>Mes applications</source>
@@ -4380,7 +4380,7 @@
       <trans-unit id="cb4f425374af2741715669ed8b541a666078b729" resname="Minimum number of letters before truncation" approved="yes">
         <source>Minimum number of letters before truncation</source>
         <target state="translated">Minimum aantal tekens alvorens te ledigen</target>
-        <jms:reference-file line="22">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="35">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="815d1b7d85075463e14c340ff9897a6c4af09ec3" resname="Missing &quot;structure&quot; parameter">
         <source>Missing "structure" parameter</source>
@@ -4550,14 +4550,14 @@
       <trans-unit id="d850ee188c7c55b64bc3624534de5c5051a57dc6" resname="New password" approved="yes">
         <source>New password</source>
         <target state="translated">Nieuw wachtwoord</target>
-        <jms:reference-file line="47">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="39">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="49">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="572cfba6707b8e82f8c893b2188bede937e3f662" resname="New password (confirmation)" approved="yes">
         <source>New password (confirmation)</source>
         <target state="translated">Nieuw wachtwoord (bevestiging)</target>
-        <jms:reference-file line="48">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="40">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="42">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17b2b838c5ce22c961a36736534a5029d6ba0087" resname="New task">
         <source>New task</source>
@@ -4574,8 +4574,8 @@
       <trans-unit id="816c52fd2bdd94a63cd0944823a6c0aa9384c103" resname="No" approved="yes">
         <source>No</source>
         <target state="translated">Nee</target>
-        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="283">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="32">web/developers/applications.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c123d8ad43d08cc48c3d6a7676e65f71eea59df" resname="No URL available" approved="yes">
         <source>No URL available</source>
@@ -4697,19 +4697,19 @@
       <trans-unit id="22838b9a8bf000656dd4ff96d8ac904c8c33fade" resname="Nom du nouveau panier" approved="yes">
         <source>Nom du nouveau panier</source>
         <target state="translated">Naam van het nieuwe mandje</target>
-        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c57d307e10f641b5b496db576d0dcd69d1daf25e" resname="Non-Restreinte (publique)" approved="yes">
         <source>Non-Restreinte (publique)</source>
         <target state="translated">Niet beperkt (publiek)</target>
-        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="25">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="108">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6eef6648406c333a4035cd5e60d0bf2ecf2606d7" resname="None" approved="yes">
         <source>None</source>
         <target state="translated">Geen</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
         <jms:reference-file line="56">web/admin/users.html.twig</jms:reference-file>
         <jms:reference-file line="260">admin/user/registrations.html.twig</jms:reference-file>
       </trans-unit>
@@ -4741,8 +4741,8 @@
       <trans-unit id="a6633333760410e40ad92a50baade0b83afe8f7f" resname="Not aggregated">
         <source>Not aggregated</source>
         <target state="new">Not aggregated</target>
-        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="241">admin/fields/templates.html.twig</jms:reference-file>
+        <jms:reference-file line="17">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cc451929f50e088ffcff10e90dfe157d2319e753" resname="Notification par email" approved="yes">
         <source>Notification par email</source>
@@ -4803,25 +4803,25 @@
       <trans-unit id="997c69f6571530618bb38ac03f4cf2d236dcc15e" resname="Number of replicas">
         <source>Number of replicas</source>
         <target state="new">Number of replicas</target>
-        <jms:reference-file line="66">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="77">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="674">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5c2a8aa4e676273c8d8f177856923ed9950e54bb" resname="Number of shards">
         <source>Number of shards</source>
         <target state="new">Number of shards</target>
-        <jms:reference-file line="62">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="73">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="670">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a44db49e9b745fe2a96ae2a2ef3595913e274b33" resname="Number of threads to use for FFMpeg" approved="yes">
         <source>Number of threads to use for FFMpeg</source>
         <target state="translated">Aantal lijnen te gebruiken voor FFMpeg</target>
-        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ce3bd4224c8c1780db56b4125ecf3f24bf748b7" resname="OK">
         <source>OK</source>
         <target>OK</target>
-        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="535">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="499">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0a98216a32426b9e66a4ac1eb6df2e96e1b495c" resname="Ok">
         <source>Ok</source>
@@ -4872,10 +4872,10 @@
       <trans-unit id="94946e4d2391ccf8ff24f984869ae8fcf9ede7c4" resname="Or login with" approved="yes">
         <source>Or login with</source>
         <target state="translated">Of meld aan met</target>
-        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
         <jms:reference-file line="103">web/login/index.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="91">login/oauth/login.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/login/register.html.twig</jms:reference-file>
+        <jms:reference-file line="56">api/auth/end_user_authorization.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1d75774c0f96b6ee44eb6643c9fea71b50b90ea8" resname="Order" approved="yes">
         <source>Order</source>
@@ -4915,7 +4915,7 @@
       <trans-unit id="77561f3d48cb738cc40f376dec4616a77da54ee1" resname="Original name" approved="yes">
         <source>Original name</source>
         <target state="translated">Originele naam</target>
-        <jms:reference-file line="44">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="672c78971d44f4576ab54c347b873ad9dc98f5f1" resname="Oups ! something went wrong !" approved="yes">
         <source>Oups ! something went wrong !</source>
@@ -4935,9 +4935,9 @@
       <trans-unit id="fb06270f7c212baabc8749ffc36e49dc8f321548" resname="Page" approved="yes">
         <source>Page</source>
         <target state="translated">Pagina</target>
-        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
         <jms:reference-file line="19">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="2">actions/Bridge/paginator.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="600584c2d5ccb97c0c0c424d9f32d6b102fcb040" resname="Pages">
         <source>Pages</source>
@@ -4947,31 +4947,31 @@
       <trans-unit id="fe42b90acc297644b70123354014701c49384489" resname="Paniers" approved="yes">
         <source>Paniers</source>
         <target state="translated">Mandjes</target>
+        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="127">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="173">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/index.html.twig</jms:reference-file>
-        <jms:reference-file line="250">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="55">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="142">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="379c70ed96868079feece6d5c6a2b91545c2515b" resname="Par %author%" approved="yes">
         <source>Par %author%</source>
         <target state="translated">Per %author%</target>
-        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="14">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="25">mobile/lightbox/feed.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8be3c943b1609fffbfc51aad666d0a04adf83c9d" resname="Password" approved="yes">
         <source>Password</source>
         <target state="translated">Wachtwoord</target>
-        <jms:reference-file line="41">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
-        <jms:reference-file line="52">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="81">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e3c007b7794e8f9fc4381136dfc7cdff5aa788a8" resname="Password (confirmation)" approved="yes">
         <source>Password (confirmation)</source>
         <target state="translated">Wachtwoord (bevestiging)</target>
-        <jms:reference-file line="53">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e77cc0549ad99a9d3ba5c384f7f329db24d6d0c" resname="Password is empty at line %line%">
         <source>Password is empty at line %line%</source>
@@ -5001,7 +5001,7 @@
       <trans-unit id="102bbf0d1fb0a23cb8d8fb6eb03685b4509176c0" resname="Percent of the time left before the end of the validation to send a reminder email">
         <source>Percent of the time left before the end of the validation to send a reminder email</source>
         <target state="new">Percent of the time left before the end of the validation to send a reminder email</target>
-        <jms:reference-file line="26">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="3d8de900b56813bb78e97afbf22578720d473219" resname="Periodically fetches an FTP repository content locally">
         <source>Periodically fetches an FTP repository content locally</source>
@@ -5067,14 +5067,14 @@
       <trans-unit id="cd95b41f85ddc0922e3fce8844279c55e9e3cdd9" resname="Playlist" approved="yes">
         <source>Playlist</source>
         <target state="translated">Afspeellijst</target>
-        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="14">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77b69f32c8780049ce0eec9782c3b77bb1e52bc3" resname="Playlists" approved="yes">
         <source>Playlists</source>
         <target state="translated">Afspeellijsten</target>
-        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="183">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="168">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a79729c3f4563330799d576273950579e1ba3f5" resname="Please accept the terms of use to register." approved="yes">
         <source>Please accept the terms of use to register.</source>
@@ -5203,7 +5203,7 @@
       <trans-unit id="40c963556bf21635f163641ae0bbc354c6f8452c" resname="Prefix for notification emails" approved="yes">
         <source>Prefix for notification emails</source>
         <target state="translated">Prefix voor email notificatie</target>
-        <jms:reference-file line="25">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="29">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="474ae549026692693381925784cc30e5b706f330" resname="Prerequisite and Configuration" approved="yes">
         <source>Prerequisite and Configuration</source>
@@ -5218,7 +5218,7 @@
       <trans-unit id="be11dff872b14e749d330f920d6b159e107f277a" resname="Presentation de vignettes de panier" approved="yes">
         <source>Presentation de vignettes de panier</source>
         <target state="translated">Presentatie van de thumbnails in het mandje</target>
-        <jms:reference-file line="998">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1007">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e709e76ff5425bd59879423588e80e67d778fa57" resname="Presets">
         <source>Presets</source>
@@ -5284,13 +5284,13 @@
       <trans-unit id="a255047b3f86eb4c0c79377f0725c89ceafe07ae" resname="Publique" approved="yes">
         <source>Publique</source>
         <target state="translated">Publiek</target>
-        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="40">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="123">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="107e7fab79b95c8f34990d625dd309e15996acba" resname="Publishers" approved="yes">
         <source>Publishers</source>
         <target state="translated">Uitgevers</target>
-        <jms:reference-file line="48">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f7f57b519fc9bc5683b4808641d3b33f53b6f9d" resname="Push">
         <source>Push</source>
@@ -5477,13 +5477,12 @@
         <source>Re-initialiser</source>
         <target state="translated">Herinitialiseren</target>
         <jms:reference-file line="411">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ca2a6abfc98ae1a46c15a6f8bbdc5fac25531462" resname="Re-ordonner" approved="yes">
         <source>Re-ordonner</source>
         <target state="translated">Hersorteren</target>
-        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="13">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="211">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="212">prod/WorkZone/Macros.html.twig</jms:reference-file>
@@ -5491,6 +5490,7 @@
         <jms:reference-file line="290">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="294">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="295">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="12">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9b19a5a212deb29444cc1b420ad81703205848be" resname="Read-only" approved="yes">
         <source>Read-only</source>
@@ -5500,12 +5500,12 @@
       <trans-unit id="8af84354a61a59531041ee67713997b84e7657ee" resname="Recaptcha private key" approved="yes">
         <source>Recaptcha private key</source>
         <target state="translated">Recaptcha private sleutel</target>
-        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="51">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c821a7953fa090cedb78553591582972bd8836e9" resname="Recaptcha public key" approved="yes">
         <source>Recaptcha public key</source>
         <target state="translated">Recaptcha publieke sleutel</target>
-        <jms:reference-file line="45">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="80f271a01202ec6ae47a6b61ad2bd75e4ccb4845" resname="Receive notification when I receive a push" approved="yes">
         <source>Receive notification when I receive a push</source>
@@ -5642,10 +5642,10 @@
       <trans-unit id="d672995a14650d0e018026b64f297663d8c71c8d" resname="Register" approved="yes">
         <source>Register</source>
         <target state="translated">Aanmelden</target>
-        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
         <jms:reference-file line="10">login/include/register-link-block.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register-provider.html.twig</jms:reference-file>
+        <jms:reference-file line="7">web/login/register-classic.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/register.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9ab985702970c5012a1c1a2db7b65d95926aecaf" resname="Register approbation" approved="yes">
         <source>Register approbation</source>
@@ -5677,7 +5677,7 @@
       <trans-unit id="ced7b308a348567fbf21dd775ee496dd01207f24" resname="Remember me" approved="yes">
         <source>Remember me</source>
         <target state="translated">Onthoud mij</target>
-        <jms:reference-file line="51">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
+        <jms:reference-file line="55">Form/Login/PhraseaAuthenticationForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8005b356e3a4dba94a532df1deec4ebce882d13" resname="Reminder : validate '%title%'">
         <source>Reminder : validate '%title%'</source>
@@ -5714,8 +5714,8 @@
         <source>Renew password</source>
         <target state="translated">Vernieuw password</target>
         <jms:reference-file line="58">Notification/Mail/MailRequestPasswordUpdate.php</jms:reference-file>
-        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/login/renew-password.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee9dca727a184d24dd17095c1acacff79855df0d" resname="Reorder collections" approved="yes">
         <source>Reorder collections</source>
@@ -5725,8 +5725,8 @@
       <trans-unit id="fe8356db1811c518f0900dba0e65602c0fdcde3a" resname="Reordonner automatiquement" approved="yes">
         <source>Reordonner automatiquement</source>
         <target state="translated">Automatische bestelling</target>
-        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="4">prod/Story/Reorder.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fc5b6dcdaa76e91a51a264ce56aedb3ac385fc3b" resname="Repertoire de stockage des fichiers" approved="yes">
         <source>Repertoire de stockage des fichiers</source>
@@ -5757,7 +5757,7 @@
       <trans-unit id="0173481a881e3245000ec3fc5da8d26053ec2d37" resname="Require authentication to download documents" approved="yes">
         <source>Require authentication to download documents</source>
         <target state="translated">Inloggen vereist om de documenten te downloaden</target>
-        <jms:reference-file line="33">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c91dfa0024a9c65cb1f4cba0f4744e66fbcccba" resname="Require email validation to activate the account" approved="yes">
         <source>Require email validation to activate the account</source>
@@ -5919,32 +5919,32 @@
       <trans-unit id="741cd64a01685389e2fabdb7091a3b70f6be63ee" resname="SMTP encryption" approved="yes">
         <source>SMTP encryption</source>
         <target state="translated">SMTP-encryptie</target>
-        <jms:reference-file line="40">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2d4a434baeeacaeeeb7e0ad914adfe6f76fb4fb6" resname="SMTP host">
         <source>SMTP host</source>
         <target>SMTP host</target>
-        <jms:reference-file line="34">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0c0c4b23b7cf057f27996bf14973bc8778d0f86e" resname="SMTP password" approved="yes">
         <source>SMTP password</source>
         <target state="translated">SMTP wachtwoord</target>
-        <jms:reference-file line="53">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="57">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="65b5a10871b0ff8eb5019b42bd57ef00c06a45a8" resname="SMTP port" approved="yes">
         <source>SMTP port</source>
         <target state="translated">SMTP poort</target>
-        <jms:reference-file line="37">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="aa18a4725d6a5fd47cfc64a79cfe902abb215068" resname="SMTP user" approved="yes">
         <source>SMTP user</source>
         <target state="translated">SMTP gebruiker</target>
-        <jms:reference-file line="44">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="48">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="78bb8826fcc2504583e625386c238563e6207595" resname="SSL">
         <source>SSL</source>
         <target state="new">SSL</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="8f40d195970d52ea94bbf5b0aa1dbe9822f10dd5" resname="SUBDEFS" approved="yes">
         <source>SUBDEFS</source>
@@ -5954,15 +5954,15 @@
       <trans-unit id="efc007a393f66cdb14d57d385822a3d9e36ef873" resname="Save" approved="yes">
         <source>Save</source>
         <target state="translated">Opslaan</target>
-        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
         <jms:reference-file line="41">web/login/renew-password.html.twig</jms:reference-file>
         <jms:reference-file line="108">actions/Feedback/list.html.twig</jms:reference-file>
+        <jms:reference-file line="53">web/developers/application.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="22">admin/worker-manager/worker_ftp.html.twig</jms:reference-file>
         <jms:reference-file line="75">task-manager/task-editor/task.html.twig</jms:reference-file>
-        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
         <jms:reference-file line="3">admin/search-engine/elastic-search.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/account/change-password.html.twig</jms:reference-file>
+        <jms:reference-file line="3">admin/search-engine/general-aggregation.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="960c9d85e9849fa58deb038c6c9bcf36ec973c99" resname="Save all changes" approved="yes">
         <source>Save all changes</source>
@@ -6018,8 +6018,8 @@
       <trans-unit id="ce3df4d818316dd10c7bca5ae8539c894dc07dbb" resname="See" approved="yes">
         <source>See</source>
         <target state="translated">Zie</target>
-        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="8">WorkZone/Browser/Browser.html.twig</jms:reference-file>
+        <jms:reference-file line="9">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a377f0dd2a261c8e46358dc8d0e8d9868bc6094f" resname="See documentation about structure manipulation.">
         <source>See documentation about structure manipulation.</source>
@@ -6029,14 +6029,14 @@
       <trans-unit id="b5c208620e2d74920057e4d500f77788b86f41db" resname="See documentation at %url%">
         <source>See documentation at %url%</source>
         <target state="new">See documentation at %url%</target>
-        <jms:reference-file line="38">Form/Configuration/WebservicesFormType.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b945126af2994e142e712b4e6f3c2cb2dd186a76" resname="See my order" approved="yes">
         <source>See my order</source>
         <target state="translated">Bekijk mijn opdracht</target>
-        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
         <jms:reference-file line="74">Notification/Mail/MailInfoOrderDelivered.php</jms:reference-file>
+        <jms:reference-file line="75">Notification/Mail/MailInfoOrderCancelled.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="369b9cb821dd6966e989359a1b8aadaf9c4db387" resname="See others" approved="yes">
         <source>See others</source>
@@ -6066,10 +6066,10 @@
       <trans-unit id="913afff1faf79724f1f685fe8b1e36a729123ca2" resname="Select all" approved="yes">
         <source>Select all</source>
         <target state="translated">Alles selecteren</target>
-        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
-        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
         <jms:reference-file line="57">actions/Feedback/list.html.twig</jms:reference-file>
         <jms:reference-file line="224">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="45">web/report/form_date_and_base.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/report/report_layout_child.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7c83f0d10a0a04ab6ae1ceb098113b081e9bc4d5" resname="Select all collections" approved="yes">
         <source>Select all collections</source>
@@ -6103,10 +6103,10 @@
         <target state="translated">Versturen</target>
         <jms:reference-file line="101">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="46">web/login/forgot-password.html.twig</jms:reference-file>
-        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="113">prod/upload/upload.html.twig</jms:reference-file>
         <jms:reference-file line="110">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="330">prod/actions/Push.html.twig</jms:reference-file>
+        <jms:reference-file line="332">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="185">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="220">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/admin/dashboard.html.twig</jms:reference-file>
@@ -6219,8 +6219,8 @@
       <trans-unit id="396c2137a0b503759e5d4930af8a16aa28ce3ee7" resname="Short description" approved="yes">
         <source>Short description</source>
         <target state="translated">Korte beschrijving</target>
-        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="18">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="101">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="32e50dd99f3b67dc93272aa6c904b83d37f4f48d" resname="Shutter speed" approved="yes">
         <source>Shutter speed</source>
@@ -6251,7 +6251,7 @@
       <trans-unit id="234bf52eb70433473b325e23026794557cca00d9" resname="Single image" approved="yes">
         <source>Single image</source>
         <target state="translated">Enkel beeld</target>
-        <jms:reference-file line="53">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e78af337eef67e03f72ea26dbe1a69c326e3660" resname="Site web" approved="yes">
         <source>Site web</source>
@@ -6262,13 +6262,13 @@
         <source>Size</source>
         <target state="translated">Grootte</target>
         <jms:reference-file line="37">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
         <jms:reference-file line="116">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="40">actions/Download/prepare.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="000f280b111f7ab59b5f5f4462a40de0553664cc" resname="Slide show" approved="yes">
         <source>Slide show</source>
         <target state="translated">Diavoorstelling</target>
-        <jms:reference-file line="54">Form/Configuration/GeneralFormType.php</jms:reference-file>
+        <jms:reference-file line="59">Form/Configuration/GeneralFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e6412f8f76fca194e1e7e1c3b13556497ac125db" resname="Some files are being downloaded" approved="yes">
         <source>Some files are being downloaded</source>
@@ -6320,8 +6320,8 @@
       <trans-unit id="8657e88f4bf4b28dd29659361c70f11dea58efa5" resname="Sous-titre" approved="yes">
         <source>Sous-titre</source>
         <target state="translated">Onder titel</target>
-        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="16">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="99">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="970f057325af27424f32675051fea5366873b007" resname="Space bar">
         <source>Space bar</source>
@@ -6336,8 +6336,8 @@
       <trans-unit id="952f375412e89ff213a8aca383d18e5691354347" resname="Start">
         <source>Start</source>
         <target>Start</target>
-        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="12">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="12">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="15">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
@@ -6354,14 +6354,14 @@
       <trans-unit id="7ec5491e76522fe1687d799f35ab2ba39ae573fe" resname="Start validation" approved="yes">
         <source>Start validation</source>
         <target state="translated">Start validatie</target>
+        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
         <jms:reference-file line="47">Notification/Mail/MailInfoReminderFeedback.php</jms:reference-file>
         <jms:reference-file line="70">Notification/Mail/MailInfoValidationReminder.php</jms:reference-file>
-        <jms:reference-file line="87">Notification/Mail/MailInfoValidationRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="faa9e7e7ef5a264c58c68a4a0b9c8bd54241450a" resname="Started">
         <source>Started</source>
         <target state="new">Started</target>
-        <jms:reference-file line="42">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="46">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e1c8377cce4ac872e1c3e8fc6bc760c5130946d" resname="Status des documents a rechercher" approved="yes">
         <source>Status des documents a rechercher</source>
@@ -6388,20 +6388,20 @@
         <target>Stop</target>
         <jms:reference-file line="8">prod/upload/lazaret.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/upload/lazaret.html.twig</jms:reference-file>
-        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="10">admin/worker-manager/worker_validation_reminder.html.twig</jms:reference-file>
+        <jms:reference-file line="10">admin/worker-manager/worker_pull_assets.html.twig</jms:reference-file>
         <jms:reference-file line="20">admin/task-manager/templates.html.twig</jms:reference-file>
         <jms:reference-file line="59">admin/task-manager/templates.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="51e9111b87116e60566740d13ba1c1eddb042333" resname="Stopped">
         <source>Stopped</source>
         <target state="new">Stopped</target>
-        <jms:reference-file line="43">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="47">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67b5fefd39cf2223cfc9023e91571fd2a87cd76a" resname="Stories" approved="yes">
         <source>Stories</source>
         <target state="translated">Verhalen</target>
-        <jms:reference-file line="31">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="44">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="315bc332aafca63cad8ac042c2e2f5111544fe9d" resname="Story Not Found" approved="yes">
@@ -6539,14 +6539,14 @@
       <trans-unit id="dd631af5459e2fae291effe51fbb608d13a75163" resname="Suppression de %n_element% playlists" approved="yes">
         <source>Suppression de %n_element% playlists</source>
         <target state="translated">%n_element% playlists verwijderen</target>
-        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="299c2796a0d682b2495627623e9f228410b8a84a" resname="Suppression de %n_element% videos" approved="yes">
         <source>Suppression de %n_element% videos</source>
         <target state="translated">%n_element% video verwijderen</target>
-        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="6">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1acfc1c7d761310db2e5e876c0cade4d522cfed2" resname="Supprimer" approved="yes">
         <source>Supprimer</source>
@@ -6572,7 +6572,7 @@
       <trans-unit id="d91e1888f2dc09f11a876e25966a6fbd32b9cd87" resname="TLS">
         <source>TLS</source>
         <target state="new">TLS</target>
-        <jms:reference-file line="41">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="45">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a524057f93fd59da6998f240a0602fabc16dfb02" resname="Tableau de bord" approved="yes">
         <source>Tableau de bord</source>
@@ -6582,11 +6582,11 @@
       <trans-unit id="848eed0fbd5429f556b2982dec3ea87136e33e44" resname="Tags" approved="yes">
         <source>Tags</source>
         <target state="translated">Trefwoorden</target>
-        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="49">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="57">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="38">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="68">Bridge/Flickr/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e98caed82acc9fa2f1ba9edeab7789e75e49c36" resname="Target Device" approved="yes">
         <source>Target Device</source>
@@ -6608,12 +6608,12 @@
       <trans-unit id="c78d2fc3a6668b4edc8cf013ce4c6cf8c269b1bf" resname="Task name">
         <source>Task name</source>
         <target state="new">Task name</target>
-        <jms:reference-file line="25">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="29">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b953a851b67dcb4e540270e49fe450d1d613eb1e" resname="Task period (in seconds)">
         <source>Task period (in seconds)</source>
         <target state="new">Task period (in seconds)</target>
-        <jms:reference-file line="32">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="36">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="cf459f472a871f1b053e16008a15cd566921aab0" resname="Technical Informations" approved="yes">
         <source>Technical Informations</source>
@@ -6634,7 +6634,7 @@
       <trans-unit id="97738411d629b01052974cc98ddb83a2cb4f8182" resname="Terms of Use" approved="yes">
         <source>Terms of Use</source>
         <target state="translated">Gebruiksvoorwaarden</target>
-        <jms:reference-file line="62">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="71">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
         <jms:reference-file line="501">web/common/dialog_export.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a6a1d25b018c9318540556e3fe374fdf8b23aff8" resname="Terms of service" approved="yes">
@@ -6653,7 +6653,7 @@
       <trans-unit id="903b3a1a72b51b7b51f85ec8c81def53ed9c9b0c" resname="The Phraseanet Web API allows other web application to rely on this instance">
         <source>The Phraseanet Web API allows other web application to rely on this instance</source>
         <target state="new">The Phraseanet Web API allows other web application to rely on this instance</target>
-        <jms:reference-file line="23">Form/Configuration/APIClientsFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/APIClientsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2558cc2c887bbe4e2444ec6ef83b4982386e871a" resname="The URL you used is out of date, please login" approved="yes">
         <source>The URL you used is out of date, please login</source>
@@ -6767,7 +6767,7 @@
       <trans-unit id="d29ae57dd01be0f4c5b2e1993379c00443a9c937" resname="The task status">
         <source>The task status</source>
         <target state="new">The task status</target>
-        <jms:reference-file line="40">Phrasea/Form/TaskForm.php</jms:reference-file>
+        <jms:reference-file line="44">Phrasea/Form/TaskForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2e77a8fce4b585aac7e3e493f08aa4d8f56bc7e2" resname="The upgrade is already started" approved="yes">
         <source>The upgrade is already started</source>
@@ -6807,7 +6807,7 @@
       <trans-unit id="3fc5195b4a6ff8dc205dbbad17104fa93db88281" resname="Thesaurus Min score">
         <source>Thesaurus Min score</source>
         <target state="new">Thesaurus Min score</target>
-        <jms:reference-file line="70">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="81">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
         <jms:reference-file line="678">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="163fc70a23cf29331bab9896c9a8a0cb0b113bd6" resname="Thesaurus branch" approved="yes">
@@ -6875,7 +6875,7 @@
       <trans-unit id="58e76d1cc6a26f43783774d888c3a260970f637b" resname="This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases." approved="yes">
         <source>This option disables the selecting of the databases on which a user can register himself, and registration is made on all granted databases.</source>
         <target state="translated">Deze optie schakelt het selecteren van databanken waarop een gebruiker zich kan registreren uit en registratie is van toepassing voor alle toegankelijke databanken.</target>
-        <jms:reference-file line="23">Form/Configuration/RegistrationFormType.php</jms:reference-file>
+        <jms:reference-file line="34">Form/Configuration/RegistrationFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="814c3298cccd06ad65ccac8a35e4f2104a4af17e" resname="This user does not participate to the validation but is only viewer." approved="yes">
         <source>This user does not participate to the validation but is only viewer.</source>
@@ -6916,19 +6916,19 @@
       <trans-unit id="eb97899aedcd5609782b5ccb4ffa390e0e66a3eb" resname="Titre" approved="yes">
         <source>Titre</source>
         <target state="translated">Titel</target>
-        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="24">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="29">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="9">prod/Baskets/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/Story/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="54">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="93">admin/publications/fiche.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="01594f4dad04782844c8175778fdf66deabf580d" resname="Toggle loop">
         <source>Toggle loop</source>
@@ -7032,8 +7032,8 @@
       <trans-unit id="c2739616a133e476dda18386df0d2487d526766a" resname="URL de callback" approved="yes">
         <source>URL de callback</source>
         <target state="translated">callback URL</target>
-        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="102">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="44">web/developers/application.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="268f900effee1beb15231a1504d02543e8827bb3" resname="Un document commande" approved="yes">
         <source>Un document commande</source>
@@ -7200,15 +7200,15 @@
         <source>Upload</source>
         <target>Upload</target>
         <jms:reference-file line="94">web/common/menubar.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="16">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="6">Bridge/Flickr/upload.html.twig</jms:reference-file>
         <jms:reference-file line="83">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="101">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="5">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="89">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="8">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9ee782a49540357e87b6dc0dde09d8bec6507af" resname="Upload URL is not set, please contact an admin" approved="yes">
         <source>Upload URL is not set, please contact an admin</source>
@@ -7238,12 +7238,12 @@
       <trans-unit id="ea1fd4c4c366bf2e13d348b67b75e96039d7a1d7" resname="Use Google Chart API">
         <source>Use Google Chart API</source>
         <target state="new">Use Google Chart API</target>
-        <jms:reference-file line="32">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2023f20c3153f9d593dfe4e5447b24866e27bd34" resname="Use a SMTP server" approved="yes">
         <source>Use a SMTP server</source>
         <target state="translated">Gebruik een SMPT server</target>
-        <jms:reference-file line="28">Form/Configuration/EmailFormType.php</jms:reference-file>
+        <jms:reference-file line="32">Form/Configuration/EmailFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="337f9aa5d63611e88aedd8cc09ee1488fb9fe3a4" resname="Use an existing index">
         <source>Use an existing index</source>
@@ -7263,7 +7263,7 @@
       <trans-unit id="c42cc91c040b3c093f851494375a1be868018231" resname="Use recaptcha API" approved="yes">
         <source>Use recaptcha API</source>
         <target state="translated">Gebruik recaptcha API</target>
-        <jms:reference-file line="41">Form/Configuration/WebservicesFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/WebservicesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="17a74b77867e7b3f4f5e5b2ad90be36cf800dfda" resname="Use the Flash uploader" approved="yes">
         <source>Use the Flash uploader</source>
@@ -7280,22 +7280,22 @@
       <trans-unit id="1d2b0439bd02b54c622696c45588eab8d051dfb9" resname="Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token" approved="yes">
         <source>Use with mod_token. Attention requires the apache modules and mod_h264_streaming mod_auth_token</source>
         <target state="translated">Gebruik met mod_token. Opgepast heeft de apache modelus en mod_h264_streaming mod_auth_token nodig.</target>
-        <jms:reference-file line="31">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="37">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="73e8bd6eff9e8b1460684911486ad731e3097ab2" resname="Used for guest account" approved="yes">
         <source>Used for guest account</source>
         <target state="translated">Gebruikt voor gast toegang</target>
-        <jms:reference-file line="34">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="47">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="84e635021b5a8691329da2b22cbdbb7137ddc018" resname="Used in search engine" approved="yes">
         <source>Used in search engine</source>
         <target state="translated">Gebruikt in de zoekmachine</target>
-        <jms:reference-file line="23">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="36">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a54e4b6b720a84b428f0feda87f35d92cc219ee7" resname="Used when opening the application" approved="yes">
         <source>Used when opening the application</source>
         <target state="translated">Gebruikt tijdens het openen van het programma</target>
-        <jms:reference-file line="30">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
+        <jms:reference-file line="43">Form/Configuration/SearchEngineFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5bb94bfadf4a04bc6b31a3298c5f19a7dead6769" resname="User already exists" approved="yes">
         <source>User already exists</source>
@@ -7350,7 +7350,7 @@
       <trans-unit id="3482565eef4d4cd1decb5ebfad6ecfc5943d30da" resname="Users must accept Terms of Use for each export" approved="yes">
         <source>Users must accept Terms of Use for each export</source>
         <target state="translated">Gebruiker moet gebruiksvoorwaarden aanvaarden bij iedere export</target>
-        <jms:reference-file line="37">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28f4718f1cf2cd1f31d49c8bce276341ffe222bd" resname="Users suggestion" approved="yes">
         <source>Users suggestion</source>
@@ -7365,8 +7365,8 @@
       <trans-unit id="3b3e9155f69edf73caab337bf5f64231188b1e48" resname="VALIDATION" approved="yes">
         <source>VALIDATION</source>
         <target state="translated">VALIDATIE</target>
-        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="6">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="112">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e400a7eef4ab49bbe657b3e3c557d64e091a356" resname="Validate e-mail address" approved="yes">
         <source>Validate e-mail address</source>
@@ -7376,9 +7376,9 @@
       <trans-unit id="dd74d182c641e4c78502d863b44d0aeff1575e54" resname="Validation" approved="yes">
         <source>Validation</source>
         <target state="translated">Goedkeuring</target>
+        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validate.php</jms:reference-file>
         <jms:reference-file line="78">eventsmanager/notify/validate.php</jms:reference-file>
-        <jms:reference-file line="23">eventsmanager/notify/validationdone.php</jms:reference-file>
         <jms:reference-file line="20">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="79">eventsmanager/notify/validationreminder.php</jms:reference-file>
         <jms:reference-file line="86">lightbox/IE6/validate.html.twig</jms:reference-file>
@@ -7396,9 +7396,9 @@
       <trans-unit id="6c259e54dcc7188e7cfe33403eca78cda53017fc" resname="Validations" approved="yes">
         <source>Validations</source>
         <target state="translated">Controles</target>
+        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="119">lightbox/IE6/validate.html.twig</jms:reference-file>
         <jms:reference-file line="165">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="20">web/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="51">mobile/lightbox/index.html.twig</jms:reference-file>
         <jms:reference-file line="100">mobile/lightbox/index.html.twig</jms:reference-file>
       </trans-unit>
@@ -7415,7 +7415,7 @@
       <trans-unit id="0cedbcdb95addc9f8d1b024fcbaf3d87dc6d044b" resname="Validity period of the download links">
         <source>Validity period of the download links</source>
         <target state="new">Validity period of the download links</target>
-        <jms:reference-file line="61">Form/Configuration/ActionsFormType.php</jms:reference-file>
+        <jms:reference-file line="74">Form/Configuration/ActionsFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="db671097785924a80ca79c2a37675116e90899e8" resname="Vers quel API voulez vous vous connecter ?" approved="yes">
         <source>Vers quel API voulez vous vous connecter ?</source>
@@ -7455,8 +7455,8 @@
       <trans-unit id="56b71e89fb1079caaadefd0889e9a22e8b0560e3" resname="Videos" approved="yes">
         <source>Videos</source>
         <target state="translated">Video's</target>
-        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
         <jms:reference-file line="174">Bridge/Api/Dailymotion.php</jms:reference-file>
+        <jms:reference-file line="159">Bridge/Api/Youtube.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="18af7efc4ef7f30783dbb1ad1bc0b9aed857a19c" resname="View on %title%">
         <source>View on %title%</source>
@@ -7608,10 +7608,10 @@
       <trans-unit id="12ee49ba726f4422d3dcc6bc7b92ab9de279d211" resname="Vous n'avez selectionne aucun element" approved="yes">
         <source>Vous n'avez selectionne aucun element</source>
         <target state="translated">U hebt geen enkel element geselecteerd</target>
+        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Bridge/index.html.twig</jms:reference-file>
         <jms:reference-file line="14">Bridge/Flickr/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5e8fd52d6c7e92e6907f1148d2e458871d17c1ae" resname="Vous ne pouvez pas editer plusieurs elements simultanement" approved="yes">
         <source>Vous ne pouvez pas editer plusieurs elements simultanement</source>
@@ -7657,8 +7657,8 @@
       <trans-unit id="94bfa418b59cf2b1d326f614666ece16ef9cbded" resname="Watch my access requests status" approved="yes">
         <source>Watch my access requests status</source>
         <target state="translated">Bekijk de status van mijn toegangsaanvraag</target>
-        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
         <jms:reference-file line="39">Notification/Mail/MailSuccessEmailConfirmationUnregistered.php</jms:reference-file>
+        <jms:reference-file line="39">Notification/Mail/MailSuccessAccessRequest.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="d67f8b5513fcc1166cb7086a07bf29144de7c879" resname="Watermark" approved="yes">
         <source>Watermark</source>
@@ -7698,8 +7698,8 @@
       <trans-unit id="ceffd5b622d10de1a19822471cb3804cb61cba28" resname="Which playlist you want to put you %number% elements into ?" approved="yes">
         <source>Which playlist you want to put you %number% elements into ?</source>
         <target state="translated">In welke playlist wilt u %number% items plaatsen ?</target>
-        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="13">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6e2507e568a039431c507b30f44aa72cbb1ed929" resname="Whoops, looks like something went wrong." approved="yes">
         <source>Whoops, looks like something went wrong.</source>
@@ -7744,9 +7744,9 @@
       <trans-unit id="5397e0583f14f6c88de06b1ef28f460a1fb5b0ae" resname="Yes" approved="yes">
         <source>Yes</source>
         <target state="translated">Ja</target>
+        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="33">web/developers/applications.html.twig</jms:reference-file>
         <jms:reference-file line="13">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="284">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4de66b40cf0800d4a25cc75b4f3f593cfc44ef6c" resname="You are Admin" approved="yes">
         <source>You are Admin</source>
@@ -8060,85 +8060,85 @@
       <trans-unit id="162536d0e4aeccdde8b707acd6111800a25d549b" resname="action : bridge" approved="yes">
         <source>action : bridge</source>
         <target state="translated">Bridge</target>
-        <jms:reference-file line="1038">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3ffc763c6cf92695a7ce387f904bbe6e7a94bdbc" resname="action : collection" approved="yes">
         <source>action : collection</source>
         <target state="translated">Collectie</target>
-        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="38">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="35">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="87">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ddc3c6161fab39cbaf5d3f59af82090b32a2c36c" resname="action : editer" approved="yes">
         <source>action : editer</source>
         <target state="translated">Wijzigen</target>
         <jms:reference-file line="10">prod/preview/caption.html.twig</jms:reference-file>
-        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="24">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="71">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b62efbefb9b0e40c14ac8218ac4257603c5b75c" resname="action : exporter" approved="yes">
         <source>action : exporter</source>
         <target state="translated">Exporteer</target>
-        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="25">prod/preview/tools.html.twig</jms:reference-file>
-        <jms:reference-file line="1040">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="52">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="128">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="129">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="130">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="6">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="7">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="123">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="155">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="211">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b0c9b7eb3d21f5a48ac5ecb0a0d969b8d3818e41" resname="action : outils" approved="yes">
         <source>action : outils</source>
         <target state="translated">Gereedschappen</target>
-        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="70">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="67">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="122">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="71e15cbcf85fd5fe848fe7fa210fa8318a09f842" resname="action : print" approved="yes">
         <source>action : print</source>
         <target state="translated">Print</target>
         <jms:reference-file line="20">prod/preview/tools.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="56">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="138">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="139">prod/results/record.html.twig</jms:reference-file>
         <jms:reference-file line="140">prod/results/record.html.twig</jms:reference-file>
-        <jms:reference-file line="10">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d222a71a73f44cb6bdf237790f350f0b1fb9eb1f" resname="action : publier" approved="yes">
         <source>action : publier</source>
         <target state="translated">Publiceren</target>
-        <jms:reference-file line="1039">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="63">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17948b21adfde1bf589b2a34a2c8253e2af91913" resname="action : push" approved="yes">
         <source>action : push</source>
         <target state="translated">Push</target>
-        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="47">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="44">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="99">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f22184cfa5be236b7193d80d5f8407a36b108b79" resname="action : status" approved="yes">
         <source>action : status</source>
         <target state="translated">Status</target>
-        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
-        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="31">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="28">prod/WorkZone/Basket.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="24ade348bc49c69cced4d173e31f7369aa466772" resname="action : supprimer" approved="yes">
         <source>action : supprimer</source>
         <target state="translated">Verwijderen</target>
-        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
         <jms:reference-file line="221">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="222">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="132">web/prod/toolbar.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b88ca5fbb2e89cb79b08c981283383361be312bf" resname="action:: nouveau panier" approved="yes">
         <source>action:: nouveau panier</source>
@@ -8551,21 +8551,21 @@
       <trans-unit id="df2642eaa7386518762050a368f5d2c49a3fe42a" resname="admin::compte-utilisateur activite" approved="yes">
         <source>admin::compte-utilisateur activite</source>
         <target state="translated">Activiteit</target>
-        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="312">Controller/Admin/UserController.php</jms:reference-file>
-        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="104">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="122">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="221">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="501">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="10b0a44531159b40162fd9349abbe2bd21946c3e" resname="admin::compte-utilisateur adresse" approved="yes">
         <source>admin::compte-utilisateur adresse</source>
         <target state="translated">Adres</target>
-        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="304">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="69">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="363">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="87">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="225">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="460">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e922f2ca7321d1d1f403e937dbf109db04bac722" resname="admin::compte-utilisateur changer mon mot de passe" approved="yes">
         <source>admin::compte-utilisateur changer mon mot de passe</source>
@@ -8575,11 +8575,11 @@
       <trans-unit id="218d3257842bd2817f0ba7bcd02f3729c60e591d" resname="admin::compte-utilisateur code postal" approved="yes">
         <source>admin::compte-utilisateur code postal</source>
         <target state="translated">Postcode</target>
-        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="306">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="76">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="370">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="94">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="468">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="bc2f858e3323d3baa8be27661724b11ce9c0a57b" resname="admin::compte-utilisateur confirmer la nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur confirmer la nouvelle adresse email</source>
@@ -8599,23 +8599,23 @@
       <trans-unit id="d79bdc62fa5ecc611e96fe7ab9f5cf4d4debabae" resname="admin::compte-utilisateur email" approved="yes">
         <source>admin::compte-utilisateur email</source>
         <target state="translated">Email</target>
-        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="301">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="117">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="335">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="112">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="22">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="452">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="215">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d194728e348f759c2a443df96338ba1e2c8adfb5" resname="admin::compte-utilisateur fax" approved="yes">
         <source>admin::compte-utilisateur fax</source>
         <target state="translated">Fax</target>
-        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="309">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="118">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="384">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="136">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="518">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6e2b9ddcaf97ba5258571cb54935f1ff6b581a2" resname="admin::compte-utilisateur id utilisateur" approved="yes">
         <source>admin::compte-utilisateur id utilisateur</source>
@@ -8627,34 +8627,34 @@
         <target state="translated">Identificatie</target>
         <jms:reference-file line="36">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="19">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
-        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="35">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="188">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="49">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="97">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="211">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="416">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f5fe48877b8b43297cc3c999ab84bbe0bd60f5af" resname="admin::compte-utilisateur mot de passe" approved="yes">
         <source>admin::compte-utilisateur mot de passe</source>
         <target state="translated">Paswoord</target>
-        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
-        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="195">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="27">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="50">api/auth/end_user_authorization.html.twig</jms:reference-file>
+        <jms:reference-file line="562">web/setup/step2.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0e2d7957bf48ebf857d73e4395e78fa73e193b5d" resname="admin::compte-utilisateur nom" approved="yes">
         <source>admin::compte-utilisateur nom</source>
         <target state="translated">Naam</target>
-        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="299">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="115">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="62">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="321">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="13">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="444">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="60">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1dbac236fd2ee8bcce590e0cdc7c4a418885c52b" resname="admin::compte-utilisateur nouvelle adresse email" approved="yes">
         <source>admin::compte-utilisateur nouvelle adresse email</source>
@@ -8670,42 +8670,42 @@
       <trans-unit id="28c517ddecdb662c767290d2e1fa53ef198307fa" resname="admin::compte-utilisateur poste" approved="yes">
         <source>admin::compte-utilisateur poste</source>
         <target state="translated">Postcode</target>
-        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="310">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="90">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="356">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="108">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="219">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="485">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eadb6eaa53204a688e4059a35261b6878fda8b37" resname="admin::compte-utilisateur prenom" approved="yes">
         <source>admin::compte-utilisateur prenom</source>
         <target state="translated">Voornaam</target>
-        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
         <jms:reference-file line="300">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="116">Event/Subscriber/RegistrationSubscriber.php</jms:reference-file>
+        <jms:reference-file line="55">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="328">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="67">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="213">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="436">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0ee82fdcf687c10dd1e5040a5b84d9a90d079a9a" resname="admin::compte-utilisateur sexe" approved="yes">
         <source>admin::compte-utilisateur sexe</source>
         <target state="translated">Geslacht</target>
         <jms:reference-file line="44">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
-        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="424">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="78b65792aca82024d5f1ff60dec83a501c01e15e" resname="admin::compte-utilisateur societe" approved="yes">
         <source>admin::compte-utilisateur societe</source>
         <target state="translated">Bedrijf</target>
-        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="311">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="97">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="349">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="107">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="16">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="493">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="217">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="115">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d15ba95c86a58884d598415b8f8a400ab636cd9" resname="admin::compte-utilisateur tel" approved="yes">
         <source>admin::compte-utilisateur tel</source>
@@ -8717,10 +8717,10 @@
         <target state="translated">Telefoon</target>
         <jms:reference-file line="308">Controller/Admin/UserController.php</jms:reference-file>
         <jms:reference-file line="342">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
         <jms:reference-file line="19">web/admin/connected-users.html.twig</jms:reference-file>
         <jms:reference-file line="510">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="223">admin/user/registrations.html.twig</jms:reference-file>
-        <jms:reference-file line="129">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="29d3952c833272679cb313988c698f11cb6bbb64" resname="admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer" approved="yes">
         <source>admin::compte-utilisateur un email de confirmation vient de vous etre envoye. Veuillez suivre les instructions contenue pour continuer</source>
@@ -8730,11 +8730,11 @@
       <trans-unit id="00a39eeb4e86af2189a6080e16418d249d98a12b" resname="admin::compte-utilisateur ville" approved="yes">
         <source>admin::compte-utilisateur ville</source>
         <target state="translated">Star</target>
-        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="305">Controller/Admin/UserController.php</jms:reference-file>
+        <jms:reference-file line="83">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="377">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="101">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="476">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f752312fcd370b6547b296ca173da51487a2c5d" resname="admin::compte-utilisateur: L'email a correctement ete mis a jour" approved="yes">
         <source>admin::compte-utilisateur: L'email a correctement ete mis a jour</source>
@@ -8823,24 +8823,24 @@
         <target state="translated">Mevrouw</target>
         <jms:reference-file line="50">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="314">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="50">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="429">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7af00728508b30971b5cd3eb769433546ad9abfa" resname="admin::compte-utilisateur:sexe: mademoiselle" approved="yes">
         <source>admin::compte-utilisateur:sexe: mademoiselle</source>
         <target state="translated">Jufrouw</target>
         <jms:reference-file line="49">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="313">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="47">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="428">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db663dadd7bd9b045a68cafcfe2ca4e0c832e50a" resname="admin::compte-utilisateur:sexe: monsieur" approved="yes">
         <source>admin::compte-utilisateur:sexe: monsieur</source>
         <target state="translated">De heer</target>
         <jms:reference-file line="51">Core/Provider/RegistrationServiceProvider.php</jms:reference-file>
         <jms:reference-file line="315">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
         <jms:reference-file line="53">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="430">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cfc904c9a87afe2d3986041a6bdb542298607880" resname="admin::monitor: bases sur lesquelles l'utilisateur est connecte :" approved="yes">
         <source>admin::monitor: bases sur lesquelles l'utilisateur est connecte :</source>
@@ -8923,10 +8923,10 @@
       <trans-unit id="14e4b19f7496c10dbb05e61dee0c436c0792235f" resname="admin::monitor: module validation" approved="yes">
         <source>admin::monitor: module validation</source>
         <target state="translated">Lightbox</target>
+        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="207">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="238">Phrasea/Controller/LightboxController.php</jms:reference-file>
         <jms:reference-file line="315">Phrasea/Controller/LightboxController.php</jms:reference-file>
-        <jms:reference-file line="121">Controller/Admin/ConnectedUsersController.php</jms:reference-file>
         <jms:reference-file line="85">lib/classes/phrasea.php</jms:reference-file>
         <jms:reference-file line="78">web/common/menubar.html.twig</jms:reference-file>
       </trans-unit>
@@ -9617,6 +9617,17 @@
         <target state="new">admin:phrasea-service-setting:tab:expose:: connection test</target>
         <jms:reference-file line="69">admin/phraseanet-service/expose.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="6d3478b79db541608a0ba8e3877cba7c52256add" resname="admin:searchengine:aggregates:New field, please confirm setting.">
+        <source>admin:searchengine:aggregates:New field, please confirm setting.</source>
+        <target state="new">admin:searchengine:aggregates:New field, please confirm setting.</target>
+        <jms:reference-file line="146">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+        <jms:reference-file line="157">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="b6dee9dc48adef7fe2f3a1e52b98e7a009fef83d" resname="admin:searchengine:aggregates:This field does not exists in current databoxes.">
+        <source>admin:searchengine:aggregates:This field does not exists in current databoxes.</source>
+        <target state="new">admin:searchengine:aggregates:This field does not exists in current databoxes.</target>
+        <jms:reference-file line="136">SearchEngine/Elastic/ElasticsearchSettingsFormType.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8f3cd845b8adbcdf064486cdd24733f53bce8bb3" resname="admin:worker Retrieve configuration error">
         <source>admin:worker Retrieve configuration error</source>
         <target state="new">admin:worker Retrieve configuration error</target>
@@ -9625,8 +9636,8 @@
       <trans-unit id="8f1dba76b561684930a25a984046b3b4149785ca" resname="alert">
         <source>alert</source>
         <target>alert</target>
-        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="306">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="256">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="edde11c24ed5e6df4e416143e77248e908567faa" resname="all caches services have been flushed" approved="yes">
         <source>all caches services have been flushed</source>
@@ -9698,14 +9709,14 @@
       <trans-unit id="e2c1d05cc230f0bd66de9600c3304eaf374ffa24" resname="basket:action:delete record form basket">
         <source>basket:action:delete record form basket</source>
         <target state="new">basket:action:delete record form basket</target>
-        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="15">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="378b261cf0bdda80ad072999d7bed4361180c838" resname="basket:action:delete record form database">
         <source>basket:action:delete record form database</source>
         <target state="new">basket:action:delete record form database</target>
-        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="79">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c501b5741b2a182f189a0ee99109f2a55fd2aaa8" resname="basket:feedback Delete item">
         <source>basket:feedback Delete item</source>
@@ -9748,48 +9759,48 @@
         <jms:reference-file line="250">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="404">web/common/dialog_export.html.twig</jms:reference-file>
         <jms:reference-file line="487">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
+        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
         <jms:reference-file line="119">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="69">web/thesaurus/import-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="228">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="653">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1054">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1173">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="90">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="142">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="159">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="172">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="55">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="73">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="23">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="40">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="13">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="71">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="255">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="374">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="47">admin/collection/create.html.twig</jms:reference-file>
-        <jms:reference-file line="129">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="47">web/admin/index.html.twig</jms:reference-file>
-        <jms:reference-file line="49">web/account/reset-email.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c6f716e883e5747e4bc8a8afc7a0ec1ccf44e0b5" resname="boutton::appliquer" approved="yes">
         <source>boutton::appliquer</source>
         <target state="translated">Toepassen</target>
-        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="40">WorkerManager/Form/WorkerConfigurationType.php</jms:reference-file>
+        <jms:reference-file line="47">WorkerManager/Form/WorkerValidationReminderType.php</jms:reference-file>
         <jms:reference-file line="43">WorkerManager/Form/WorkerPullAssetsType.php</jms:reference-file>
         <jms:reference-file line="77">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb7084f3be2ac7d8cf870a9bb83df976dc65ad5b" resname="boutton::chercher" approved="yes">
         <source>boutton::chercher</source>
         <target state="translated">zoeken</target>
-        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="126">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="61">web/admin/users.html.twig</jms:reference-file>
+        <jms:reference-file line="659">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1179">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a71090794c12d5b26f62d9f0c68c0d894f7e00e" resname="boutton::choisir" approved="yes">
         <source>boutton::choisir</source>
@@ -9811,14 +9822,14 @@
       <trans-unit id="32e5c3419a0a410255ee44e462fd7329f708873f" resname="boutton::demarrer" approved="yes">
         <source>boutton::demarrer</source>
         <target state="translated">Starten</target>
-        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="9">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d49d2b52ce2f1912f7ada4a3f57ab39fd2e9904e" resname="boutton::editer" approved="yes">
         <source>boutton::editer</source>
         <target state="translated">Bewerken</target>
-        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="26">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="21">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6b126c214de4c40550d9dc32b02766809b1cac1a" resname="boutton::enregistrer" approved="yes">
         <source>boutton::enregistrer</source>
@@ -9846,16 +9857,16 @@
         <target state="translated">Sluiten</target>
         <jms:reference-file line="59">Controller/Prod/LanguageController.php</jms:reference-file>
         <jms:reference-file line="90">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
         <jms:reference-file line="23">web/lightbox/sc_note.html.twig</jms:reference-file>
-        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
-        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
+        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
         <jms:reference-file line="45">web/thesaurus/link-field-step3.html.twig</jms:reference-file>
         <jms:reference-file line="115">web/thesaurus/accept.html.twig</jms:reference-file>
         <jms:reference-file line="129">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="24">web/report/all_content.html.twig</jms:reference-file>
-        <jms:reference-file line="11">prod/actions/Push.html.twig</jms:reference-file>
-        <jms:reference-file line="393">prod/actions/edit_default.html.twig</jms:reference-file>
-        <jms:reference-file line="398">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="105">web/thesaurus/properties.html.twig</jms:reference-file>
+        <jms:reference-file line="36">web/thesaurus/export-topics.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ce91bb36902944da7788997865b8c482a59e80fe" resname="boutton::generer" approved="yes">
         <source>boutton::generer</source>
@@ -9870,9 +9881,9 @@
       <trans-unit id="1e4c65d295605a0e884818b5c06d32a63fd692d5" resname="boutton::modifier" approved="yes">
         <source>boutton::modifier</source>
         <target state="translated">bewerken</target>
-        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
-        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="1">Bridge/Dailymotion/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Youtube/actionelement.html.twig</jms:reference-file>
+        <jms:reference-file line="1">Bridge/Flickr/actionelement.html.twig</jms:reference-file>
         <jms:reference-file line="65">web/admin/users.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef6ccc2669466ac98a3d580bd7bab8f33d0e4bcc" resname="boutton::monter" approved="yes">
@@ -9883,22 +9894,22 @@
       <trans-unit id="a6083d9bc73ab5df12f4949b67577186f6e8c240" resname="boutton::pause" approved="yes">
         <source>boutton::pause</source>
         <target state="translated">Pauze</target>
-        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="12">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="28bb622fa0fe835d89deb626494ce572cbd27072" resname="boutton::precedent" approved="yes">
         <source>boutton::precedent</source>
         <target state="translated">vorige</target>
+        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="426">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="516">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="629">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="696">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="754">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="866">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="3">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="6">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5ac4cff651bd34d7b0f295259a0c0907d6af5cd1" resname="boutton::rechercher" approved="yes">
         <source>boutton::rechercher</source>
@@ -9929,26 +9940,26 @@
       <trans-unit id="e0af1d0d7872c48928d4faef76c45567426e62f9" resname="boutton::retour" approved="yes">
         <source>boutton::retour</source>
         <target state="translated">terug</target>
-        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
-        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
         <jms:reference-file line="28">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
         <jms:reference-file line="20">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="20">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="25">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
+        <jms:reference-file line="37">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="54">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="20">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="28">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
+        <jms:reference-file line="116">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="154">web/developers/application.html.twig</jms:reference-file>
         <jms:reference-file line="223">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="44">admin/collection/details.html.twig</jms:reference-file>
         <jms:reference-file line="50">user/import/file.html.twig</jms:reference-file>
-        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
         <jms:reference-file line="162">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="64">admin/databox/details.html.twig</jms:reference-file>
+        <jms:reference-file line="531">web/admin/editusers.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a7a9651d909792bcf98f2d1e96c43cb1d3a618e4" resname="boutton::retry" approved="yes">
         <source>boutton::retry</source>
@@ -9958,55 +9969,55 @@
       <trans-unit id="bd9ec3151bdf1eae02e402222d4e36949525a27f" resname="boutton::suivant" approved="yes">
         <source>boutton::suivant</source>
         <target state="translated">volgende</target>
+        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="365">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="429">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="519">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="632">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="699">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="757">web/setup/step2.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/sc_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/lightbox/feed_options_box.html.twig</jms:reference-file>
-        <jms:reference-file line="18">web/lightbox/feed_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a83f74309cdfc79345f54eb1f4e4e2747316f820" resname="boutton::supprimer" approved="yes">
         <source>boutton::supprimer</source>
         <target state="translated">verwijderen</target>
         <jms:reference-file line="43">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
         <jms:reference-file line="130">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
-        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
-        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
-        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
-        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
         <jms:reference-file line="35">Bridge/Dailymotion/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Dailymotion/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="26">actions/Bridge/disconnected.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Youtube/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Youtube/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="35">Bridge/Flickr/actionelements.html.twig</jms:reference-file>
+        <jms:reference-file line="21">Bridge/Flickr/actioncontainers.html.twig</jms:reference-file>
+        <jms:reference-file line="29">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="24">prod/results/feeds_entry.html.twig</jms:reference-file>
+        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
         <jms:reference-file line="93">admin/collection/suggested_value.html.twig</jms:reference-file>
         <jms:reference-file line="136">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="151">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="176">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="201">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="162">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="95">admin/publications/list.html.twig</jms:reference-file>
         <jms:reference-file line="410">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="6">web/thesaurus/presets.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="68b702f13ff62025c57948bf5c4a5b47af10dee9" resname="boutton::telecharger" approved="yes">
         <source>boutton::telecharger</source>
         <target state="translated">Downloaden</target>
         <jms:reference-file line="160">web/common/dialog_export.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
         <jms:reference-file line="21">web/lightbox/feed_options_box.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/lightbox/sc_options_box.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4288c5788ee74d7fa3f325987a8e752687b43023" resname="boutton::telecharger tous les documents" approved="yes">
         <source>boutton::telecharger tous les documents</source>
         <target state="translated">Alle documenten downloaden</target>
-        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="99">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="101">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="136">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="184">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a14c32cf4cd3784ed567e115f3ef016ad2ee2265" resname="boutton::tester" approved="yes">
         <source>boutton::tester</source>
@@ -10018,57 +10029,57 @@
         <source>boutton::valider</source>
         <target state="translated">bevestigen</target>
         <jms:reference-file line="49">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
-        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
-        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
-        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
-        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
-        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
-        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
         <jms:reference-file line="886">web/prod/index.html.twig</jms:reference-file>
-        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
-        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
-        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
         <jms:reference-file line="70">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="19">Bridge/Dailymotion/video_deleteelement.html.twig</jms:reference-file>
-        <jms:reference-file line="24">Bridge/Dailymotion/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Dailymotion/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Dailymotion/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="36">Bridge/Youtube/playlist_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="70">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/video_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Youtube/video_moveinto_playlist.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Youtube/playlist_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="53">Bridge/Flickr/photoset_createcontainer.html.twig</jms:reference-file>
+        <jms:reference-file line="39">Bridge/Flickr/photo_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photo_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="19">Bridge/Flickr/photoset_deleteelement.html.twig</jms:reference-file>
+        <jms:reference-file line="27">Bridge/Flickr/photo_moveinto_photoset.html.twig</jms:reference-file>
         <jms:reference-file line="351">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="373">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="20">prod/Baskets/Reorder.html.twig</jms:reference-file>
         <jms:reference-file line="7">prod/Baskets/Update.html.twig</jms:reference-file>
+        <jms:reference-file line="20">prod/Story/Reorder.html.twig</jms:reference-file>
+        <jms:reference-file line="121">web/developers/application_form.html.twig</jms:reference-file>
+        <jms:reference-file line="21">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
+        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
+        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
         <jms:reference-file line="130">admin/collection/suggested_value.html.twig</jms:reference-file>
-        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="46">admin/collection/create.html.twig</jms:reference-file>
         <jms:reference-file line="58">admin/collection/collection.html.twig</jms:reference-file>
-        <jms:reference-file line="128">admin/publications/fiche.html.twig</jms:reference-file>
-        <jms:reference-file line="45">admin/publications/list.html.twig</jms:reference-file>
-        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
-        <jms:reference-file line="83">web/admin/setup.html.twig</jms:reference-file>
-        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
-        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
-        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="39">admin/collection/reorder.html.twig</jms:reference-file>
         <jms:reference-file line="41">user/import/view.html.twig</jms:reference-file>
+        <jms:reference-file line="274">admin/user/registrations.html.twig</jms:reference-file>
+        <jms:reference-file line="34">web/admin/structure.html.twig</jms:reference-file>
         <jms:reference-file line="159">admin/statusbit/edit.html.twig</jms:reference-file>
-        <jms:reference-file line="48">web/account/reset-email.html.twig</jms:reference-file>
-        <jms:reference-file line="229">web/account/account.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/access.html.twig</jms:reference-file>
+        <jms:reference-file line="403">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="111">web/admin/dashboard.html.twig</jms:reference-file>
+        <jms:reference-file line="530">web/admin/editusers.html.twig</jms:reference-file>
+        <jms:reference-file line="57">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="75">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="74">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="160">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="143">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="91">web/thesaurus/link-field-step2.html.twig</jms:reference-file>
+        <jms:reference-file line="51">web/thesaurus/index.html.twig</jms:reference-file>
+        <jms:reference-file line="120">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="70">web/thesaurus/import-dialog.html.twig</jms:reference-file>
+        <jms:reference-file line="229">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="1060">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="34">mobile/lightbox/note_form.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b27b98c3e0119082312d402ca0b89dd39f00f5c8" resname="boutton::vue graphique" approved="yes">
@@ -10263,8 +10274,8 @@
       <trans-unit id="dbfe8cf37a8d7b4941dd9f89e79302038b2bedef" resname="dans %feed_name%" approved="yes">
         <source>dans %feed_name%</source>
         <target state="translated">in %feed_name%</target>
-        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
         <jms:reference-file line="52">prod/results/entry.html.twig</jms:reference-file>
+        <jms:reference-file line="48">prod/results/feeds_entry.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="aab7fdd9c18941cbc8d78fa0c690361ffd8c50bf" resname="date dajout" approved="yes">
         <source>date dajout</source>
@@ -10313,10 +10324,10 @@
       <trans-unit id="9ead47a82a0d25985f22f10651d1f93b3abba317" resname="edit">
         <source>edit</source>
         <target state="new">edit</target>
-        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
         <jms:reference-file line="32">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="143">web/account/account.html.twig</jms:reference-file>
         <jms:reference-file line="164">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="82">prod/WorkZone/Macros.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd35f7126454c3af225a579bd27f89176be81c3d" resname="edit: chosiir limage du regroupement" approved="yes">
         <source>edit: chosiir limage du regroupement</source>
@@ -10640,12 +10651,12 @@
       <trans-unit id="0d25ab4ea387d19f49a120acb928c7f9500b0cf3" resname="index::advance_search: disable-facet">
         <source>index::advance_search: disable-facet</source>
         <target state="new">index::advance_search: disable-facet</target>
-        <jms:reference-file line="911">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="16b1c68bd21754876991dfc8df38b024383fbca4" resname="index::advance_search: facet">
         <source>index::advance_search: facet</source>
         <target state="new">index::advance_search: facet</target>
-        <jms:reference-file line="907">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="909">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2f830d57f4cedb2a49c7b109f9b91b0f8ba83e8b" resname="index::advance_search: facet-order">
         <source>index::advance_search: facet-order</source>
@@ -10665,7 +10676,7 @@
       <trans-unit id="dfb02fcdeb804315cd6ad8388efcfb4ccc4abf38" resname="index::advance_search: hidden-facet-values-order">
         <source>index::advance_search: hidden-facet-values-order</source>
         <target state="new">index::advance_search: hidden-facet-values-order</target>
-        <jms:reference-file line="913">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="921">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a35cc75d1072f7dad99c8e91596298f55f20a54" resname="index::advance_search: order-by-hits">
         <source>index::advance_search: order-by-hits</source>
@@ -10676,6 +10687,11 @@
         <source>index::advance_search: order-by-hits-asc</source>
         <target state="new">index::advance_search: order-by-hits-asc</target>
         <jms:reference-file line="256">web/prod/index.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ea214aed2c346724c9b874431706654f560585b6" resname="index::advance_search: show-unset-field-facet">
+        <source>index::advance_search: show-unset-field-facet</source>
+        <target state="new">index::advance_search: show-unset-field-facet</target>
+        <jms:reference-file line="918">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1039a002699408da4c4fe74638a6b44f60499069" resname="index:advanced-preferences:: use truncation">
         <source>index:advanced-preferences:: use truncation</source>
@@ -10730,9 +10746,9 @@
       <trans-unit id="49956c0a16703da1e642ef7ea5f5d56ddb026c9b" resname="lightbox::recaptitulatif" approved="yes">
         <source>lightbox::recaptitulatif</source>
         <target state="translated">Beknopt</target>
-        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
         <jms:reference-file line="96">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/lightbox/agreement_box.html.twig</jms:reference-file>
+        <jms:reference-file line="161">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="95">mobile/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e96c3b316d4e505d764d209e1074dcd059e396c3" resname="lightbox::see_less_basket">
@@ -10844,8 +10860,8 @@
       <trans-unit id="46f7a3bb71222626147c7e64c6a59a3f4c3d8e42" resname="login::notification: Mise a jour du mot de passe avec succes" approved="yes">
         <source>login::notification: Mise a jour du mot de passe avec succes</source>
         <target state="translated">Update van het paswoord met succes uitgevoerd</target>
-        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
         <jms:reference-file line="67">Controller/Root/AccountController.php</jms:reference-file>
+        <jms:reference-file line="408">Controller/Root/LoginController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="28dd2416483329c548279196d0c60f722578632f" resname="login::notification: demande de confirmation par mail envoyee" approved="yes">
         <source>login::notification: demande de confirmation par mail envoyee</source>
@@ -10935,15 +10951,15 @@
         <source>no</source>
         <target state="translated">Nee</target>
         <jms:reference-file line="91">web/common/technical_datas.html.twig</jms:reference-file>
-        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="14">user/import/view.html.twig</jms:reference-file>
-        <jms:reference-file line="75">web/account/sessions.html.twig</jms:reference-file>
+        <jms:reference-file line="582">web/admin/subdefs.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6c632badea2664bc707979fac5e58072b6a2feba" resname="no image selected" approved="yes">
         <source>no image selected</source>
         <target state="translated">geen beeld geselecteerd</target>
-        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="307">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="257">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37031f99ac78580c9f82e04fa237d295ea10ca41" resname="non" approved="yes">
         <source>non</source>
@@ -10954,10 +10970,10 @@
       <trans-unit id="a81b09d9521597ebcaf0cc8b49ad7a8be8e4cc61" resname="notice" approved="yes">
         <source>notice</source>
         <target state="translated">mededeling</target>
-        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
-        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
         <jms:reference-file line="77">web/lightbox/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="76">lightbox/IE6/feed.html.twig</jms:reference-file>
+        <jms:reference-file line="81">lightbox/IE6/validate.html.twig</jms:reference-file>
+        <jms:reference-file line="92">web/lightbox/validate.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cafe5f11d6a3b26e59f28454d0ad90a951c64a6a" resname="nouveau" approved="yes">
         <source>nouveau</source>
@@ -11228,7 +11244,7 @@
       <trans-unit id="0259e4e17a1f2697d4f4f0108080276a5d7573de" resname="original logo">
         <source>original logo</source>
         <target state="new">original logo</target>
-        <jms:reference-file line="23">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="26">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="5898fc860300e228dcd54c0b1045b5fa0dcda502" resname="oui" approved="yes">
         <source>oui</source>
@@ -11305,8 +11321,8 @@
       <trans-unit id="9069777ad6c5ece82d14a23d39082acba0873d60" resname="paniers::description du nouveau panier" approved="yes">
         <source>paniers::description du nouveau panier</source>
         <target state="translated">Beschrijving van het nieuwe mandje</target>
-        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
         <jms:reference-file line="5">prod/Baskets/Create.html.twig</jms:reference-file>
+        <jms:reference-file line="17">prod/orders/order_item.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="647fb4052fcefc4f2cbbe79aa1a04e8acbd37f59" resname="par %user_name%" approved="yes">
         <source>par %user_name%</source>
@@ -11326,7 +11342,7 @@
       <trans-unit id="ead5a6379197deb9163d2101354822e6caaa30eb" resname="personalize logo">
         <source>personalize logo</source>
         <target state="new">personalize logo</target>
-        <jms:reference-file line="24">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
+        <jms:reference-file line="27">Form/Configuration/PersonalisationLogoFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f16110620b1971f58336063cbdb64df7e0e0c7ac" resname="pertinence" approved="yes">
         <source>pertinence</source>
@@ -11336,7 +11352,7 @@
       <trans-unit id="da819bd8e531681e8cc8b0c5f30da694b7ffe03c" resname="php.ini path" approved="yes">
         <source>php.ini path</source>
         <target state="translated">php.ini pad</target>
-        <jms:reference-file line="44">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
+        <jms:reference-file line="50">Form/Configuration/ExecutablesFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4827b7c0fd9fb14fc29a808b020353c744b83978" resname="phraseanet:: Creer une base sur un serveur different de l'application box" approved="yes">
         <source>phraseanet:: Creer une base sur un serveur different de l'application box</source>
@@ -11377,11 +11393,11 @@
       <trans-unit id="8039b17c124d6907eb83dc8b705888769f45d82d" resname="phraseanet:: adresse" approved="yes">
         <source>phraseanet:: adresse</source>
         <target state="translated">Adres</target>
-        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="7">web/common/dialog_export.html.twig</jms:reference-file>
+        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
+        <jms:reference-file line="554">web/setup/step2.html.twig</jms:reference-file>
         <jms:reference-file line="31">admin/collection/collection.html.twig</jms:reference-file>
         <jms:reference-file line="89">web/admin/connected-users.html.twig</jms:reference-file>
-        <jms:reference-file line="181">web/account/account.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a934108e5aa19f91fafd6eb9ee20b00bc248bab9" resname="phraseanet:: aide" approved="yes">
         <source>phraseanet:: aide</source>
@@ -11470,8 +11486,8 @@
       <trans-unit id="da1f4cb9f98aef274dbb8f5992dedaf20e91ea71" resname="phraseanet:: preview" approved="yes">
         <source>phraseanet:: preview</source>
         <target state="translated">Voorvertoning</target>
-        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
         <jms:reference-file line="267">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="22">prod/actions/printer_default.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2baca947f8536e2ff6bab1c45c1876c04706a6a0" resname="phraseanet:: propositions" approved="yes">
         <source>phraseanet:: propositions</source>
@@ -11488,19 +11504,19 @@
       <trans-unit id="99a70ecaddc20d59056e5d479c6fa9d0bc113a0e" resname="phraseanet:: sous definition" approved="yes">
         <source>phraseanet:: sous definition</source>
         <target state="translated">Per definitie</target>
-        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="93">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="685">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="c33ce7e20779d5b34c1c812406e2f22b779a45d0" resname="phraseanet:: thesaurus" approved="yes">
         <source>phraseanet:: thesaurus</source>
         <target state="translated">Thesaurus</target>
-        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/index.html.twig</jms:reference-file>
         <jms:reference-file line="11">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="12">web/thesaurus/load-thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="15">web/prod/tab_headers.html.twig</jms:reference-file>
-        <jms:reference-file line="265">prod/actions/edit_default.html.twig</jms:reference-file>
+        <jms:reference-file line="5">web/thesaurus/thesaurus.html.twig</jms:reference-file>
+        <jms:reference-file line="235">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b6022bf4291f5e9d7d7051fe6c3d6a6abbd92c1a" resname="phraseanet:: tri" approved="yes">
         <source>phraseanet:: tri</source>
@@ -11510,10 +11526,10 @@
       <trans-unit id="771634fc3ec89c0a08c7666e776fc5db3072f318" resname="phraseanet:: tri par date" approved="yes">
         <source>phraseanet:: tri par date</source>
         <target state="translated">Op datum sorteren</target>
-        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="318">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="320">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="321">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="93">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db34986ff3eb1fd0e90f897a97eaf52ea6708600" resname="phraseanet:: tri par nom" approved="yes">
         <source>phraseanet:: tri par nom</source>
@@ -11587,9 +11603,9 @@
         <source>phraseanet::chargement</source>
         <target state="translated">Laden</target>
         <jms:reference-file line="48">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="278">prod/actions/edit_default.html.twig</jms:reference-file>
         <jms:reference-file line="34">admin/collection/suggested_value.html.twig</jms:reference-file>
+        <jms:reference-file line="78">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="70c4053d038cd11fa8fcb91bf79e580b89fad194" resname="phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible" approved="yes">
         <source>phraseanet::erreur: La connection au serveur Phraseanet semble etre indisponible</source>
@@ -11607,8 +11623,8 @@
         <source>phraseanet::erreur: Votre session est fermee, veuillez vous re-authentifier</source>
         <target state="translated">Uw sessile werd afgesloten, gelieve opnieuw in te loggen</target>
         <jms:reference-file line="38">Controller/Prod/LanguageController.php</jms:reference-file>
-        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="42">web/admin/index.html.twig</jms:reference-file>
+        <jms:reference-file line="150">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="754677fa0aa06c7f10237a728e6f33eaea06d42b" resname="phraseanet::erreur: echec du serveur de mail" approved="yes">
         <source>phraseanet::erreur: echec du serveur de mail</source>
@@ -11756,35 +11772,35 @@
       <trans-unit id="fdb5ea435d0e0d2d8e9dc7e2dc925c031406385c" resname="preview:: Description" approved="yes">
         <source>preview:: Description</source>
         <target state="translated">Beschrijving</target>
-        <jms:reference-file line="954">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="963">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="424597224c5d2322b6e8db99037234f7b2641de0" resname="preview:: Historique" approved="yes">
         <source>preview:: Historique</source>
         <target state="translated">Historie</target>
-        <jms:reference-file line="955">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="964">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="74e09022ffbf0d295142654902e9d7a007f209a5" resname="preview:: Popularite" approved="yes">
         <source>preview:: Popularite</source>
         <target state="translated">Populariteit</target>
-        <jms:reference-file line="958">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="967">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f9c61385964471a1171066ba2ba3622a98ffb84b" resname="preview:: arreter le diaporama" approved="yes">
         <source>preview:: arreter le diaporama</source>
         <target state="translated">stop de slideshow</target>
-        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="10">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="96">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="60">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="62">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="56">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="77a36033b8fdccc947d744ae8e3120c7d8dafa46" resname="preview:: demarrer le diaporama" approved="yes">
         <source>preview:: demarrer le diaporama</source>
         <target state="translated">start de slideshow</target>
-        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
-        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="8">prod/preview/result_train_options.html.twig</jms:reference-file>
         <jms:reference-file line="94">prod/preview/reg_train.html.twig</jms:reference-file>
+        <jms:reference-file line="58">prod/preview/feed_train.html.twig</jms:reference-file>
         <jms:reference-file line="60">prod/preview/basket_train.html.twig</jms:reference-file>
+        <jms:reference-file line="54">prod/preview/result_train.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a5cc2b2cd9b0421d131185277e9005d8e616582c" resname="preview::date">
         <source>preview::date</source>
@@ -11813,7 +11829,7 @@
       <trans-unit id="2b03b2c44ce1a3c17af6b603d666344f64ebe942" resname="preview::tab:feedback">
         <source>preview::tab:feedback</source>
         <target state="new">preview::tab:feedback</target>
-        <jms:reference-file line="956">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="965">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f7f27fe47e2d3556c660a6fade6ceba7e8e62c4c" resname="preview::tab:feedback closed">
         <source>preview::tab:feedback closed</source>
@@ -11981,20 +11997,20 @@
       <trans-unit id="98ab0e2a8cf4a7c9f6952361e6c750a8009b70a5" resname="prive">
         <source>prive</source>
         <target>prive</target>
-        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
         <jms:reference-file line="79">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="91">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="039db3240f9c47314f5b8f05835c54795f45324e" resname="privé" approved="yes">
         <source>privé</source>
         <target state="translated">privaat</target>
-        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
         <jms:reference-file line="60">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="60">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6dd8429cc900b9460f1e9d4be6155a6ee1b6de42" resname="processing" approved="yes">
         <source>processing</source>
         <target state="translated">verwerken</target>
-        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="308">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="258">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f63658cad863dee4a5876278e836472380183ade" resname="prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble" approved="yes">
         <source>prod::Les enregistrements ne provienent pas tous de la meme base et ne peuvent donc etre traites ensemble</source>
@@ -12010,7 +12026,7 @@
       <trans-unit id="f8877a3e5fa41e324ef59243c175353144990647" resname="prod::action:property title">
         <source>prod::action:property title</source>
         <target state="new">prod::action:property title</target>
-        <jms:reference-file line="1044">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1053">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ef27ad74061e0e15683e84dec7f5559f7797637f" resname="prod::advancesearch:tooltips:datefield_restriction_explanation">
         <source>prod::advancesearch:tooltips:datefield_restriction_explanation</source>
@@ -12175,8 +12191,8 @@
       <trans-unit id="021da4e7ad79ba6ef0855ecca3539db02b2d12f9" resname="prod::export: send mail notification">
         <source>prod::export: send mail notification</source>
         <target state="new">prod::export: send mail notification</target>
+        <jms:reference-file line="1059">web/prod/index.html.twig</jms:reference-file>
         <jms:reference-file line="18">web/lightbox/validate.html.twig</jms:reference-file>
-        <jms:reference-file line="1050">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cb08c63b1c016e31a255a38795c8e4cb66b0e66e" resname="prod::facet:base_label">
         <source>prod::facet:base_label</source>
@@ -12201,7 +12217,7 @@
       <trans-unit id="47f76b5a8ec06b165c0d83ed447999def6f368e4" resname="prod::notification: notification title">
         <source>prod::notification: notification title</source>
         <target state="new">prod::notification: notification title</target>
-        <jms:reference-file line="1046">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1055">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fd532704ccd19891fe39fc3e14235cbfa6b79abf" resname="prod::publication:title">
         <source>prod::publication:title</source>
@@ -12211,17 +12227,17 @@
       <trans-unit id="5fa97d7a05eb572c80ae0ccf85be3a27dcddb943" resname="prod::push: List name can not be empty">
         <source>prod::push: List name can not be empty</source>
         <target state="new">prod::push: List name can not be empty</target>
-        <jms:reference-file line="1048">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1057">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2682250f21be2e6ce7e89ab678c50a394191206a" resname="prod::push: New list title">
         <source>prod::push: New list title</source>
         <target state="new">prod::push: New list title</target>
-        <jms:reference-file line="1047">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1056">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="19aeacc47cb48d5ae39c216aa0d456ac0f2ea55d" resname="prod::push: add">
         <source>prod::push: add</source>
         <target state="new">prod::push: add</target>
-        <jms:reference-file line="1049">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1058">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="dee7c522bf9e0eea45e003fb4d0f736bc251a954" resname="prod::push:push_set_title">
         <source>prod::push:push_set_title</source>
@@ -12366,19 +12382,19 @@
       <trans-unit id="6ad73c8fd370f62ccd3bf50cd9cc3563aed5273c" resname="prod::tools: document">
         <source>prod::tools: document</source>
         <target state="new">prod::tools: document</target>
-        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
         <jms:reference-file line="74">Controller/Prod/ToolsController.php</jms:reference-file>
+        <jms:reference-file line="41">Controller/Prod/ShareController.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e36d93428a247d085ffbb974db21290395643463" resname="prod::videoTools:chapterTitle">
         <source>prod::videoTools:chapterTitle</source>
         <target state="new">prod::videoTools:chapterTitle</target>
-        <jms:reference-file line="1042">web/prod/index.html.twig</jms:reference-file>
+        <jms:reference-file line="1051">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4dc1d766c992fbd57317a321602272b20469a64" resname="prod::workzone:Actions">
         <source>prod::workzone:Actions</source>
         <target state="new">prod::workzone:Actions</target>
-        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="2">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="2">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="6140f86d00814c5627728413d43421ce867c11db" resname="prod::workzone:feedback add user">
         <source>prod::workzone:feedback add user</source>
@@ -12594,8 +12610,8 @@
       <trans-unit id="a2a8888f67982de346cedbe03b5884757de77925" resname="prod:expose:publication:Parent Publication">
         <source>prod:expose:publication:Parent Publication</source>
         <target state="new">prod:expose:publication:Parent Publication</target>
-        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/WorkZone/ExposeNew.html.twig</jms:reference-file>
+        <jms:reference-file line="10">prod/WorkZone/ExposePublicationAssets.html.twig</jms:reference-file>
         <jms:reference-file line="41">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d190364e0bc239d60124d5a906249199fcedbcf7" resname="prod:expose:publication:Password">
@@ -12929,13 +12945,18 @@
         <target state="new">prod:workzone:facetstab:tooltips:remove_facet_filter</target>
         <jms:reference-file line="218">web/prod/index.html.twig</jms:reference-file>
       </trans-unit>
+      <trans-unit id="9fb38743f0e67ac389f4d31a55eff4ec5acac703" resname="prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)">
+        <source>prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</source>
+        <target state="new">prod:workzone:facetstab:unset_field_facet_label_(%fieldname%)</target>
+        <jms:reference-file line="59">Elastic/Search/FacetsResponse.php</jms:reference-file>
+      </trans-unit>
       <trans-unit id="61c9b2b17db77a27841bbeeabff923448b0f6388" resname="public" approved="yes">
         <source>public</source>
         <target state="translated">publiek</target>
-        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
-        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
         <jms:reference-file line="64">Bridge/Dailymotion/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="83">Bridge/Dailymotion/upload.html.twig</jms:reference-file>
+        <jms:reference-file line="64">Bridge/Youtube/video_modify.html.twig</jms:reference-file>
+        <jms:reference-file line="95">Bridge/Youtube/upload.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9647ab4603346566d2218fda731606baafcbe408" resname="publication : autheur" approved="yes">
         <source>publication : autheur</source>
@@ -13043,11 +13064,11 @@
       <trans-unit id="1d740fd7fe206b5e6e57bef828e876a1bc484dd5" resname="rafraichir" approved="yes">
         <source>rafraichir</source>
         <target state="translated">vernieuwen</target>
+        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
+        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
+        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="17">prod/results/feeds.html.twig</jms:reference-file>
         <jms:reference-file line="22">prod/results/feeds.html.twig</jms:reference-file>
-        <jms:reference-file line="131">prod/WorkZone/Basket.html.twig</jms:reference-file>
-        <jms:reference-file line="3">prod/WorkZone/Macros.html.twig</jms:reference-file>
-        <jms:reference-file line="88">prod/WorkZone/Story.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0dea865dcd106d77e52ea8bffe6f87e2add0ac53" resname="recordtype">
         <source>recordtype</source>
@@ -13236,8 +13257,8 @@
         <source>report:: Connexion</source>
         <target state="translated">Verbinding</target>
         <jms:reference-file line="666">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
         <jms:reference-file line="25">web/report/all_content.html.twig</jms:reference-file>
+        <jms:reference-file line="9">web/report/report_layout.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="afa9685c95f7dff29cb2ad048da368c6e3dbadbc" resname="report:: Databox content">
         <source>report:: Databox content</source>
@@ -13312,14 +13333,14 @@
       <trans-unit id="48808e405192603e079ef1ccbbc1a1df98e317bd" resname="report:: collections" approved="yes">
         <source>report:: collections</source>
         <target state="translated">Collecties</target>
-        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="96">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="665">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="6a1193a920be0725a4560344ca10db36147ffd34" resname="report:: commentaire" approved="yes">
         <source>report:: commentaire</source>
         <target state="translated">Commentaar</target>
-        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="99">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="667">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="51f822380b654c4fc5adb28eb0643f37aac0d89b" resname="report:: copyright" approved="yes">
         <source>report:: copyright</source>
@@ -13329,9 +13350,9 @@
       <trans-unit id="cf3a5321aa85f0706b89021206bd8cd1ad57da54" resname="report:: date" approved="yes">
         <source>report:: date</source>
         <target state="translated">Datum</target>
+        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="669">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="670">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="69">module/report/filter.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="e125eaf6fca2110f86b6ebba60371a4875c87e03" resname="report:: document ajoute" approved="yes">
         <source>report:: document ajoute</source>
@@ -13382,21 +13403,21 @@
       <trans-unit id="26d00286d5aecf7cfda0e1395c4208440409b8c0" resname="report:: non-renseigne" approved="yes">
         <source>report:: non-renseigne</source>
         <target state="translated">Niet-informatief</target>
-        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
-        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
+        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
+        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
         <jms:reference-file line="117">module/report/validate.php</jms:reference-file>
+        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
+        <jms:reference-file line="60">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="411">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="508">module/report/activity.php</jms:reference-file>
         <jms:reference-file line="520">module/report/activity.php</jms:reference-file>
-        <jms:reference-file line="99">module/report/question.php</jms:reference-file>
         <jms:reference-file line="117">module/report/sent.php</jms:reference-file>
-        <jms:reference-file line="110">module/report/add.php</jms:reference-file>
         <jms:reference-file line="161">module/report/download.php</jms:reference-file>
-        <jms:reference-file line="117">module/report/push.php</jms:reference-file>
-        <jms:reference-file line="114">module/report/edit.php</jms:reference-file>
         <jms:reference-file line="110">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="118">module/report/connexion.php</jms:reference-file>
         <jms:reference-file line="123">module/report/connexion.php</jms:reference-file>
+        <jms:reference-file line="464">module/report/nav.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="07c06c0cac8bd3e3507a72d6cb7fa1ee23a6bf13" resname="report:: page d'accueil" approved="yes">
         <source>report:: page d'accueil</source>
@@ -13428,9 +13449,9 @@
       <trans-unit id="8df95f5dffb705018ebae64a4850f1f93bafc098" resname="report:: question" approved="yes">
         <source>report:: question</source>
         <target state="translated">Vraag</target>
-        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
-        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
         <jms:reference-file line="43">module/report/question.php</jms:reference-file>
+        <jms:reference-file line="102">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="668">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b9ef4ecd16724b3218cf46f9956b8b157498c3a1" resname="report:: questions" approved="yes">
         <source>report:: questions</source>
@@ -13450,8 +13471,8 @@
       <trans-unit id="8fb18670b89f5cefede425401428a70189f654ea" resname="report:: record id" approved="yes">
         <source>report:: record id</source>
         <target state="translated">Record id</target>
-        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
         <jms:reference-file line="90">module/report/filter.php</jms:reference-file>
+        <jms:reference-file line="678">classes/module/report.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a11e1e1373aae28668cdf7a08486e767283bbaa2" resname="report:: resolution" approved="yes">
         <source>report:: resolution</source>
@@ -13731,7 +13752,7 @@
       <trans-unit id="44a5de1cdcf30547c937f197cd3d58e143de62a6" resname="setup::custom-link:help-menu">
         <source>setup::custom-link:help-menu</source>
         <target state="new">setup::custom-link:help-menu</target>
-        <jms:reference-file line="58">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="63">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0286ea45f1074802cfe8fbf84b7c439fb287d0de" resname="setup::custom-link:language-link">
         <source>setup::custom-link:language-link</source>
@@ -13746,7 +13767,7 @@
       <trans-unit id="2de3bc78c6fb26b56dd934a81dc76afdba8c79ab" resname="setup::custom-link:location">
         <source>setup::custom-link:location</source>
         <target state="new">setup::custom-link:location</target>
-        <jms:reference-file line="57">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="62">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="f4db79dfecabb4b9acb44a4b49e9b6b433b28d04" resname="setup::custom-link:location-link">
         <source>setup::custom-link:location-link</source>
@@ -13756,13 +13777,13 @@
       <trans-unit id="ccfe45428ee9769a865d3d90c0e4dc50a6b68e9c" resname="setup::custom-link:name-link">
         <source>setup::custom-link:name-link</source>
         <target state="new">setup::custom-link:name-link</target>
-        <jms:reference-file line="23">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="28">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
         <jms:reference-file line="97">web/admin/setup.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fdecb6454c7adeaeb05bac7f574ee70884900ca2" resname="setup::custom-link:navigation-bar">
         <source>setup::custom-link:navigation-bar</source>
         <target state="new">setup::custom-link:navigation-bar</target>
-        <jms:reference-file line="59">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="64">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="4696021003b181f9acc9261382e07364c6b83036" resname="setup::custom-link:order-link">
         <source>setup::custom-link:order-link</source>
@@ -13772,12 +13793,12 @@
       <trans-unit id="1b09a3a0a8b0205f23b3fe59074f8dfd72d0b0ae" resname="setup::custom-link:placeholder-link-url">
         <source>setup::custom-link:placeholder-link-url</source>
         <target state="new">setup::custom-link:placeholder-link-url</target>
-        <jms:reference-file line="47">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="52">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="a1380c70f5190d6c0c38214fe24ac99272ef7bd2" resname="setup::custom-link:select-language">
         <source>setup::custom-link:select-language</source>
         <target state="new">setup::custom-link:select-language</target>
-        <jms:reference-file line="34">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
+        <jms:reference-file line="39">Form/Configuration/CustomLinkFormType.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="67572283912404fe90681e8566d880e1fd10d58e" resname="setup::custom-link:title-custom-link">
         <source>setup::custom-link:title-custom-link</source>
@@ -13817,8 +13838,8 @@
       <trans-unit id="9fef1c0f1a70c8bc024e6691f1584083c27d2b13" resname="status:: numero de bit" approved="yes">
         <source>status:: numero de bit</source>
         <target state="translated">aantal bit</target>
-        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
         <jms:reference-file line="9">admin/statusbit/edit.html.twig</jms:reference-file>
+        <jms:reference-file line="10">web/admin/statusbit.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="802c606a20e093fac7d2b5a45d947a4dff96e628" resname="status:: retrouver sous forme de filtre dans la recherche" approved="yes">
         <source>status:: retrouver sous forme de filtre dans la recherche</source>
@@ -13983,8 +14004,8 @@
       <trans-unit id="c8eadb101df19fb4960c791cf1afaa49d3516feb" resname="task::ftp:proxy">
         <source>task::ftp:proxy</source>
         <target>task::ftp:proxy</target>
-        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="5">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="5">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d50701eb37a2e5b7dfe3358ba91ff9a1cc6f10ef" resname="task::ftp:proxy password">
         <source>task::ftp:proxy password</source>
@@ -13994,8 +14015,8 @@
       <trans-unit id="a7e5c84ff2404f76423afe64d0f5b8fbea07c024" resname="task::ftp:proxy port" approved="yes">
         <source>task::ftp:proxy port</source>
         <target state="translated">task::ftp:proxy poort</target>
-        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
         <jms:reference-file line="11">task-manager/task-editor/ftp.html.twig</jms:reference-file>
+        <jms:reference-file line="11">task-manager/task-editor/ftp-pull.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17d927a070b462263321072111c64cc0505c9d14" resname="task::ftp:proxy user">
         <source>task::ftp:proxy user</source>
@@ -14097,8 +14118,8 @@
       <trans-unit id="416134a1966f12f8d23f9f54f3cc32ea43ef3e46" resname="thesaurus:: Lier la branche de thesaurus au champ" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ</source>
         <target state="translated">Link de tak van de thesaurus aan veld</target>
-        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/link-field-step1.html.twig</jms:reference-file>
+        <jms:reference-file line="1154">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="213a599ea75e45b7e28a260a71b032b3e3601e2b" resname="thesaurus:: Lier la branche de thesaurus au champ %branch%" approved="yes">
         <source>thesaurus:: Lier la branche de thesaurus au champ %branch%</source>
@@ -14108,9 +14129,9 @@
       <trans-unit id="227338ab622537da92490cedc6709de0b9122e56" resname="thesaurus:: Nouveau synonyme" approved="yes">
         <source>thesaurus:: Nouveau synonyme</source>
         <target state="translated">Nieuw synoniem</target>
+        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
         <jms:reference-file line="1050">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d6bec8860c3453260869cea4fb043fac543cf724" resname="thesaurus:: Nouveau terme" approved="yes">
         <source>thesaurus:: Nouveau terme</source>
@@ -14120,8 +14141,8 @@
       <trans-unit id="ef0a054e6da228e6ad009d469c4bdf31b1de7999" resname="thesaurus:: Nouveau terme specifique" approved="yes">
         <source>thesaurus:: Nouveau terme specifique</source>
         <target state="translated">Nieuwe specifieke term</target>
-        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/new-term.html.twig</jms:reference-file>
+        <jms:reference-file line="1085">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="261cd0e03ca27d32466be99d5cd9a0426d3a508c" resname="thesaurus:: Proprietes" approved="yes">
         <source>thesaurus:: Proprietes</source>
@@ -14143,8 +14164,8 @@
       <trans-unit id="f56e32a67c0a47d74d3441e499bfe64858ffee36" resname="thesaurus:: accepter..." approved="yes">
         <source>thesaurus:: accepter...</source>
         <target state="translated">Aanvaarden...</target>
-        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="10">web/thesaurus/accept.html.twig</jms:reference-file>
+        <jms:reference-file line="1412">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c56e1002fd59b3fed0108426b7926f3252d9fc8d" resname="thesaurus:: afficher les termes refuses" approved="yes">
         <source>thesaurus:: afficher les termes refuses</source>
@@ -14259,15 +14280,15 @@
         <target state="translated">Export in text format</target>
         <jms:reference-file line="5">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="85">web/thesaurus/export-text-dialog.html.twig</jms:reference-file>
-        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-text.html.twig</jms:reference-file>
+        <jms:reference-file line="1222">web/thesaurus/thesaurus.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8ec3584a75e01816472150b1c24268c9612dd51" resname="thesaurus:: export en topics" approved="yes">
         <source>thesaurus:: export en topics</source>
         <target state="translated">Exporteer in topics</target>
+        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
         <jms:reference-file line="1233">web/thesaurus/thesaurus.html.twig</jms:reference-file>
         <jms:reference-file line="5">web/thesaurus/export-topics.html.twig</jms:reference-file>
-        <jms:reference-file line="5">web/thesaurus/export-topics-dialog.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a09dafb2a5c9c7200a3125cca1148346e7bc1843" resname="thesaurus:: exporter" approved="yes">
         <source>thesaurus:: exporter</source>
@@ -14662,8 +14683,8 @@
       <trans-unit id="1118f7e206d8ec4d92392f3e8c2804b156b3a082" resname="thumbnail validation" approved="yes">
         <source>thumbnail validation</source>
         <target state="translated">thumbnail goedkeuring</target>
-        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="309">actions/Tools/videoEditor.html.twig</jms:reference-file>
+        <jms:reference-file line="259">actions/Tools/index.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e96ed809b61066d6ea96ba9afc8747a042b361a" resname="tout le monde" approved="yes">
         <source>tout le monde</source>
@@ -14710,8 +14731,8 @@
         <source>upload:: Status :</source>
         <target state="translated">Status</target>
         <jms:reference-file line="80">prod/upload/upload.html.twig</jms:reference-file>
-        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
         <jms:reference-file line="462">prod/upload/lazaret.html.twig</jms:reference-file>
+        <jms:reference-file line="75">prod/upload/upload-flash.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4fea0574cc81b5fd40ab0537b0905cc4c3806039" resname="users rights have been reseted" approved="yes">
         <source>users rights have been reseted</source>
@@ -14721,11 +14742,11 @@
       <trans-unit id="e204d28a2874f6123747650d3e4003d4357d75eb" resname="validate" approved="yes">
         <source>validate</source>
         <target state="translated">OK</target>
+        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
         <jms:reference-file line="88">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="120">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="160">actions/Tools/index.html.twig</jms:reference-file>
         <jms:reference-file line="186">actions/Tools/index.html.twig</jms:reference-file>
-        <jms:reference-file line="162">actions/Tools/videoEditor.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c02a2db6d6cdf30d37962e221624cc7661f4b892" resname="validation:: NON" approved="yes">
         <source>validation:: NON</source>
@@ -14791,128 +14812,128 @@
       <trans-unit id="ecbe1590a62c751a6bafe631fc5d05158d0962b4" resname="workzone:datepicker:april">
         <source>workzone:datepicker:april</source>
         <target state="new">workzone:datepicker:april</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="23ed9061fbf1a184658e05e57a121a72474b54eb" resname="workzone:datepicker:august">
         <source>workzone:datepicker:august</source>
         <target state="new">workzone:datepicker:august</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7e55bc758f272d38198385584d6f50c2dd0eae13" resname="workzone:datepicker:december">
         <source>workzone:datepicker:december</source>
         <target state="new">workzone:datepicker:december</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="db178b383e47bbe58670afd6a67528a4712444d7" resname="workzone:datepicker:february">
         <source>workzone:datepicker:february</source>
         <target state="new">workzone:datepicker:february</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a4e3f12ef1defef487381a8339ea49840666414a" resname="workzone:datepicker:friday">
         <source>workzone:datepicker:friday</source>
         <target state="new">workzone:datepicker:friday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="93f6bd6902114b73c225005188bce87569a3ac9c" resname="workzone:datepicker:january">
         <source>workzone:datepicker:january</source>
         <target state="new">workzone:datepicker:january</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0f1d297c3d3d9bc7cd800a9bd1a938904f4440ab" resname="workzone:datepicker:july">
         <source>workzone:datepicker:july</source>
         <target state="new">workzone:datepicker:july</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8d860a667674628da86b76fb3be676370a61893c" resname="workzone:datepicker:june">
         <source>workzone:datepicker:june</source>
         <target state="new">workzone:datepicker:june</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2242d17f28dc262529688d688b5c2e128813ad8b" resname="workzone:datepicker:march">
         <source>workzone:datepicker:march</source>
         <target state="new">workzone:datepicker:march</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="2ce30e1185f0f46df340ca727d4d9d89f42b6f5b" resname="workzone:datepicker:may">
         <source>workzone:datepicker:may</source>
         <target state="new">workzone:datepicker:may</target>
-        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="206">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="176">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8a7199e82486037293a2cfb17003ed9a30e2cfb2" resname="workzone:datepicker:monday">
         <source>workzone:datepicker:monday</source>
         <target state="new">workzone:datepicker:monday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0bbaf1d4dbaa3b5eb27154fcc9579f89c848b091" resname="workzone:datepicker:nextText">
         <source>workzone:datepicker:nextText</source>
         <target state="new">workzone:datepicker:nextText</target>
-        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="204">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="174">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ba391713621e89b5ecec7bc867e949e386332732" resname="workzone:datepicker:november">
         <source>workzone:datepicker:november</source>
         <target state="new">workzone:datepicker:november</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="46727c5b9b3455e2cec4fc761568262af710f119" resname="workzone:datepicker:october">
         <source>workzone:datepicker:october</source>
         <target state="new">workzone:datepicker:october</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7eef21d25b8fa0b6940fe6c87640f82612d0393f" resname="workzone:datepicker:prevText">
         <source>workzone:datepicker:prevText</source>
         <target state="new">workzone:datepicker:prevText</target>
-        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="203">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="173">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9d4fa7c1a1d4486201a760bcfb2f342ec8329f00" resname="workzone:datepicker:saturday">
         <source>workzone:datepicker:saturday</source>
         <target state="new">workzone:datepicker:saturday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a8aa1e4c6df39f7365a4fab8f3c70d3d8d4757ee" resname="workzone:datepicker:september">
         <source>workzone:datepicker:september</source>
         <target state="new">workzone:datepicker:september</target>
-        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="207">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="177">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd48f23064201336fafcab46a34c085d5a886cb6" resname="workzone:datepicker:sunday">
         <source>workzone:datepicker:sunday</source>
         <target state="new">workzone:datepicker:sunday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="de522dc0285d55c95bb9af4aa39020ac35548353" resname="workzone:datepicker:thursday">
         <source>workzone:datepicker:thursday</source>
         <target state="new">workzone:datepicker:thursday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d274289f8c48bcb43c06efe9386967b7f8fb56df" resname="workzone:datepicker:tuesday">
         <source>workzone:datepicker:tuesday</source>
         <target state="new">workzone:datepicker:tuesday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="423742b6f616f9847ea24afec03e24b15f3ff10f" resname="workzone:datepicker:wednesday">
         <source>workzone:datepicker:wednesday</source>
         <target state="new">workzone:datepicker:wednesday</target>
-        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
         <jms:reference-file line="208">prod/WorkZone/ExposeEdit.html.twig</jms:reference-file>
+        <jms:reference-file line="178">prod/WorkZone/Basket.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cbfb58c29147c5881e828d18a477f922211873a0" resname="workzone:feedback:expiration-closed">
         <source>workzone:feedback:expiration-closed</source>
@@ -14935,8 +14956,8 @@
         <source>yes</source>
         <target state="translated">Ja</target>
         <jms:reference-file line="89">web/common/technical_datas.html.twig</jms:reference-file>
+        <jms:reference-file line="79">web/account/sessions.html.twig</jms:reference-file>
         <jms:reference-file line="580">web/admin/subdefs.html.twig</jms:reference-file>
-        <jms:reference-file line="76">web/account/sessions.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="646b0ebbe9829e44e9e99e9ab991a526f758001d" resname="you are about to change the  representation thumbnail of your video" approved="yes">
         <source>you are about to change the  representation thumbnail of your video</source>

--- a/resources/locales/validators.de.xlf
+++ b/resources/locales/validators.de.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:30:52Z" source-language="en" target-language="de" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:11Z" source-language="en" target-language="de" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,9 +9,9 @@
       <trans-unit id="96f0767cb7ea65a7f86c8c9432e80d16cf9d8680" resname="Please provide the same passwords." approved="yes">
         <source>Please provide the same passwords.</source>
         <target state="translated">Bitte geben Sie diesselbe Passwörter ein.</target>
-        <jms:reference-file line="44">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="36">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="90b8c9717bb7ed061dbf20fe1986c8b8593d43d4" resname="The token provided is not valid anymore" approved="yes">
         <source>The token provided is not valid anymore</source>

--- a/resources/locales/validators.en.xlf
+++ b/resources/locales/validators.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:31:06Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:22Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,9 +9,9 @@
       <trans-unit id="96f0767cb7ea65a7f86c8c9432e80d16cf9d8680" resname="Please provide the same passwords." approved="yes">
         <source>Please provide the same passwords.</source>
         <target state="translated">Please provide the same passwords.</target>
-        <jms:reference-file line="44">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="36">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="90b8c9717bb7ed061dbf20fe1986c8b8593d43d4" resname="The token provided is not valid anymore" approved="yes">
         <source>The token provided is not valid anymore</source>

--- a/resources/locales/validators.fr.xlf
+++ b/resources/locales/validators.fr.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:31:23Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:37Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,9 +9,9 @@
       <trans-unit id="96f0767cb7ea65a7f86c8c9432e80d16cf9d8680" resname="Please provide the same passwords." approved="yes">
         <source>Please provide the same passwords.</source>
         <target state="translated">Veuillez indiquer des mots de passe identiques.</target>
-        <jms:reference-file line="44">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="36">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="90b8c9717bb7ed061dbf20fe1986c8b8593d43d4" resname="The token provided is not valid anymore" approved="yes">
         <source>The token provided is not valid anymore</source>

--- a/resources/locales/validators.nl.xlf
+++ b/resources/locales/validators.nl.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2021-04-20T14:31:42Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
+  <file date="2021-04-22T18:58:55Z" source-language="en" target-language="nl" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,9 +9,9 @@
       <trans-unit id="96f0767cb7ea65a7f86c8c9432e80d16cf9d8680" resname="Please provide the same passwords.">
         <source>Please provide the same passwords.</source>
         <target state="new">Please provide the same passwords.</target>
-        <jms:reference-file line="44">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="36">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
-        <jms:reference-file line="49">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="46">Form/Login/PhraseaRecoverPasswordForm.php</jms:reference-file>
+        <jms:reference-file line="58">Form/Login/PhraseaRegisterForm.php</jms:reference-file>
+        <jms:reference-file line="38">Form/Login/PhraseaRenewPasswordForm.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="90b8c9717bb7ed061dbf20fe1986c8b8593d43d4" resname="The token provided is not valid anymore">
         <source>The token provided is not valid anymore</source>

--- a/tests/Alchemy/Tests/Phrasea/Form/Configuration/APIClientsFormTypeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Form/Configuration/APIClientsFormTypeTest.php
@@ -13,6 +13,6 @@ class APIClientsFormTypeTest extends FormTestCase
 {
     public function getForm()
     {
-        return new APIClientsFormType();
+        return new APIClientsFormType(self::$DI['app']['translator']);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/Form/Configuration/ActionsFormTypeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Form/Configuration/ActionsFormTypeTest.php
@@ -13,6 +13,6 @@ class ActionsFormTypeTest extends FormTestCase
 {
     public function getForm()
     {
-        return new ActionsFormType();
+        return new ActionsFormType(self::$DI['app']['translator']);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/Form/Configuration/FtpExportFormTypeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Form/Configuration/FtpExportFormTypeTest.php
@@ -13,6 +13,6 @@ class FtpExportFormTypeTest extends FormTestCase
 {
     public function getForm()
     {
-        return new FtpExportFormType();
+        return new FtpExportFormType(self::$DI['app']['translator']);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/Form/Configuration/ModulesFormTypeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Form/Configuration/ModulesFormTypeTest.php
@@ -13,6 +13,6 @@ class ModulesFormTypeTest extends FormTestCase
 {
     public function getForm()
     {
-        return new ModulesFormType();
+        return new ModulesFormType(self::$DI['app']['translator']);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/Form/Configuration/RegistrationFormTypeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Form/Configuration/RegistrationFormTypeTest.php
@@ -13,6 +13,6 @@ class RegistrationFormTypeTest extends FormTestCase
 {
     public function getForm()
     {
-        return new RegistrationFormType();
+        return new RegistrationFormType(self::$DI['app']['translator']);
     }
 }

--- a/tests/Alchemy/Tests/Phrasea/Form/Configuration/SearchEngineFormTypeTest.php
+++ b/tests/Alchemy/Tests/Phrasea/Form/Configuration/SearchEngineFormTypeTest.php
@@ -13,6 +13,6 @@ class SearchEngineFormTypeTest extends FormTestCase
 {
     public function getForm()
     {
-        return new SearchEngineFormType();
+        return new SearchEngineFormType(self::$DI['app']['translator']);
     }
 }


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3426 : crashed when @Ignore annotation was used in form item
  - PHRAS-3426 : translate "help_message"s from forms
  - replace many "string-typed" form elements by "type::class"
  - dump translations (4 new strings)
