### PR TITLE
PHRAS-3460 Prod - Detailed view - Timeline tab (History) - events sorting is wrong and some events do not appear

### DIFF
--- a/lib/classes/record/preview.php
+++ b/lib/classes/record/preview.php
@@ -335,7 +335,7 @@ class record_preview extends record_adapter
         $sql .= 'ORDER BY d.date, usrid DESC';
 
         foreach ($this->getDataboxConnection()->executeQuery($sql, $params)->fetchAll(PDO::FETCH_ASSOC) as $row) {
-            $hour = $this->app['date-formatter']->getPrettyString(new DateTime($row['date']));
+            $hour = $row['date'];
 
             if ( ! isset($tab[$hour]))
                 $tab[$hour] = [];

--- a/templates/web/prod/preview/short_history.html.twig
+++ b/templates/web/prod/preview/short_history.html.twig
@@ -58,8 +58,9 @@
           {% endif %}
 
           </span>
-           <p style="font-size:10px;text-decoration:italic;">{{hour}}</p>
+           <p style="font-size:10px;text-decoration:italic;">{{ app['date-formatter'].getPrettyString(date(hour)) }}</p>
        </div>
+      </div>
 
       {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Changelog
### Changed
  - Breaking change
  
### Fixes
  - PHRAS-3460 : Prod - Detailed view - Timeline tab (History) - events sorting is wrong and some events do not appear


