### PR TITLE
PHRAS-3645_candidates-special-chars

### DIFF
--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Term.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Term.php
@@ -16,7 +16,7 @@ class Term implements TermInterface
     // So, this is a huuuge regex to match a group of words eventually followed
     // by another group of words in parenthesis. It also takes care of trimming
     // spaces.
-    const TERM_REGEX = '/^\s*(\w[^\(\)]*\w|\w)\s*(?:\(\s*([^\(\)]*[^\s\(\)])\s*\))?/u';
+//    const TERM_REGEX = '/^\s*(\w[^\(\)]*\w|\w)\s*(?:\(\s*([^\(\)]*[^\s\(\)])\s*\))?/u';
     //                       [_____term______]       (   [_____context_____]    )
 
     private $value;
@@ -52,12 +52,35 @@ class Term implements TermInterface
 
     public static function parse($string)
     {
-        preg_match(self::TERM_REGEX, $string, $matches);
+//        preg_match(self::TERM_REGEX, $string, $matches);
+//
+//        return new self(
+//            isset($matches[1]) ? $matches[1] : null,
+//            isset($matches[2]) ? $matches[2] : null
+//        );
 
-        return new self(
-            isset($matches[1]) ? $matches[1] : null,
-            isset($matches[2]) ? $matches[2] : null
-        );
+        $term = $string;
+        $context = '';
+        if( ($p0 = strpos($string, '(')) !== false) {
+            $term = substr($term, 0, $p0);
+            $context = substr($string, $p0+1);
+            if( ($p1 = strpos($context, ')')) !== false) {
+                $context = substr($context, 0, $p1);
+            }
+        }
+        if(($term = trim($term)) === '') {
+            $term = null;
+        }
+        if(($context = trim($context)) === '') {
+            $context = null;
+        }
+        if($term === null && $context !== null) {
+            // special case "(foo)"
+            $term = $context;
+            $context = null;
+        }
+
+        return new self($term, $context);
     }
 
     public static function dump(TermInterface $term)


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-3645: thesaurus indexation _before_ fetch record (prevents double-candidates)
  - PHRAS-3645: <term (context)> parsing in php (fix first special char)