### PR TITLE
PHRAS-3666 PROD - PRINT - PDF - Generated pdf cant be printed even if no password is defined

### DIFF
--- a/lib/Alchemy/Phrasea/Out/Module/PDFRecords.php
+++ b/lib/Alchemy/Phrasea/Out/Module/PDFRecords.php
@@ -49,19 +49,9 @@ class PDFRecords extends PDF
         $this->thumbnailName  = $printer->getThumbnailName();
         $this->previewName    = $printer->getPreviewName();
 
-        $this->pdf->SetProtection([
-            'print',
-            'modify',
-            'copy',
-            'annot-forms',
-            'fill-forms',
-            'extract',
-            'assemble',
-            'print-high',
-            'owner'
-        ],
-            $userPassword
-        );
+        if (!empty($userPassword)) {
+            $this->pdf->SetProtection([], $userPassword);
+        }
 
         $this->pdf->setPrintOwnerUser($app->getAuthenticatedUser());
 


### PR DESCRIPTION
## Changelog

  
### Fixes
  - PHRAS-3666: PROD - PRINT - PDF - Generated pdf cant be printed even if no password is defined


