### PR TITLE
PHRAS-3519_filesystem-atomic-move : remove delay

### DIFF
--- a/lib/classes/media/subdef.php
+++ b/lib/classes/media/subdef.php
@@ -782,7 +782,8 @@ class media_subdef extends media_abstract implements cache_cacheableInterface
      */
     private function isStillAccessible()
     {
-        return $this->is_physically_present && $this->getFilesystem()->exists($this->getRealPath(), 10);    // allow 10 secs for the file to be visible on shared fs
+        // return $this->is_physically_present && $this->getFilesystem()->exists($this->getRealPath(), 10);    // allow 10 secs for the file to be visible on shared fs
+        return $this->is_physically_present && $this->getFilesystem()->exists($this->getRealPath());    // NO delay allowed, this slows down phr if any subdef is missing
     }
 
     /**


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3519: remove delay to subdef->isStillAccessible() calling fs->exists().
    because it's called by getsubdef(), any missing subdef will slow down phr by 10s. on every getsubdef() call.
