### PR TITLE
PHRAS-3996_legacy-download-remove-excel

### DIFF
--- a/templates/web/common/dialog_export.html.twig
+++ b/templates/web/common/dialog_export.html.twig
@@ -104,13 +104,18 @@
                 <li><a href="#ftp">{{ 'export:: FTP' | trans }}</a></li>
             {% endif %}
         </ul>
+
         {% if download.get_total_download() > 0 %}
+
+            {# ##########################################
+            direct / async download
+            ############################################# #}
 
             <div id="download">
                 <div style="padding:10px; text-align: center;">
                     <h4>{{ 'export:: telechargement' | trans }}</h4>
                     {% if app['conf'].get(['download_async', 'enabled'], false) %}
-                        {# \Alchemy\Phrasea\Controller\Prod\DownloadController::checkDownloadAsync #}
+                        {# \Alchemy\Phrasea\Controller\Prod\DownloadController::listDownloadAsync #}
                         {% set download_path = 'list_download_async' %}
                     {% else %}
                         {# \Alchemy\Phrasea\Controller\Prod\DownloadController::checkDownload #}
@@ -145,12 +150,14 @@
                                 </div>
                             {% endif %}
                         {% endfor %}
+                        {% if app['conf'].get(['download_async', 'enabled'], false) %}
                         <div class="well-small">
                             <label for="include_report" class="checkbox">
                                 <input class="caption" type="checkbox" id="include_report" name="include_report" value="INCLUDE_REPORT" />
                                 {{ 'prod::download: report as spreadsheet' | trans }}
                             </label>
                         </div>
+                        {% endif %}
                         {% if download.has_business_fields_access() %}
                             <div class="businessfields well-small" style="margin-left:20px;display:none;">
                                 <label for="business_download" class="checkbox">
@@ -186,6 +193,10 @@
                     </form>
                 </div>
             </div>
+
+            {# ##########################################
+            email
+            ############################################# #}
 
             <div id="sendmail">
                 <div style="padding:10px; text-align: center;">
@@ -288,6 +299,12 @@
             </div>
         {% endif %}
         {% if download.get_total_order() > 0 %}
+
+
+            {# ##########################################
+            order
+            ############################################# #}
+
             <div id="order">
                 {% for name, values in download.get_display_orderable() %}
                     {% if values.available > 0 %}
@@ -434,6 +451,12 @@
                 </form>
             </div>
         {% endif %}
+
+
+        {# ##########################################
+        ftp
+        ############################################# #}
+
         {% if download.get_total_ftp() > 0 %}
             <div id="ftp">
                 <div style="padding:10px; text-align: center;">

--- a/templates/web/prod/actions/Download/prepare.html.twig
+++ b/templates/web/prod/actions/Download/prepare.html.twig
@@ -91,6 +91,7 @@
     </div>
 
     <div style="display:none">
+        {# \Alchemy\Phrasea\Controller\Prod\DoDownloadController::downloadDocuments #}
         <form name="download" action="{{ path('document_download', {'token': token.getValue(), 'type': type, 'anonymous': anonymous}) }}" method="post" target="file_frame">
             {% if anonymous %}
                 <input type="hidden" name="anonymous" value="1" />
@@ -105,6 +106,7 @@
             {% set time = time < 1 ? 2 : (time > 10 ? 10 : time) %}
 
             {% if list['complete'] is not defined %} {# Zip not done #}
+            {# \Alchemy\Phrasea\Controller\Prod\DoDownloadController::downloadExecute #}
                 $.post("{{ path('execute_download', {'token': token.getValue(), 'type': type, 'anonymous': anonymous}) }}", function(data){
                     if(data.success) {
                         $('form[name=download]').submit();


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-3996: disable excel report for legacy download
  - log async downloads
  - send EXPORT_CREATE event for async download (listened by ExpiringRights plugin)

