### PR TITLE
PHRAS-3780 enable opcache zend extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN echo "BUILDING PHP PECL EXTENTIONS" \
         zmq-beta \
         imagick-beta \
         xdebug-2.6.1 \
-    && docker-php-ext-enable redis amqp zmq imagick \
+    && docker-php-ext-enable redis amqp zmq imagick opcache \
     && pecl clear-cache \
     && docker-php-source delete
 RUN echo "BUILDING AND INSTALLING FFMPEG" \

--- a/docker/phraseanet/php.ini.sample
+++ b/docker/phraseanet/php.ini.sample
@@ -1757,7 +1757,7 @@ opcache.enable=$OPCACHE_ENABLED
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 1000000 are allowed.
-;opcache.max_accelerated_files=10000
+opcache.max_accelerated_files=2503
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ;opcache.max_wasted_percentage=5


### PR DESCRIPTION
### Fixes
  - PHRAS-3780: fix opcache activation in fpm container
  - enable opcache zend extension in php config