### PR TITLE
PHRAS-3688 Update image to Ubuntu 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    aws-ecr: circleci/aws-ecr@8.1.2
+    aws-ecr: circleci/aws-ecr@6.15.0
 executors:
   docker_build:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
     aws-ecr: circleci/aws-ecr@6.15.0
+    aws-cli: circleci/aws-cli@1.3.1
 executors:
   docker_build:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
 
     build_phraseanet-fpm:
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
           docker_layer_caching: true
         working_directory: ~/alchemy-fr/Phraseanet
         steps:
@@ -120,7 +120,7 @@ jobs:
 
     build_phraseanet-worker:
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
           docker_layer_caching: true
         working_directory: ~/alchemy-fr/Phraseanet
         steps:
@@ -135,7 +135,7 @@ jobs:
 
     build_phraseanet-nginx:
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
           docker_layer_caching: true
         working_directory: ~/alchemy-fr/Phraseanet
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    aws-ecr: circleci/aws-ecr@4.0.1
+    aws-ecr: circleci/aws-ecr@8.1.2
 executors:
   docker_build:
     machine:


### PR DESCRIPTION
## Changelog
### Fixes
  - PHRAS-3688: FIX Circle CI Image version deprecation
  - FIX image building, caused by to Circle CI Image version deprecation