### PR TITLE
PHRAS-3619 After record removal, we have an HTTP status 200 on the /records route of the API on the deleted record

### DIFF
--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -2159,7 +2159,8 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
 
         $this->app['filesystem']->remove($ftodel);
 
-        $this->delete_data_from_cache(self::CACHE_SUBDEFS);
+        // delete the corresponding key record_id from the cache
+        $this->delete_data_from_cache();
 
         $this->dispatch(RecordEvents::DELETED, new DeletedEvent($this));
 

--- a/lib/classes/record/adapter.php
+++ b/lib/classes/record/adapter.php
@@ -2159,6 +2159,9 @@ class record_adapter implements RecordInterface, cache_cacheableInterface
 
         $this->app['filesystem']->remove($ftodel);
 
+        // delete cache of subdefs
+        $this->delete_data_from_cache(self::CACHE_SUBDEFS);
+
         // delete the corresponding key record_id from the cache
         $this->delete_data_from_cache();
 


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3619: After record removal, we have an HTTP status 200 on the /records route of the API on the deleted record
  - delete the correponding record_id  key in cache
