### PR TITLE
PHRAS-3509 Prod - tools - document substitution - the generation message for sub-definition is published twice.

### DIFF
--- a/lib/Alchemy/Phrasea/Media/SubdefSubstituer.php
+++ b/lib/Alchemy/Phrasea/Media/SubdefSubstituer.php
@@ -74,8 +74,8 @@ class SubdefSubstituer
 
         $this->createMediaSubdef($record, 'document', $media);
 
-        $record->setMimeType($media->getFile()->getMimeType());
-        $record->setType($media->getType());
+        $record->setMimeType($media->getFile()->getMimeType(), false); // param to be false because subdefs will be rebuild later depends on $shouldSubdefsBeRebuilt
+        $record->setType($media->getType(), false);
 
         $record->write_metas();
 

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -267,11 +267,13 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
 
     /**
      * @param string $type
+     * @param bool $shouldSubdefsBeRebuilt
+     *
      * @return $this
      * @throws Exception
      * @throws DBALException
      */
-    public function setType($type)
+    public function setType($type, $shouldSubdefsBeRebuilt = true)
     {
         $type = strtolower($type);
 
@@ -284,7 +286,7 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
         $sql = 'UPDATE record SET moddate = NOW(), type = :type WHERE record_id = :record_id';
         $this->getDataboxConnection()->executeUpdate($sql, ['type' => $type, 'record_id' => $this->getRecordId()]);
 
-        if ($old_type !== $type) {
+        if (($old_type !== $type) && $shouldSubdefsBeRebuilt) {
             $this->dispatch(RecordEvents::SUBDEFINITION_CREATE, new SubdefinitionCreateEvent($this));
         }
 
@@ -330,8 +332,17 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
         return $this->setMimeType($mime);
     }
 
-    public function setMimeType($mime)
+    /**
+     * @param $mime
+     * @param bool $shouldSubdefsBeRebuilt
+     *
+     * @return $this
+     * @throws DBALException
+     */
+    public function setMimeType($mime, $shouldSubdefsBeRebuilt = true)
     {
+        $oldMime = $this->getMimeType();
+
         // see http://lists.w3.org/Archives/Public/xml-dist-app/2003Jul/0064.html
         if (!preg_match("/^[a-zA-Z0-9!#$%^&\\*_\\-\\+{}\\|'.`~]+\\/[a-zA-Z0-9!#$%^&\\*_\\-\\+{}\\|'.`~]+$/", $mime)) {
             throw new \Exception(sprintf('Unrecognized mime type %s', $mime));
@@ -342,7 +353,9 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
             array(':mime' => $mime, ':record_id' => $this->getRecordId())
         )) {
 
-            $this->dispatch(RecordEvents::SUBDEFINITION_CREATE, new SubdefinitionCreateEvent($this));
+            if (($oldMime !== $mime) && $shouldSubdefsBeRebuilt) {
+                $this->dispatch(RecordEvents::SUBDEFINITION_CREATE, new SubdefinitionCreateEvent($this));
+            }
 
             $this->delete_data_from_cache();
         }


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3509: Prod - tools - document substitution - the generation message for sub-definition is published twice.


