### PR TITLE
PHRAS-3109 gitlog in "About Phraseanet"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,16 +64,25 @@ behat.yml
 # Exclude crossdomain.xml file it's generated
 /www/crossdomain.xml
 
-# Exclude jison files
+# Exclude json files
 grammar/query.js
 grammar/jison-*
+
 
 pimple.json
 playbook.retry
 npm-debug.log
 
+# Exclude stack datas
 /Phrasea_datas
+/volumes
 
+# Exclude alternate env files
 .env.*
 env.local
-/volumes
+
+# Exclude gitlog files
+www/gitlog.txt
+
+
+


### PR DESCRIPTION
## Changelog
### Changed
   If the file `www / gitlog.txt` exist, it will be copied in FPM container and can be retrieved in
   "About Phraseanet".
  You need to generate this file with a Git log cmd, before build image

   
### Fixes
  - PHRAS-3109

