### PR TITLE
PHRAS-4033 fix timeline history for writemetadata and subdefinition

### DIFF
--- a/lib/classes/Session/Logger.php
+++ b/lib/classes/Session/Logger.php
@@ -295,7 +295,8 @@ class Session_Logger
         $comment = json_encode([
             'finished' => empty($finished) ? '' : $finished->format('Y-m-d H:i:s'),
             'duration' => empty($finished) ? '' : $finished->getTimestamp() - $workerRunningJob->getCreated()->getTimestamp() ,
-            'status'   => $status
+            'status'   => $status,
+            'subdefName' => $subdefName
         ]);
 
         if ($count > 0) {

--- a/lib/conf.d/bases_structure.xml
+++ b/lib/conf.d/bases_structure.xml
@@ -2580,7 +2580,7 @@
           </field>
           <field>
             <name>action</name>
-            <type>enum('push','add','validate','edit','collection','status','print','substit','publish','download','mail','ftp','delete', 'subdefCreation', 'writeMetadatas', '')</type>
+            <type>enum('push','add','validate','edit','collection','status','print','substit','publish','download','mail','ftp','delete','subdefCreation','writeMetadatas','')</type>
             <null></null>
             <extra></extra>
             <default></default>

--- a/templates/web/prod/preview/short_history.html.twig
+++ b/templates/web/prod/preview/short_history.html.twig
@@ -43,11 +43,27 @@
           {% set content = done['final']|join(', ') %}
           {% trans with {'%dest%' : dest, '%content%' : content} %}Envoi par ftp a %dest% de %content%{% endtrans %}
         {% elseif action == 'subdefCreation' %}
-            {% set comment = done['comment'] | join(', ') | json_to_array %}
-            {% trans with {'%subdefName%' : done['final'] | join(', '), '%started%' : hour, '%duration%' : (comment.duration == '') ? '-' : comment.duration | date_duration , '%status%' : comment.status} %}create subdefinition: %subdefName% start at %started%  during %duration% -- status %status%{% endtrans %}
+            {% for  k, comment in done['comment'] %}
+                {% set comment = comment | json_to_array %}
+                {% set subdefName = comment.subdefName is defined ? comment.subdefName : done['final'][k]  %}
+
+                {% trans with {'%subdefName%' : subdefName, '%started%' : hour, '%duration%' : (comment.duration == '') ? '-' : comment.duration | date_duration , '%status%' : comment.status} %}create subdefinition: %subdefName% start at %started%  during %duration% -- status %status%{% endtrans %}
+                {% if  done['final']|length > 1  %}
+                   {# separate with line break #}
+                    <br><br>
+                {% endif %}
+            {% endfor %}
         {% elseif action == 'writeMetadatas' %}
-            {% set comment = done['comment'] | join(', ') | json_to_array %}
-            {% trans with {'%subdefName%' : done['final'] | join(', '), '%started%' : hour, '%duration%' : (comment.duration == '') ? '-' : comment.duration | date_duration , '%status%' : comment.status} %}write metadatas: %subdefName% start at %started%  during %duration% -- status %status%{% endtrans %}
+            {% for  k, comment in done['comment'] %}
+                {% set comment = comment | json_to_array %}
+                {% set subdefName = comment.subdefName is defined ? comment.subdefName : done['final'][k]  %}
+
+                {% trans with {'%subdefName%' : subdefName, '%started%' : hour, '%duration%' : (comment.duration == '') ? '-' : comment.duration | date_duration , '%status%' : comment.status} %}write metadatas: %subdefName% start at %started%  during %duration% -- status %status%{% endtrans %}
+            {% endfor %}
+            {% if  done['final']|length > 1  %}
+                {# separate with line break #}
+                <br><br>
+            {% endif %}
         {% elseif action == 'delete' %}
           {{ 'report::supression du document' | trans }}
         {% elseif action == 'add' %}


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-4033: fix timeline history for writemetadata and subdefinition
  - fix alter table in log_docs


