### PR TITLE
PHRAS-4010 Add mysql8 as alternative datastore

### DIFF
--- a/.env
+++ b/.env
@@ -49,8 +49,8 @@
 #                       choose to launch only some workers, see worker profile list below.
 # - "worker"          : launch one container worker with all jobs run on it.
 # - "cmd"             : launch a container based on worker image, useful for run cmd manualy. 
-# - "db"              : launch a mariadb container, because this is the primary
-#                       datastore for production usage, use your own service.
+# - "db"              : db profile will launch a mariadb container, 
+#                       because this is the primary datastore, you should use you own SGDD service for production needs.
 # - "elastisearch"    : launch a elasticsearch container.
 # - "rabbitmq"        : launch a rabbitmq container.
 # - "redis"           : launch a redis container for app cache.
@@ -60,8 +60,8 @@
 # - "squid"           : reverse proxy for dev only.
 # - "mailhog"         : for catching all email emit by app for dev.
 # - "db-backup"       : launch and run a container to cron database backups and backup file's rotation.
-# - "mysql8"          : launch a mysql8 container, because this is the primary
-#                       for production, use your own mysql service as datastore (/!\ do not mix with the "db" profile). 
+# - "mysql8"          : launch a mysql8 container (beta), (/!\ do not mix with the "db" profile)
+#                       Because this is the primary datastore, you should use you own SGDD service for production needs.
 #
 # Profiles worker list:
 # - "assetsInjest"

--- a/.env
+++ b/.env
@@ -29,8 +29,7 @@
 #                                     activate ide debugger, ports mapping for
 #                                     datastores
 # - "docker-compose.phrasea.yml"    : For integrate this stack in the "traefik" of Phrasea stack
-#
-# - "docker-compose.limits.yml"     : defines containers cpu and memory limits for all Phraseanet and gateway containers only.
+# - "docker-compose.altenatives.yml": all alternative services, used only on evoluation or transition periods 
 #
 #
 # 2/ "COMPOSE_PROFILES" value define which profiles you want to use
@@ -59,6 +58,8 @@
 # - "squid"           : reverse proxy for dev only.
 # - "mailhog"         : for catching all email emit by app for dev.
 # - "db-backup"       : launch and run a container to cron database backups and backup file's rotation.
+# - "mysql8"          : launch a mysql8 container, because this is the primary
+#                       for production, use your own mysql service as datastore (/!\ do not mix with the "db" profile).  
 #
 # Profiles worker list:
 # - "assetsInjest"
@@ -97,10 +98,6 @@
 # - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml
 # - COMPOSE_PROFILES=app,setup,db,pma,elasticsearch,rabbitmq,redis,redis-session,workers,cmd,mailhog,gateway-classic
 #
-# # To test with tools and apply resources throttling on Phraseanet containers :
-# - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml:docker-compose.limits.yml
-# - COMPOSE_PROFILES=app,setup,db,pma,elasticsearch,rabbitmq,redis,redis-session,workers,cmd,mailhog,gateway-classic
-#
 # For testing with debug and SSL (the traekik is provide by Phrasea stack):
 # - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml:docker-compose.under-phrasea.yml
 # - COMPOSE_PROFILES=app,setup,gateway-traefik,db,pma,elasticsearch,rabbitmq,redis,redis-session,worker,workers,mailhog
@@ -110,7 +107,7 @@
 # - COMPOSE_PROFILES=app,setup,workers,gateway-traefik
 #
 # Example with all profiles:
-# - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml:docker-compose.limits.yml
+# - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml
 # - COMPOSE_PROFILES=app,setup,gateway-classic,db,elasticsearch,redis,redis-session,rabbitmq,pma,mailhog,assetsInjest,createRecord,deleteRecord,editRecord,
 #                    exportMail,downloadAsync,exposeUpload,exportFtp,mainQueue,populateIndex,pullAssets,recordsActions,subdefCreation,
 #                    validationReminder,webhook,writeMetadatas,shareBasket,scheduler,cmd,elk,db-backup,phraseanet-saml-sp
@@ -140,24 +137,12 @@ PHRASEANET_DOCKER_REGISTRY=local
 
 # Docker images tag.
 # @run
-PHRASEANET_DOCKER_TAG=4.1.8-rc8
+PHRASEANET_DOCKER_TAG=4.1.8-rc7
 
 # Stack Name
 # An optionnal Name for the stack
 # @run
 STACK_NAME=
-
-# --- Phraseanet containers resources limit settings ------------------------------------------------------------------------------------
-
-WORKER_CPU=2
-GATEWAY_CPU=2
-FPM_CPU=2
-WORKER_MEMORY_LIMIT=2048M
-GATEWAY_MEMORY_LIMIT=2048M
-FPM_MEMORY_LIMIT=2048M
-WORKER_MEMORY_RESERVATION=256M
-GATEWAY_MEMORY_RESERVATION=256M
-FPM_MEMORY_RESERVATION=256M
 
 # --- Phraseanet container network settings ------------------------------------------------------------------------------------
 
@@ -482,14 +467,6 @@ PHRASEANET_CACHE_HOST=redis
 # @run
 PHRASEANET_CACHE_PORT=6379
 
-# PHP session management
-# @run
-PHRASEANET_SESSION_TYPE=redis
-# @run
-PHRASEANET_SESSION_HOST=redis-session
-# @run
-PHRASEANET_SESSION_PORT=6379
-
 # --- Phraseanet general settings --------------------------------------------------------------------------------------
 
 # Variables below are used in the "configuration.yml" file:
@@ -534,10 +511,6 @@ PHRASEANET_ADMIN_ACCOUNT_PASSWORD=iJRqXU0MwbyJewQLBbra6IWHsWly
 # @run
 PHRASEANET_DOWNLOAD_ASYNC=false
 
-# User Session duration settings 
-# @run
-PHRASEANET_USER_SESSION_IDLE=14400
-PHRASEANET_USER_SESSION_LIFETIME=86400
 
 # --- Phraseanet MySQL settings ----------------------------------------------------------------------------------------
 

--- a/.env
+++ b/.env
@@ -29,8 +29,10 @@
 #                                     activate ide debugger, ports mapping for
 #                                     datastores
 # - "docker-compose.phrasea.yml"    : For integrate this stack in the "traefik" of Phrasea stack
-# - "docker-compose.altenatives.yml": all alternative services, used only on evoluation or transition periods 
 #
+# - "docker-compose.limits.yml"     : defines containers cpu and memory limits for all Phraseanet and gateway containers only.
+#
+# - "docker-compose.altenatives.yml": all alternative services, used only on evoluation or transition periods 
 #
 # 2/ "COMPOSE_PROFILES" value define which profiles you want to use
 # in docker-compose.
@@ -59,7 +61,7 @@
 # - "mailhog"         : for catching all email emit by app for dev.
 # - "db-backup"       : launch and run a container to cron database backups and backup file's rotation.
 # - "mysql8"          : launch a mysql8 container, because this is the primary
-#                       for production, use your own mysql service as datastore (/!\ do not mix with the "db" profile).  
+#                       for production, use your own mysql service as datastore (/!\ do not mix with the "db" profile). 
 #
 # Profiles worker list:
 # - "assetsInjest"
@@ -98,6 +100,10 @@
 # - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml
 # - COMPOSE_PROFILES=app,setup,db,pma,elasticsearch,rabbitmq,redis,redis-session,workers,cmd,mailhog,gateway-classic
 #
+# # To test with tools and apply resources throttling on Phraseanet containers :
+# - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml:docker-compose.limits.yml
+# - COMPOSE_PROFILES=app,setup,db,pma,elasticsearch,rabbitmq,redis,redis-session,workers,cmd,mailhog,gateway-classic
+#
 # For testing with debug and SSL (the traekik is provide by Phrasea stack):
 # - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml:docker-compose.under-phrasea.yml
 # - COMPOSE_PROFILES=app,setup,gateway-traefik,db,pma,elasticsearch,rabbitmq,redis,redis-session,worker,workers,mailhog
@@ -107,7 +113,7 @@
 # - COMPOSE_PROFILES=app,setup,workers,gateway-traefik
 #
 # Example with all profiles:
-# - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml
+# - COMPOSE_FILE=docker-compose.yml:docker-compose.datastores.yml:docker-compose.tools.yml:docker-compose.limits.yml
 # - COMPOSE_PROFILES=app,setup,gateway-classic,db,elasticsearch,redis,redis-session,rabbitmq,pma,mailhog,assetsInjest,createRecord,deleteRecord,editRecord,
 #                    exportMail,downloadAsync,exposeUpload,exportFtp,mainQueue,populateIndex,pullAssets,recordsActions,subdefCreation,
 #                    validationReminder,webhook,writeMetadatas,shareBasket,scheduler,cmd,elk,db-backup,phraseanet-saml-sp
@@ -137,12 +143,24 @@ PHRASEANET_DOCKER_REGISTRY=local
 
 # Docker images tag.
 # @run
-PHRASEANET_DOCKER_TAG=4.1.8-rc7
+PHRASEANET_DOCKER_TAG=4.1.8-rc8
 
 # Stack Name
 # An optionnal Name for the stack
 # @run
 STACK_NAME=
+
+# --- Phraseanet containers resources limit settings ------------------------------------------------------------------------------------
+
+WORKER_CPU=2
+GATEWAY_CPU=2
+FPM_CPU=2
+WORKER_MEMORY_LIMIT=2048M
+GATEWAY_MEMORY_LIMIT=2048M
+FPM_MEMORY_LIMIT=2048M
+WORKER_MEMORY_RESERVATION=256M
+GATEWAY_MEMORY_RESERVATION=256M
+FPM_MEMORY_RESERVATION=256M
 
 # --- Phraseanet container network settings ------------------------------------------------------------------------------------
 
@@ -467,6 +485,14 @@ PHRASEANET_CACHE_HOST=redis
 # @run
 PHRASEANET_CACHE_PORT=6379
 
+# PHP session management
+# @run
+PHRASEANET_SESSION_TYPE=redis
+# @run
+PHRASEANET_SESSION_HOST=redis-session
+# @run
+PHRASEANET_SESSION_PORT=6379
+
 # --- Phraseanet general settings --------------------------------------------------------------------------------------
 
 # Variables below are used in the "configuration.yml" file:
@@ -511,6 +537,10 @@ PHRASEANET_ADMIN_ACCOUNT_PASSWORD=iJRqXU0MwbyJewQLBbra6IWHsWly
 # @run
 PHRASEANET_DOWNLOAD_ASYNC=false
 
+# User Session duration settings 
+# @run
+PHRASEANET_USER_SESSION_IDLE=14400
+PHRASEANET_USER_SESSION_LIFETIME=86400
 
 # --- Phraseanet MySQL settings ----------------------------------------------------------------------------------------
 

--- a/docker-compose.altenatives.yml
+++ b/docker-compose.altenatives.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+
+  db:
+    image: mysql
+    # NOTE: use of "mysql_native_password" is not recommended: https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password
+    # (this is just an example, not intended to be a production configuration)
+    command: --default-authentication-plugin=mysql_native_password --max_allowed_packet=$MYSQL_MAX_ALLOWED_PACKET --max_connections=$MYSQL_MAX_CONNECTION --long_query_time=$MYSQL_LONG_QUERY_TIME --sql_mode="NO_ENGINE_SUBSTITUTION"
+    restart: on-failure
+    profiles: ["mysql8"]
+    environment:
+    - MYSQL_ROOT_PASSWORD
+    - MYSQL_MAX_ALLOWED_PACKET
+    - MYSQL_MAX_CONNECTION
+    - MYSQL_LONG_QUERY_TIME
+    - MYSQL_SLOW_QUERY_LOG
+    - MYSQL_QUERY_CACHE_LIMIT
+    - MYSQL_QUERY_CACHE_SIZE
+    - MYSQL_KEY_BUFFER_SIZE
+    volumes:
+    - ${PHRASEANET_DB_DIR}2:/var/lib/mysql
+    networks:
+      - internal

--- a/docker-compose.altenatives.yml
+++ b/docker-compose.altenatives.yml
@@ -9,6 +9,12 @@ services:
     command: --default-authentication-plugin=mysql_native_password --max_allowed_packet=$MYSQL_MAX_ALLOWED_PACKET --max_connections=$MYSQL_MAX_CONNECTION --long_query_time=$MYSQL_LONG_QUERY_TIME --sql_mode="NO_ENGINE_SUBSTITUTION"
     restart: on-failure
     profiles: ["mysql8"]
+    entrypoint:
+      sh -c "
+        echo 'CREATE DATABASE IF NOT EXISTS ab_master CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;CREATE DATABASE IF NOT EXISTS db_databox1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;CREATE DATABASE IF NOT EXISTS db_unitTest CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;CREATE DATABASE IF NOT EXISTS db_dataset1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;CREATE DATABASE IF NOT EXISTS db_dataset2 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; CREATE USER `$PHRASEANET_DB_USER`@`%` IDENTIFIED BY \"$PHRASEANET_DB_PASSWORD\";GRANT ALL PRIVILEGES ON *.* to `$PHRASEANET_DB_USER`@`%`;' > /docker-entrypoint-initdb.d/init.sql;
+        chmod +x /usr/local/bin/docker-entrypoint.sh /docker-entrypoint-initdb.d/init.sql;
+        /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --max_allowed_packet=$MYSQL_MAX_ALLOWED_PACKET --max_connections=$MYSQL_MAX_CONNECTION --long_query_time=$MYSQL_LONG_QUERY_TIME --sql_mode="NO_ENGINE_SUBSTITUTION" --slow_query_log=$MYSQL_SLOW_QUERY_LOG
+      "
     environment:
     - MYSQL_ROOT_PASSWORD
     - MYSQL_MAX_ALLOWED_PACKET

--- a/docker-compose.altenatives.yml
+++ b/docker-compose.altenatives.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
 
   db:
-    image: mysql
+    image: mysql:8.0.36-debian
     # NOTE: use of "mysql_native_password" is not recommended: https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password
     # (this is just an example, not intended to be a production configuration)
     command: --default-authentication-plugin=mysql_native_password --max_allowed_packet=$MYSQL_MAX_ALLOWED_PACKET --max_connections=$MYSQL_MAX_CONNECTION --long_query_time=$MYSQL_LONG_QUERY_TIME --sql_mode="NO_ENGINE_SUBSTITUTION"
@@ -25,6 +25,6 @@ services:
     - MYSQL_QUERY_CACHE_SIZE
     - MYSQL_KEY_BUFFER_SIZE
     volumes:
-    - ${PHRASEANET_DB_DIR}2:/var/lib/mysql
+    - ${PHRASEANET_DB_DIR}_mysql8:/var/lib/mysql:rw
     networks:
       - internal

--- a/lib/Alchemy/Phrasea/Core/Database/DatabaseMaintenanceService.php
+++ b/lib/Alchemy/Phrasea/Core/Database/DatabaseMaintenanceService.php
@@ -93,7 +93,7 @@ class DatabaseMaintenanceService
                     $this->alterTableEngine($tableName, $engine, $recommends);
                 }
 
-                $ret = $this->upgradeTable($allTables[$tableName]);
+                $ret = $this->upgradeTable($allTables[$tableName], $output);
                 $recommends = array_merge($recommends, $ret);
 
                 unset($allTables[$tableName]);
@@ -285,7 +285,7 @@ class DatabaseMaintenanceService
         unset($stmt);
     }
 
-    public function upgradeTable(\SimpleXMLElement $table)
+    public function upgradeTable(\SimpleXMLElement $table, OutputInterface $output)
     {
         $this->reconnect();
 
@@ -302,9 +302,10 @@ class DatabaseMaintenanceService
 
             $collation = trim((string)$field->collation) != '' ? trim((string)$field->collation) : 'utf8_unicode_ci';
 
-            if (in_array(strtolower((string)$field->type), ['text', 'longtext', 'mediumtext', 'tinytext'])
-                || substr(strtolower((string)$field->type), 0, 7) == 'varchar'
-                || in_array(substr(strtolower((string)$field->type), 0, 4), ['char', 'enum'])
+            $type = trim(strtolower((string)$field->type));
+            if (in_array($type, ['text', 'longtext', 'mediumtext', 'tinytext'])
+                || substr($type, 0, 7) == 'varchar'
+                || in_array(substr($type, 0, 4), ['char', 'enum'])
             ) {
                 $collations = array_reverse(explode('_', $collation));
                 $code = array_pop($collations);
@@ -328,7 +329,10 @@ class DatabaseMaintenanceService
                 $expr .= ' DEFAULT ' . $_default . '';
             }
 
-            $correct_table['fields'][trim((string)$field->name)] = $expr;
+            $correct_table['fields'][trim((string)$field->name)] = [
+                'expr' => $expr,
+                'expr8' => preg_replace('/^(\\w*int)(\\(\\d+\\))?(.*)?$/', '$1$3', $expr)
+            ];
         }
         if ($table->indexes) {
             foreach ($table->indexes->index as $index) {
@@ -359,6 +363,36 @@ class DatabaseMaintenanceService
 
         foreach ($rs2 as $row2) {
             $f_name = $row2['Field'];
+
+            // accept alias collations as same as in lib/conf.d/bases_structure.xml (utf8_unicode_ci)
+            if(in_array(strtolower($row2['Collation']), ['utf8mb3_unicode_ci', 'utf8mb4_unicode_ci'])) {
+                $row2['Collation'] = 'utf8_unicode_ci';
+            }
+
+            // accept current_timestamp() as result of CURRENT_TIMESTAMP
+            if(strtolower($row2['Default']) === 'current_timestamp()') {
+                $row2['Default'] = "CURRENT_TIMESTAMP";
+            }
+
+            // match integers (https://dev.mysql.com/worklog/task/?id=13127)
+            if(isset($correct_table['fields'][$f_name])) {
+                $matches = [];
+                if(preg_match("/^(\\w*int)(\\(\d+\\))?(.*)?$/", $row2['Type'], $matches) === 1) {
+                    $matches = array_merge($matches, ['', '', '', '']); // set missing matches (easier to test)
+                    if($matches[2] === '') {
+                        // mysql 8 : we must use the expr8
+                        $correct_table['fields'][$f_name] = $correct_table['fields'][$f_name]['expr8'];
+                    }
+                    else {
+                        // mysql 5
+                        $correct_table['fields'][$f_name] = $correct_table['fields'][$f_name]['expr'];
+                    }
+                }
+                else {
+                    $correct_table['fields'][$f_name] = $correct_table['fields'][$f_name]['expr'];
+                }
+            }
+
             $expr_found = trim($row2['Type']);
 
             $_extra = $row2['Extra'];
@@ -427,11 +461,15 @@ class DatabaseMaintenanceService
                     }
                 }
 
-                if (strtolower($expr_found) !== strtolower($correct_table['fields'][$f_name])) {
-                    $alter[] = "ALTER TABLE `" . $table['name'] . "` CHANGE `$f_name` `$f_name` " . $correct_table['fields'][$f_name];
+                $expected = $correct_table['fields'][$f_name];
+                if (strtolower($expr_found) !== strtolower($expected)) {
+                    $output->writeln(sprintf("expected: <info>%s</info>", $expected));
+                    $output->writeln(sprintf("got     : <info>%s</info>", $expr_found));
+                    $alter[] = "ALTER TABLE `" . $table['name'] . "` CHANGE `$f_name` `$f_name` " . $expected;
                 }
                 unset($correct_table['fields'][$f_name]);
-            } else {
+            }
+            else {
                 $return[] = [
                     'message' => 'Un champ pourrait etre supprime',
                     'sql' => "ALTER TABLE " . $this->connection->getDatabase() . ".`" . $table['name'] . "` DROP `$f_name`;"
@@ -478,6 +516,8 @@ class DatabaseMaintenanceService
             if (isset($correct_table['indexes'][$kIndex])) {
 
                 if (mb_strtolower($expr_found) !== mb_strtolower($correct_table['indexes'][$kIndex])) {
+                    $output->writeln(sprintf("expected: <info>%s</info>", $correct_table['indexes'][$kIndex]));
+                    $output->writeln(sprintf("got     : <info>%s</info>", $expr_found));
                     $alter[] = 'ALTER TABLE `' . $table['name'] . '` DROP ' . $full_name_index . ', ADD ' . $correct_table['indexes'][$kIndex];
                 }
 
@@ -498,6 +538,7 @@ class DatabaseMaintenanceService
             $this->reconnect();
 
             try {
+                $output->writeln(sprintf("%s \n", $a));
                 $this->connection->exec($a);
             } catch (\Exception $e) {
                 $return[] = [
@@ -512,6 +553,7 @@ class DatabaseMaintenanceService
             $this->reconnect();
 
             try {
+                $output->writeln(sprintf("%s \n", $a));
                 $this->connection->exec($a);
             } catch (\Exception $e) {
                 $return[] = [
@@ -541,7 +583,7 @@ class DatabaseMaintenanceService
 
         foreach ($iterator as $fileinfo) {
             if (!$fileinfo->isDot()) {
-// printf("---- [%d]\n", __LINE__);
+
                 if (substr($fileinfo->getFilename(), 0, 1) == '.') {
                     continue;
                 }
@@ -551,7 +593,6 @@ class DatabaseMaintenanceService
                 /** @var \patchAbstract $patch */
                 $patch = new $classname();
 
-// printf("---- [%d]\n", __LINE__);
                 if (!in_array($base->get_base_type(), $patch->concern())) {
                     continue;
                 }
@@ -560,18 +601,15 @@ class DatabaseMaintenanceService
                     continue;
                 }
 
-// printf("---- [%d] %s ; from: %s ; patch: %s; to:%s\n", __LINE__, $classname, $from, $patch->get_release(), $to);
-// printf("---- [%d]\n", __LINE__);
                 // if patch is older than current install
                 if (version::lte($patch->get_release(), $from)) {
                     continue;
                 }
-// printf("---- [%d]\n", __LINE__);
+
                 // if patch is new than current target
                 if (version::gt($patch->get_release(), $to)) {
                     continue;
                 }
-// printf("---- [%d]\n", __LINE__);
 
                 $n = 0;
                 do {
@@ -591,7 +629,7 @@ class DatabaseMaintenanceService
 
         // disable mail
         $this->app['swiftmailer.transport'] = null;
-// var_dump($list_patches);
+
         foreach ($list_patches as $patch) {
 
             $output->writeln(sprintf(" - patch \"%s\" (release %s) should be applied", get_class($patch), $patch->get_release()));


### PR DESCRIPTION
### Adds
  - PHRAS-4010: Adding mysql8 as alternative datastore (beta)
  - Allow to choose mysql8 as data store, for test purpose only
  - Require a DB content migration by export/import database.