### PR TITLE
PHRAS-3771-fix-libheif-version-to-v1.13.0-4.1.6-rc2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main non-free" > /etc/apt/sou
     && mkdir /tmp/libheif \
     && git clone https://github.com/strukturag/libheif.git /tmp/libheif \
     && cd /tmp/libheif \
+    && git checkout v1.13.0 \
     && ./autogen.sh \
     && ./configure \
     && make \


### PR DESCRIPTION
Fix libheif version to v1.13.0-4.1.6-rc2
  
### Fixes
  - PHRAS-3771 : Fix libheif version to v1.13.0-4.1.6-rc2


