### PR TITLE
PHRAS-3686 Prod - caption : characters (#,!) into a clickable url link can lead to cut the link

### DIFF
--- a/lib/Alchemy/Phrasea/Core/Provider/TwigServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/TwigServiceProvider.php
@@ -120,7 +120,7 @@ class TwigServiceProvider implements ServiceProviderInterface
 
         $twig->addFilter(new \Twig_SimpleFilter('linkify', function (\Twig_Environment $twig, $string) use ($app) {
             return preg_replace(
-                "/(\\W|^)(https?:\/{2,4}[\\w:#%\/;$()~_?\/\-=\\\.&]+)/m"
+                "/(\\W|^)(https?:\/{2,4}[\\w:#!%\/;$()~_?\/\-=\\\.&]+)/m"
                 ,
                 '$1$2 <a title="' . $app['translator']->trans('Open the URL in a new window') . '" class=" fa fa-external-link" href="$2" style="font-size:1.2em;display:inline;padding:2px 5px;margin:0 4px 0 2px;" target="_blank"> &nbsp;</a>$7'
                 , $string


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3686: Prod - caption : characters (#,!) into a clickable url link can lead to cut the link


