### PR TITLE
PHRAS-3479_trace-crash-on-usec0

### DIFF
--- a/lib/Alchemy/Phrasea/Model/Repositories/WorkerRunningJobRepository.php
+++ b/lib/Alchemy/Phrasea/Model/Repositories/WorkerRunningJobRepository.php
@@ -80,13 +80,13 @@ class WorkerRunningJobRepository extends EntityRepository
         $recordId       = $payload['recordId'];
         $subdefName     = $payload['subdefName'];
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf('canDoJob("%s") for %s.%s.%s ?', $jobType, $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
         // first protect sql by a critical section
         if( !( $recordMutexId = $this->getRecordMutex($databoxId, $recordId)) ) {
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 'getRecordMutex() failed'
             ), FILE_APPEND | LOCK_EX);
 
@@ -115,7 +115,7 @@ class WorkerRunningJobRepository extends EntityRepository
                     $row = $stmt->fetch(PDO::FETCH_ASSOC);
                 }
                 else {
-                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("!!! FAILED select on %s.%s.%s because (%s)", $databoxId, $recordId, $subdefName, $stmt->errorCode())
                     ), FILE_APPEND | LOCK_EX);
                 }
@@ -126,7 +126,7 @@ class WorkerRunningJobRepository extends EntityRepository
                     $workerRunningJobId = $this->creteOrUpdateJob($cnx, $payload, $jobType);
                 }
                 else {
-                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("job %s (id=%s) already running on %s.%s.%s", $row['work'], $row['id'], $databoxId, $recordId, $subdefName)
                     ), FILE_APPEND | LOCK_EX);
                 }
@@ -136,13 +136,13 @@ class WorkerRunningJobRepository extends EntityRepository
             catch (Exception $e) {
                 $cnx->rollBack();
 
-                file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("!!! FAILED in transaction to select/create on %s.%s.%s because (%s)", $databoxId, $recordId, $subdefName, $e->getMessage())
                 ), FILE_APPEND | LOCK_EX);
             }
         }
         else {
-            file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("!!! FAILED to create transaction to select/create on %s.%s.%s", $databoxId, $recordId, $subdefName)
             ), FILE_APPEND | LOCK_EX);
         }
@@ -193,7 +193,7 @@ class WorkerRunningJobRepository extends EntityRepository
                 if ($cnx->exec($sql) === 1) {
                     // went well, the row is inserted
                     $workerJobId = $cnx->lastInsertId();
-                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("created job %s (id=%s) for %s.%s.%s", $type, $workerJobId, $payload['databoxId'], $payload['recordId'], $payload['subdefName'])
                     ), FILE_APPEND | LOCK_EX);
                 }
@@ -213,7 +213,7 @@ class WorkerRunningJobRepository extends EntityRepository
                     // went well, the row is updated
                     $workerJobId = $payload['workerJobId'];
 
-                    file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("updated job %s (id=%s) for %s.%s.%s", $type, $workerJobId, $payload['databoxId'], $payload['recordId'], $payload['subdefName'])
                     ), FILE_APPEND | LOCK_EX);
                 }
@@ -226,7 +226,7 @@ class WorkerRunningJobRepository extends EntityRepository
         catch (Exception $e) {
             // bad case : we return null anyway
 
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("!!! FAILED creating/updating job %s for %s.%s.%s because (%s)", $type, $payload['databoxId'], $payload['recordId'], $payload['subdefName'], $e->getMessage())
             ), FILE_APPEND | LOCK_EX);
         }
@@ -269,14 +269,14 @@ class WorkerRunningJobRepository extends EntityRepository
 
             if ($cnx->exec($sql) > 0) {
                 // affected rows is 1 since by definition this key is unique
-                file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("!!! old mutex for %s.%s deleted (!!! SHOULD NOT HAPPEN !!!)", $databoxId, $recordId)
                 ), FILE_APPEND | LOCK_EX);
             }
         }
         catch(Exception $e) {
             // here something went very wrong, like sql death
-            file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("!!! FAILED while trying to delete old mutex for %s.%s (!!! SHOULD NOT HAPPEN !!!)", $databoxId, $recordId)
             ), FILE_APPEND | LOCK_EX);
 
@@ -303,7 +303,7 @@ class WorkerRunningJobRepository extends EntityRepository
 
                 if(($a = $cnx->exec($sql)) === 1) {
 
-                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("getMutex tryout %s for %s.%s OK", $tryout, $databoxId, $recordId)
                     ), FILE_APPEND | LOCK_EX);
 
@@ -321,7 +321,7 @@ class WorkerRunningJobRepository extends EntityRepository
                 if($tryout < 3) {
                     $rnd = rand(10, 50) * 10;   // 100 ms ... 500 ms with 10 ms steps
 
-                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("getMutex retry in %d msec", $rnd)
                     ), FILE_APPEND | LOCK_EX);
 
@@ -330,7 +330,7 @@ class WorkerRunningJobRepository extends EntityRepository
             }
         }
 
-        file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("!!! FAILED getMutex for %s.%s because (%s)", $databoxId, $recordId, $e->getMessage())
         ), FILE_APPEND | LOCK_EX);
 
@@ -359,7 +359,7 @@ class WorkerRunningJobRepository extends EntityRepository
 
                 $cnx->exec($sql);
 
-                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("releaseMutex (id=%s) DONE", $recordMutexId)
                 ), FILE_APPEND | LOCK_EX);
 
@@ -369,7 +369,7 @@ class WorkerRunningJobRepository extends EntityRepository
                 if($tryout < 3) {
                     $rnd = rand(10, 50) * 10;   // 100 ms ... 500 ms with 10 ms steps
 
-                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("releaseMutex (id=%s) retry in %d msec", $recordMutexId, $rnd)
                     ), FILE_APPEND | LOCK_EX);
 
@@ -380,7 +380,7 @@ class WorkerRunningJobRepository extends EntityRepository
 
         // Here we were not able to release a mutex (bad)
         // The last chance will be later, when old mutex (60s) is deleted
-        file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("!!! FAILED release mutex (id=%s) because (%s)", $recordMutexId, $e->getMessage())
         ), FILE_APPEND | LOCK_EX);
     }
@@ -410,7 +410,7 @@ class WorkerRunningJobRepository extends EntityRepository
 
                 if(($a = $cnx->exec($sql) )=== 1) {
                     // ok
-                    file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                    file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                         sprintf("job (id=%d) marked as finished", $workerRunningJobId)
                     ), FILE_APPEND | LOCK_EX);
 
@@ -420,7 +420,7 @@ class WorkerRunningJobRepository extends EntityRepository
                 throw new Exception(sprintf("updating WorkerRunningJob should return 1 row affected, got %s", $a));
             }
             catch (Exception $e) {
-                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("failed to mark job (id=%d) as finished (tryout %s, retry in 1 sec) because (%s)", $workerRunningJobId, $tryout, $e->getMessage())
                 ), FILE_APPEND | LOCK_EX);
                 if($tryout < 2) {
@@ -428,7 +428,7 @@ class WorkerRunningJobRepository extends EntityRepository
                 }
             }
         }
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("!!! FAILED to mark job (id=%d) as finished", $workerRunningJobId)
         ), FILE_APPEND | LOCK_EX);
     }
@@ -518,7 +518,7 @@ class WorkerRunningJobRepository extends EntityRepository
     public function reconnect()
     {
 //        if(!$this->getEntityManager()->isOpen()) {
-//            file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(true)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+//            file_put_contents(dirname(__FILE__) . '/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
 //                sprintf("recreate _em")
 //            ), FILE_APPEND | LOCK_EX);
 //            $this->_em = $this->_em->create(

--- a/lib/Alchemy/Phrasea/WorkerManager/Subscriber/RecordSubscriber.php
+++ b/lib/Alchemy/Phrasea/WorkerManager/Subscriber/RecordSubscriber.php
@@ -210,7 +210,7 @@ class RecordSubscriber implements EventSubscriberInterface
     {
         $record = $event->getRecord();
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("Event WorkerEvents::SUBDEFINITION_WRITE_META catched  for %s.%s.%s", $record->getDataboxId(), $record->getRecordId(), $event->getSubdefName())
         ), FILE_APPEND | LOCK_EX);
 
@@ -288,19 +288,19 @@ class RecordSubscriber implements EventSubscriberInterface
                     ]
                 ];
 
-                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("sending message MessagePublisher::WRITE_METADATAS_TYPE for %s.%s.%s ...", $databoxId, $recordId, $event->getSubdefName())
                 ), FILE_APPEND | LOCK_EX);
 
                 $this->messagePublisher->publishMessage($payload, MessagePublisher::WRITE_METADATAS_TYPE);
 
-                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("   ... message MessagePublisher::WRITE_METADATAS_TYPE sent for %s.%s.%s", $databoxId, $recordId, $event->getSubdefName())
                 ), FILE_APPEND | LOCK_EX);
             }
             else {
 
-                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+                file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                     sprintf("no MessagePublisher::WRITE_METADATAS_TYPE for %s.%s.%s because(isSubdefMetadataUpdateRequired=%d)", $databoxId, $recordId, $event->getSubdefName(), $this->isSubdefMetadataUpdateRequired($databox, $type, $subdef->get_name()))
                 ), FILE_APPEND | LOCK_EX);
 

--- a/lib/Alchemy/Phrasea/WorkerManager/Worker/SubdefCreationWorker.php
+++ b/lib/Alchemy/Phrasea/WorkerManager/Worker/SubdefCreationWorker.php
@@ -65,7 +65,7 @@ class SubdefCreationWorker implements WorkerInterface
         $databoxId      = $payload['databoxId'];
         $subdefName     = $payload['subdefName'];
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("process SubdefCreation for %s.%s.%s", $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
@@ -90,7 +90,7 @@ class SubdefCreationWorker implements WorkerInterface
                 ],
                 MessagePublisher::SUBDEF_CREATION_TYPE
             );
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("cannot CreateSubdef for %s.%s.%s, delayed", $databoxId, $recordId, $subdefName)
             ), FILE_APPEND | LOCK_EX);
             return ;
@@ -98,7 +98,7 @@ class SubdefCreationWorker implements WorkerInterface
 
         // here we can work
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("ready to CreateSubdef for %s.%s.%s", $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
@@ -107,7 +107,7 @@ class SubdefCreationWorker implements WorkerInterface
         try {
             $this->subdefGenerator->generateSubdefs($record, [$subdefName]);
 
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("subdef generated for %s.%s.%s (?)", $databoxId, $recordId, $subdefName)
             ), FILE_APPEND | LOCK_EX);
 
@@ -115,13 +115,13 @@ class SubdefCreationWorker implements WorkerInterface
         catch (Exception $e) {
             $this->logger->error("Exception catched: " . $e->getMessage());
 
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("!!! subdef generation failed (ignored) for %s.%s.%s : %s", $databoxId, $recordId, $subdefName, $e->getMessage())
             ), FILE_APPEND | LOCK_EX);
 
         }
         catch (Throwable $e) {
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("subdef generation failed, retry delayed for %s.%s.%s : %s", $databoxId, $recordId, $subdefName, $e->getMessage())
             ), FILE_APPEND | LOCK_EX);
 
@@ -143,7 +143,7 @@ class SubdefCreationWorker implements WorkerInterface
             return ;
         }
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("checking subdef file for %s.%s.%s", $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
@@ -159,7 +159,7 @@ class SubdefCreationWorker implements WorkerInterface
 
         if (!$this->filesystem->exists($filePathToCheck)) {
 
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("!!! subdef file missing, retry delayed for %s.%s.%s", $databoxId, $recordId, $subdefName)
             ), FILE_APPEND | LOCK_EX);
 
@@ -182,7 +182,7 @@ class SubdefCreationWorker implements WorkerInterface
 
         // checking ended
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("subdef file exists, order to write meta for %s.%s.%s", $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
@@ -196,7 +196,7 @@ class SubdefCreationWorker implements WorkerInterface
             )
         );
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("Event WorkerEvents::SUBDEFINITION_WRITE_META posted  for %s.%s.%s", $record->getDataboxId(), $record->getRecordId(), $subdefName)
         ), FILE_APPEND | LOCK_EX);
 

--- a/lib/Alchemy/Phrasea/WorkerManager/Worker/WriteMetadatasWorker.php
+++ b/lib/Alchemy/Phrasea/WorkerManager/Worker/WriteMetadatasWorker.php
@@ -67,7 +67,7 @@ class WriteMetadatasWorker implements WorkerInterface
         $recordId    = $payload['recordId'];
         $subdefName  = $payload['subdefName'];
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("process WriteMeta for %s.%s.%s", $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
@@ -87,7 +87,7 @@ class WriteMetadatasWorker implements WorkerInterface
                 ],
                 MessagePublisher::WRITE_METADATAS_TYPE
             );
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("cannot WriteMeta for %s.%s.%s, delayed", $databoxId, $recordId, $subdefName)
             ), FILE_APPEND | LOCK_EX);
 
@@ -96,13 +96,13 @@ class WriteMetadatasWorker implements WorkerInterface
 
         // here we can work
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf("ready to WriteMeta for %s.%s.%s", $databoxId, $recordId, $subdefName)
         ), FILE_APPEND | LOCK_EX);
 
         $record  = $databox->get_record($recordId);
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf(" - recordid = %s", $record->getRecordId())
         ), FILE_APPEND | LOCK_EX);
 
@@ -119,14 +119,14 @@ class WriteMetadatasWorker implements WorkerInterface
         $this->repoWorker->reconnect();
 
         try {
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf(" - getsubdef %s", $subdefName)
             ), FILE_APPEND | LOCK_EX);
 
             $subdef = $record->get_subdef($subdefName);
         }
         catch (Exception $e) {
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf(" - %s", $e->getMessage())
             ), FILE_APPEND | LOCK_EX);
 
@@ -150,7 +150,7 @@ class WriteMetadatasWorker implements WorkerInterface
         }
 
         if (!$subdef->is_physically_present()) {
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf(" - not present")
             ), FILE_APPEND | LOCK_EX);
 
@@ -265,7 +265,7 @@ class WriteMetadatasWorker implements WorkerInterface
             }
         }
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf(" - reset")
         ), FILE_APPEND | LOCK_EX);
 
@@ -277,7 +277,7 @@ class WriteMetadatasWorker implements WorkerInterface
 
         $this->writer->erase($subdef->get_name() != 'document' || $clearDoc, true);
 
-        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+        file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf(" - erased")
         ), FILE_APPEND | LOCK_EX);
 
@@ -287,7 +287,7 @@ class WriteMetadatasWorker implements WorkerInterface
 
             $this->messagePublisher->pushLog(sprintf('meta written for sbasid=%1$d - recordid=%2$d (%3$s)', $databox->get_sbas_id(), $recordId, $subdef->get_name() ));
 
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("meta written in %s.%s.%s", $databoxId, $recordId, $subdefName)
             ), FILE_APPEND | LOCK_EX);
 
@@ -303,7 +303,7 @@ class WriteMetadatasWorker implements WorkerInterface
                 $stopInfo = $matches[0];
             }
 
-            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (\DateTime::createFromFormat('U.u', microtime(TRUE)))->format('Y-m-d\TH:i:s.u'), getmypid(), __FILE__, __LINE__,
+            file_put_contents(dirname(__FILE__).'/../../../../../logs/trace.txt', sprintf("%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
                 sprintf("meta NOT written in %s.%s.%s because (%s)\n  Will %sretry", $databoxId, $recordId, $subdefName, $msg, ($stopInfo ? "not ":""))
             ), FILE_APPEND | LOCK_EX);
 


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3479: "trace" do not report usec anymore

bonus : the translation dumper run ok again (because php7 syntax is now avoided)