### PR TITLE
PHRAS-3715 Docker - fix build image - fix imagmagick version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main non-free" > /etc/apt/sou
     && make \
     && make install \
     && mkdir /tmp/ImageMagick \
-    && curl https://imagemagick.org/archive/ImageMagick.tar.gz| tar zx -C /tmp/ImageMagick --strip-components 1 \
+    && curl https://imagemagick.org/archive/releases/ImageMagick-7.1.0-39.tar.gz | tar zx -C /tmp/ImageMagick --strip-components 1 \
     && cd /tmp/ImageMagick \
     && ./configure \
     && make \


### PR DESCRIPTION
### Fixes
  - PHRAS-3715: fix build image fails due to imagmagick version change
  - ImageMagick build fails due to version changes
