### PR TITLE
PHRAS-3318 sp saml - Fix K8S service name on proxy nginx usage

### DIFF
--- a/.env
+++ b/.env
@@ -833,6 +833,11 @@ PHRASEANET_FTP_DIR=./datas/ftp
 # For dev who don't have SSH_AUTH_SOCK (avoid an empty volume name)
 SSH_AUTH_SOCK=/dev/null
 
+# Kubernet context needs full pod hosname on nginx reverse proxing 
+# This is need for PHraseanet  SAML context on K8S
+PHRASEANET_K8S_NAMESPACE=
+
+#
 # SAML Service provider setting 
 # simplesamlphp as service provider for Phraseanet
 # must be associated to a plugin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     - GATEWAY_SEND_TIMEOUT
     - GATEWAY_PROXY_TIMEOUT
     - GATEWAY_FASTCGI_TIMEOUT
+    - PHRASEANET_K8S_NAMESPACE
     ports:
       - ${PHRASEANET_APP_PORT}:80
     networks:
@@ -56,6 +57,7 @@ services:
     - GATEWAY_SEND_TIMEOUT
     - GATEWAY_PROXY_TIMEOUT
     - GATEWAY_FASTCGI_TIMEOUT
+    - PHRASEANET_K8S_NAMESPACE
     networks:
       - internal
     labels:

--- a/docker/nginx/root/entrypoint.sh
+++ b/docker/nginx/root/entrypoint.sh
@@ -2,6 +2,16 @@
 
 set -xe
 
-cat /nginx.conf.sample | sed "s/\$MAX_BODY_SIZE/$MAX_BODY_SIZE/g" | sed "s/\$GATEWAY_SEND_TIMEOUT/$GATEWAY_SEND_TIMEOUT/g"  | sed "s/\$GATEWAY_FASTCGI_TIMEOUT/$GATEWAY_FASTCGI_TIMEOUT/g" | sed "s/\$MAX_BODY_SIZE/$MAX_BODY_SIZE/g" | sed "s/\$GATEWAY_PROXY_TIMEOUT/$GATEWAY_PROXY_TIMEOUT/g"  > /etc/nginx/conf.d/default.conf
+if [ -n "$PHRASEANET_K8S_NAMESPACE" ]; then
+  echo "PHRASEANET_K8S_NAMESPACE is defined : $PHRASEANET_K8S_NAMESPACE"
+  NEW_TARGET=phraseanet-saml-sp.$PHRASEANET_K8S_NAMESPACE.svc.cluster.local
+  NEW_RESOLVER=kube-dns.kube-system.svc.cluster.local
+else
+  echo "NO PHRASEANET_K8S_NAMESPACE is defined"
+  NEW_TARGET=phraseanet-saml-sp
+  NEW_RESOLVER=127.0.0.11
+fi
+
+cat /nginx.conf.sample | sed "s/\$MAX_BODY_SIZE/$MAX_BODY_SIZE/g" | sed "s/\$GATEWAY_SEND_TIMEOUT/$GATEWAY_SEND_TIMEOUT/g"  | sed "s/\$GATEWAY_FASTCGI_TIMEOUT/$GATEWAY_FASTCGI_TIMEOUT/g" | sed "s/\$MAX_BODY_SIZE/$MAX_BODY_SIZE/g" | sed "s/\$GATEWAY_PROXY_TIMEOUT/$GATEWAY_PROXY_TIMEOUT/g"  | sed "s/\$NEW_TARGET/$NEW_TARGET/g"  | sed "s/\$NEW_RESOLVER/$NEW_RESOLVER/g" > /etc/nginx/conf.d/default.conf
 cat /fastcgi_timeout.conf  | sed "s/\$GATEWAY_FASTCGI_TIMEOUT/$GATEWAY_FASTCGI_TIMEOUT/g" > /etc/nginx/fastcgi_extended_params
 exec "$@"

--- a/docker/nginx/root/nginx.conf.sample
+++ b/docker/nginx/root/nginx.conf.sample
@@ -5,7 +5,7 @@ proxy_send_timeout          $GATEWAY_PROXY_TIMEOUT;
 client_header_timeout       $GATEWAY_SEND_TIMEOUT;
 client_body_timeout         $GATEWAY_SEND_TIMEOUT;
 fastcgi_read_timeout        $GATEWAY_FASTCGI_TIMEOUT;
-resolver 127.0.0.11;
+resolver $NEW_RESOLVER;
 
 upstream backend {
     server phraseanet:9000;
@@ -65,7 +65,7 @@ server {
         proxy_redirect off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        set $target phraseanet-saml-sp:8080;
+        set $target $NEW_TARGET:8080;
         proxy_pass http://$target;
 
     }


### PR DESCRIPTION
### Fixes
  - PHRAS-3318: Fix K8S service name on proxy nginx usage
  - sp saml need revers proxing. K8S need full service url when proxying