### PR TITLE
PHRAS-3929 Ser redis version For SAML container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -353,7 +353,7 @@ RUN echo "deb http://archive.debian.org/debian stretch main non-free" > /etc/apt
     && docker-php-ext-install -j$(nproc) ldap \
     && docker-php-ext-install zip mbstring pdo_mysql gettext mcrypt \
     && pecl install \
-        redis \
+        redis-5.3.7 \
     && docker-php-ext-enable redis \
     && pecl clear-cache \
     && docker-php-source delete


### PR DESCRIPTION
Set Redis version for saml-sp container in Dockerfile

## Changelog
### Changed
  - Breaking change
  
### Fixes
  - PHRAS-3929: Set Redis version for saml-sp container

