### PR TITLE
PHRAS-3637 : API - Upload Url | Let's Encrypt ssl certificate verification fail. use the correct guzzle version

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V1Controller.php
@@ -92,7 +92,7 @@ use Alchemy\Phrasea\WorkerManager\Event\AssetsCreateEvent;
 use Alchemy\Phrasea\WorkerManager\Event\RecordsWriteMetaEvent;
 use Alchemy\Phrasea\WorkerManager\Event\WorkerEvents;
 use Doctrine\ORM\EntityManager;
-use Guzzle\Http\Client as Guzzle;
+use GuzzleHttp\Client as Guzzle;
 use League\Fractal\Resource\Item;
 use media_subdef;
 use Neutron\TemporaryFilesystem\TemporaryFilesystemInterface;
@@ -963,8 +963,8 @@ class V1Controller extends Controller
                 $tempfile = $tmpFs->createTemporaryFile('download_', null, $pi['extension']);
 
                 try {
-                    $guzzle = new Guzzle($url);
-                    $res = $guzzle->get("", [], ['save_to' => $tempfile])->send();
+                    $guzzle = new Guzzle(['base_uri' => $url]);
+                    $res = $guzzle->get("", ['save_to' => $tempfile]);
                 }
                 catch (\Exception $e) {
                     return $this->getBadRequestAction($request, sprintf('Error "%s" downloading "%s"', $e->getMessage(), $url));

--- a/lib/Alchemy/Phrasea/Controller/Api/V3/V3RecordController.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V3/V3RecordController.php
@@ -21,7 +21,7 @@ use Alchemy\Phrasea\Model\Entities\LazaretSession;
 use collection;
 use Doctrine\DBAL\DBALException;
 use Exception;
-use Guzzle\Http\Client as Guzzle;
+use GuzzleHttp\Client as Guzzle;
 use Neutron\TemporaryFilesystem\TemporaryFilesystemInterface;
 use p4field;
 use record_adapter;
@@ -104,8 +104,8 @@ class V3RecordController extends Controller
                 $tempfile = $tmpFs->createTemporaryFile('download_', null, $pi['extension']);
 
                 try {
-                    $guzzle = new Guzzle($url);
-                    $res = $guzzle->get("", [], ['save_to' => $tempfile])->send();
+                    $guzzle = new Guzzle(['base_uri' => $url]);
+                    $res = $guzzle->get("", ['save_to' => $tempfile]);
                 }
                 catch (Exception $e) {
                     return Result::createBadRequest($request, sprintf('Error "%s" downloading "%s"', $e->getMessage(), $url));

--- a/lib/Alchemy/Phrasea/Controller/Prod/UploadController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/UploadController.php
@@ -26,7 +26,7 @@ use Alchemy\Phrasea\Model\Entities\LazaretFile;
 use Alchemy\Phrasea\Model\Entities\LazaretSession;
 use DataURI\Exception\Exception as DataUriException;
 use DataURI\Parser;
-use Guzzle\Http\Client as Guzzle;
+use GuzzleHttp\Client as Guzzle;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -88,10 +88,10 @@ class UploadController extends Controller
             $url = $request->get('url');
             $basename = pathinfo($url, PATHINFO_BASENAME);
 
-            $guzzle = new Guzzle($url);
-            $res = $guzzle->head("")->send();
-            $response['content-type'] = $res->getContentType();
-            $response['content-length'] = $res->getContentLength();
+            $guzzle = new Guzzle(['base_uri' => $url]);
+            $res = $guzzle->head('');
+            $response['content-type'] = $res->getHeaderLine('content-type');
+            $response['content-length'] = doubleval($res->getHeaderLine('content-length'));
             $response['basename'] = $basename;
         }
         catch (\Exception $e) {
@@ -161,8 +161,8 @@ class UploadController extends Controller
             $tempfile = $this->getTemporaryFilesystem()->createTemporaryFile('download_', null, $pi['extension']);
 
             try {
-                $guzzle = new Guzzle($url);
-                $res = $guzzle->get("", [], ['save_to' => $tempfile])->send();
+                $guzzle = new Guzzle(['base_uri' => $url]);
+                $res = $guzzle->get("", ['save_to' => $tempfile]);
             }
             catch (\Exception $e) {
                 throw new BadRequestHttpException(sprintf('Error "%s" downloading "%s"', $e->getMessage(), $url));


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3637: API - Upload Url | Let's Encrypt ssl certificate verification fail. use the correct guzzle version
 

