### PR TITLE
PHRAS-3976_quickfix_418RC8PHRAS3768

### DIFF
--- a/lib/classes/patch/418RC8PHRAS3768.php
+++ b/lib/classes/patch/418RC8PHRAS3768.php
@@ -63,10 +63,11 @@ class patch_418RC8PHRAS3768 implements patchInterface
 
     private function patch_appbox(base $appbox, Application $app)
     {
-        $cnx = $appbox->get_connection();
-        $sql = "ALTER TABLE `BasketElements` ADD `vote_expired` DATETIME NULL, ADD INDEX `vote_expired` (`vote_expired`)";
+// disabled cause crash on some install (missing table) due to pre-post migration (?)
+        //        $cnx = $appbox->get_connection();
+//        $sql = "ALTER TABLE `BasketElements` ADD `vote_expired` DATETIME NULL, ADD INDEX `vote_expired` (`vote_expired`)";
 //        try {
-            $cnx->exec($sql);
+//            $cnx->exec($sql);
 //        }
 //        catch (\Exception $e) {
             // the field already exist ?


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3976: disable patch crashing caused missing table "basketelements"
