### PR TITLE
PHRAS-3564_subdef-service-api

### DIFF
--- a/lib/Alchemy/Phrasea/Application/Helper/JsonBodyAware.php
+++ b/lib/Alchemy/Phrasea/Application/Helper/JsonBodyAware.php
@@ -61,8 +61,8 @@ trait JsonBodyAware
      * @param null|string $schemaUri
      * @return stdClass
      */
-    public function decodeJsonBody(Request $request, $schemaUri = null)
+    public function decodeJsonBody(Request $request, $schemaUri = null, $format = JsonBodyHelper::OBJECT)
     {
-        return $this->getJsonBodyHelper()->decodeJsonBody($request, $schemaUri);
+        return $this->getJsonBodyHelper()->decodeJsonBody($request, $schemaUri, $format);
     }
 }

--- a/lib/Alchemy/Phrasea/Controller/Api/V3/V3SubdefsServiceController.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V3/V3SubdefsServiceController.php
@@ -9,7 +9,9 @@ use Alchemy\Phrasea\Border\Manager;
 use Alchemy\Phrasea\Controller\Api\Result;
 use Alchemy\Phrasea\Controller\Controller;
 use Alchemy\Phrasea\Filesystem\FilesystemService;
+use Alchemy\Phrasea\Helper\JsonBodyHelper;
 use Alchemy\Phrasea\Media\SubdefGenerator;
+use databox_subdef;
 use Exception;
 use Guzzle\Http\Client;
 use Neutron\TemporaryFilesystem\TemporaryFilesystemInterface;
@@ -30,14 +32,20 @@ class V3SubdefsServiceController extends Controller
         /** @var UploadedFile $file */
         $file = $request->files->get('file');
         /** @var string $body  json supplemental infos */
-        $body = $request->get('body');
+        $body = $this->decodeJsonBody($request, null, JsonBodyHelper::ASSOC_ARRAY);
+
+        $src = $file->getRealPath();
+        $dst = dirname(__FILE__).'/../../../../../../logs/' . $file->getFilename();
+        copy($src, $dst);
 
         file_put_contents(dirname(__FILE__).'/../../../../../../logs/subdefgenerator.txt', sprintf("\n%s [%s] : %s (%s); %s\n", (date('Y-m-d\TH:i:s')), getmypid(), __FILE__, __LINE__,
             sprintf(
-                "into callbackAction_POST with\n - file: \"%s\"\n - filesize: %d\n - body: \"%s\"" ,
+                "into callbackAction_POST with\n - file: \"%s\"\n - filesize: %d\n - body: \"%s\"\n - src=%s\n - dst=%s" ,
                 $file->getRealPath(),
                 $file->getSize(),
-                $body
+                $body,
+                $src,
+                $dst
             )
         ), FILE_APPEND | LOCK_EX);
 
@@ -62,7 +70,7 @@ class V3SubdefsServiceController extends Controller
      */
     public function indexAction_POST(Request $request)
     {
-        $body = $this->decodeJsonBody($request);
+        $body = $this->decodeJsonBody($request, null, JsonBodyHelper::OBJECT);
 
         $dbox_id = $body->databoxId;
         $databox = $this->app->getApplicationBox()->get_databox($dbox_id);
@@ -139,10 +147,33 @@ class V3SubdefsServiceController extends Controller
 
             $media = $this->app->getMediaFromUri($sourceFile);
 
-            $type = $media->getType();   // 'document', 'audio', 'video', 'image', 'flash', 'map'
-            $subdefs = $databox->get_subdef_structure()->getSubdefGroup($type);
 
-            // $subdef = new \databox_subdef($type, $sxSettings, $this->getTranslator());
+            $phrSubdefs = [];    // array of phr subdefs by name, will give the list of wanted subdefs (aliased by client)
+            $allWanted = [];     // in case no wanted subdef was passed in body, prepare a full list
+            $type = $media->getType();   // 'document', 'audio', 'video', 'image', 'flash', 'map'
+            foreach($databox->get_subdef_structure()->getSubdefGroup($type) as $sd) {
+                $phrSubdefs[$sd->get_name()] = ['subdef' => $sd, 'destinations' => []];
+                $allWanted[$sd->get_name()] = ['source' => $sd->get_name()];
+            }
+            // list wanted subdefs
+            $wanted = (array)$body->destination->subdefs;
+            if(empty($wanted)) {
+                $wanted = $allWanted;    // no list of wanted subdefs : send all
+            }
+            unset($allWanted);
+
+            // map a list of phr sources to a list of alias (wanted) names
+            foreach ($wanted as $w => $a) {
+                $a = (array) $a;
+                if(!array_key_exists($a['source'], $phrSubdefs)) {
+                    // the source (phr subdef name) is unknown : ignore
+                    continue;
+                }
+                $k = $a['source'];
+                unset($a['source']);
+                $phrSubdefs[$k]['destinations'][$w] = (array) $a;
+            }
+
 
             $guzzle = new Client();
             $guzzle->setSslVerification(false);
@@ -151,59 +182,61 @@ class V3SubdefsServiceController extends Controller
             $destPayload = $body->destination->payload ?: [];
 
             try {
-                foreach ($subdefs as $subdef) {
-                    if (is_array($body->destination->subdefs) && !in_array($subdef->get_name(), $body->destination->subdefs)) {
-                        continue;
+                foreach ($phrSubdefs as $sd) {
+                    /** @var databox_subdef $subdef */
+                    $subdef = $sd['subdef'];
+                    foreach ($sd['destinations'] as $destName => $destAttr) {
+
+                        $postFilename = $postFilenameRoot . '_' . $destName;
+
+                        $start = microtime(true);
+                        $ext = $this->getFilesystemService()->getExtensionFromSpec($subdef->getSpecs());
+
+                        /** @var string $destFile */
+                        $destFile = $this->getTmpFilesystem()->createTemporaryFile(null, '_' . $subdef->get_name(), $ext);
+
+                        $this->getSubdefGenerator()->generateSubdefFromFile($sourceFile, $subdef, $destFile);
+
+                        $duration = microtime(true) - $start;
+
+                        $postFilename .= '.' . $ext;
+
+                        $data = [
+                            'filename'       => $postFilename,
+                            'extension'      => $ext,
+                            'name'           => $subdef->get_name(),
+                            'class'          => $subdef->get_class(),
+                            'filesize'       => filesize($destFile),
+                            'build_duration' => $duration,
+                        ];
+
+                        $start = microtime(true);
+
+                        $postFields = array_merge((array)$destPayload, [
+                            'file_info' => $data,
+                        ]);
+
+                        try {
+                            $guzzle->post($destination_url)
+                                ->addPostFields($postFields)
+                                ->addPostFile('file', $destFile, null, $postFilename)
+                                ->send();
+                        }
+                        catch (Exception $e) {
+                            throw new Exception(sprintf(
+                                'Failed to post subdef "%s" file: %s',
+                                $subdef->get_name(),
+                                $e->getMessage()
+                            ), 0, $e);
+                        }
+                        finally {
+                            unlink($destFile);
+                        }
+
+                        $data['post_duration'] = microtime(true) - $start;
+
+                        $ret['sent'][$subdef->get_name()] = $data;
                     }
-
-                    $postFilename = $postFilenameRoot.'_'.$subdef->get_name();
-
-                    $start = microtime(true);
-                    $ext = $this->getFilesystemService()->getExtensionFromSpec($subdef->getSpecs());
-
-                    /** @var string $destFile */
-                    $destFile = $this->getTmpFilesystem()->createTemporaryFile(null, '_'.$subdef->get_name(), $ext);
-
-                    $this->getSubdefGenerator()->generateSubdefFromFile($sourceFile, $subdef, $destFile);
-
-                    $duration = microtime(true) - $start;
-
-                    $postFilename .= '.'.$ext;
-
-                    $data = [
-                        'filename' => $postFilename,
-                        'extension' => $ext,
-                        'name' => $subdef->get_name(),
-                        'class' => $subdef->get_class(),
-                        'filesize' => filesize($destFile),
-                        'build_duration' => $duration,
-                    ];
-
-                    $start = microtime(true);
-
-                    $postFields = array_merge((array)$destPayload, [
-                        'file_info' => $data,
-                    ]);
-
-                    try {
-                        $guzzle->post($destination_url)
-                            ->addPostFields($postFields)
-                            ->addPostFile('file', $destFile, null, $postFilename)
-                            ->send();
-                    } catch (Exception $e) {
-                        throw new Exception(sprintf(
-                            'Failed to post subdef "%s" file: %s',
-                            $subdef->get_name(),
-                            $e->getMessage()
-                        ), 0, $e);
-                    } finally {
-                        unlink($destFile);
-                    }
-
-                    $data['post_duration'] = microtime(true) - $start;
-
-                    $ret['sent'][$subdef->get_name()] = $data;
-
                 }
             } finally {
                 unlink($sourceFile);

--- a/lib/Alchemy/Phrasea/Helper/JsonBodyHelper.php
+++ b/lib/Alchemy/Phrasea/Helper/JsonBodyHelper.php
@@ -21,6 +21,16 @@ use Webmozart\Json\ValidationFailedException;
 
 class JsonBodyHelper
 {
+    /**
+     * Decode a JSON value as PHP object.
+     */
+    const OBJECT = 0;
+
+    /**
+     * Decode a JSON value as associative array.
+     */
+    const ASSOC_ARRAY = 1;
+
     /** @var JsonValidator */
     private $validator;
     /** @var JsonDecoder */
@@ -60,7 +70,7 @@ class JsonBodyHelper
      * @param null|string|object $schemaUri
      * @return mixed
      */
-    public function decodeJsonBody(Request $request, $schemaUri = null)
+    public function decodeJsonBody(Request $request, $schemaUri = null, $format = self::OBJECT)
     {
         if(empty($content = $request->getContent())) {
             // in case of multipart/form-data (e.g. to upload a file), the only way to send
@@ -72,6 +82,7 @@ class JsonBodyHelper
         $schema = $schemaUri ? $this->retrieveSchema($schemaUri) : null;
 
         try {
+            $this->decoder->setObjectDecoding($format===self::ASSOC_ARRAY ? $this->decoder::ASSOC_ARRAY : $this->decoder::OBJECT);
             return $this->decoder->decode($content, $schema);
         } catch (DecodingFailedException $exception) {
             throw new UnprocessableEntityHttpException('Json request cannot be decoded', $exception);

--- a/lib/Alchemy/Phrasea/Media/SubdefGenerator.php
+++ b/lib/Alchemy/Phrasea/Media/SubdefGenerator.php
@@ -286,7 +286,7 @@ class SubdefGenerator
             $this->logger->error(sprintf('Subdef generation failed for record %d with message %s', $record->getRecordId(), $e->getMessage()));
         }
 
-        if($start){
+        if($start) {
 
             // the subdef was done
 
@@ -420,6 +420,21 @@ class SubdefGenerator
         }
         catch (Exception $e) {
             $this->logger->error(sprintf('Subdef generation failed with message %s', $e->getMessage()));
+        }
+
+        // watermark ?
+        if($subdef_class->getSpecs() instanceof Image) {
+            /** @var Subdef\Image $image */
+            $image = $subdef_class->getSubdefType();
+            /** @var Boolean $wm */
+            $wm = $image->getOption(Subdef\Image::OPTION_WATERMARK);
+            if($wm->getValue()) {
+
+                // we must watermark the file
+                /** @var Text $wmt */
+                $wmt = $image->getOption(Subdef\Image::OPTION_WATERMARKTEXT);
+                $this->wartermarkImageFile($pathdest, $wmt->getValue());
+            }
         }
 
         $duration = microtime(true) - $start;


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3564: wmark is applied (phr subdef setting)
 
### Adds
   Mapping from expected name (destination.subdefs/keys) to phr subdef name ("source") : Allows to ask for a subset of phr subdefs (see sample)
   Default will map all phr subdefs.

sample request (json raw body):

```
{
    "databoxId": 2,
    "source": {
        "url":"https://file-examples-com.github.io/uploads/2017/10/file_example_JPG_2500kB.jpg"
    },
    "destination": {
        "subdefs": {
            "thumbnail":  {
                "source": "thumbnail"
            },
            "preview": {
                "source": "preview"
            },
            "over": {
                "source": "preview_mobile"
            }
        },
        "url":"http://172.32.0.1:8082/api/v3/subdefs_service_callback/?oauth_token=xxxxxxx",
        "payload": {
            "text":"this is some text",
            "int":555
        },
        "filename":"asset_555_"
    }
}
```
output to subdefgenerator.txt :
```
2021-11-25T18:21:01 [818] : /var/alchemy/Phraseanet/lib/Alchemy/Phrasea/Controller/Api/V3/V3SubdefsServiceController.php (52); into callbackAction_POST with
 - file: "/tmp/php2x7G0P"
 - filesize: 74357
 - saved to: "/var/alchemy/Phraseanet/logs/asset_555_preview.jpg"
 - payload: array (
  'text' => 'this is some text',
  'int' => '555',
  'file_info' => 
  array (
    'filename' => 'asset_555_preview.jpg',
    'extension' => 'jpg',
    'name' => 'preview',
    'class' => 'preview',
    'filesize' => '74357',
    'build_duration' => '1.4797649383545',
  ),
)

2021-11-25T18:21:03 [749] : /var/alchemy/Phraseanet/lib/Alchemy/Phrasea/Controller/Api/V3/V3SubdefsServiceController.php (52); into callbackAction_POST with
 - file: "/tmp/phpDubmqE"
 - filesize: 10836
 - saved to: "/var/alchemy/Phraseanet/logs/asset_555_thumbnail.jpg"
 - payload: array (
  'text' => 'this is some text',
  'int' => '555',
  'file_info' => 
  array (
    'filename' => 'asset_555_thumbnail.jpg',
    'extension' => 'jpg',
    'name' => 'thumbnail',
    'class' => 'thumbnail',
    'filesize' => '10836',
    'build_duration' => '1.2976748943329',
  ),
)

2021-11-25T18:21:04 [741] : /var/alchemy/Phraseanet/lib/Alchemy/Phrasea/Controller/Api/V3/V3SubdefsServiceController.php (52); into callbackAction_POST with
 - file: "/tmp/phpReo3ZV"
 - filesize: 17495
 - saved to: "/var/alchemy/Phraseanet/logs/asset_555_over.jpg"
 - payload: array (
  'text' => 'this is some text',
  'int' => '555',
  'file_info' => 
  array (
    'filename' => 'asset_555_over.jpg',
    'extension' => 'jpg',
    'name' => 'preview_mobile',
    'class' => 'preview',
    'filesize' => '17495',
    'build_duration' => '1.0901601314545',
  ),
)
```
