### PR TITLE
PHRAS-3687: Remove .env non-closed double-quot that breaks design in html doc

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@
 # - "docker-compose.override.yml"   : For dev only, use the code from hosts,
 #                                     activate ide debugger, ports mapping for
 #                                     datastores
-# - "docker-compose.phrasea.yml"    : For integrate this stack in the "traefik" of Phrasea stack"
+# - "docker-compose.phrasea.yml"    : For integrate this stack in the "traefik" of Phrasea stack
 #
 #
 #


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3687: Remove .env non-closed double-quot that breaks design in html doc

