### PR TITLE
PHRAS-3616 System:Updrade generates error in case a referenced databox doesn't exist

### DIFF
--- a/lib/classes/patch/415PHRAS3604.php
+++ b/lib/classes/patch/415PHRAS3604.php
@@ -3,6 +3,7 @@
 use Alchemy\Phrasea\Application;
 use Alchemy\Phrasea\Model\Repositories\FeedItemRepository;
 use Alchemy\Phrasea\Model\Entities\FeedItem;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class patch_415PHRAS3604 implements patchInterface
 {
@@ -71,7 +72,12 @@ class patch_415PHRAS3604 implements patchInterface
         /** @var FeedItem $feedItem */
         foreach ($feedItemRepository->findAll() as $feedItem) {
             // if the record is not found, delete the feedItem
-            if ($app->findDataboxById($feedItem->getSbasId())->getRecordRepository()->find($feedItem->getRecordId()) == null) {
+            try {
+                if ($app->findDataboxById($feedItem->getSbasId())->getRecordRepository()->find($feedItem->getRecordId()) == null) {
+                    $app['orm.em']->remove($feedItem);
+                }
+            } catch (NotFoundHttpException $e) {
+                // the referenced sbas_id is not found, so delete also the feedItem
                 $app['orm.em']->remove($feedItem);
             }
         }

--- a/lib/classes/patch/415PHRAS3604.php
+++ b/lib/classes/patch/415PHRAS3604.php
@@ -77,9 +77,8 @@ class patch_415PHRAS3604 implements patchInterface
                     $app['orm.em']->remove($feedItem);
                 }
             } catch (NotFoundHttpException $e) {
-                // the referenced sbas_id is not found,
-
-                // $app['orm.em']->remove($feedItem);  // do nothing
+                // the referenced sbas_id is not found, so delete also the feedItem
+                 $app['orm.em']->remove($feedItem);
             }
         }
 

--- a/lib/classes/patch/415PHRAS3604.php
+++ b/lib/classes/patch/415PHRAS3604.php
@@ -77,8 +77,9 @@ class patch_415PHRAS3604 implements patchInterface
                     $app['orm.em']->remove($feedItem);
                 }
             } catch (NotFoundHttpException $e) {
-                // the referenced sbas_id is not found, so delete also the feedItem
-                $app['orm.em']->remove($feedItem);
+                // the referenced sbas_id is not found,
+
+                // $app['orm.em']->remove($feedItem);  // do nothing
             }
         }
 


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-3616 : System:Updrade generates error in case a referenced databox doesn't exist
  - fix patch 4.1.5 PHRAS-3604


