### PR TITLE
Phras 3700 upgrade swiftmailer to v5.4.12 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
     "simple-bus/serialization": "^2.0",
     "sorien/silex-dbal-profiler": "^1.1",
     "sorien/silex-pimple-dumper": "^1.0",
-    "swiftmailer/swiftmailer": "~5.4.5",
+    "swiftmailer/swiftmailer": "^5.4.12",
     "symfony/symfony": "~2.7.10|~2.8.3",
     "themattharris/tmhoauth": "~0.7",
     "twig/extensions": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -6621,16 +6621,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.5",
+            "version": "v5.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "cd142238a339459b10da3d8234220963f392540c"
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/cd142238a339459b10da3d8234220963f392540c",
-                "reference": "cd142238a339459b10da3d8234220963f392540c",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
                 "shasum": ""
             },
             "require": {


### PR DESCRIPTION
## Changelog
### Changed
  - Upgrade swiftmailer to v5.4.12
  
### Fixes
  - PHRAS-3700: Issue when sending mail through Office 365 SMTP
  - Upgrade swiftmailer to v5.4.12 for TLS 1.1 / 1.2 support

