### PR TITLE
PHRAS-3484 set rabbitmq version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
       - internal
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:3.6.16-management
     restart: on-failure
     environment:
     - RABBITMQ_DEFAULT_USER


### PR DESCRIPTION
## Changelog
### Changed
  -  Docker Rabbitmq version is set  to rabbitmq:3.6.16-management
 