### PR TITLE
PHRAS-4085_data-volumes-api

### DIFF
--- a/bin/maintenance
+++ b/bin/maintenance
@@ -15,6 +15,7 @@ use Alchemy\Phrasea\Command\Maintenance\CleanRightsCommand;
 use Alchemy\Phrasea\Command\Maintenance\CleanWebhookLogsCommand;
 use Alchemy\Phrasea\Command\Maintenance\CleanWorkerRunningJobCommand;
 use Alchemy\Phrasea\Command\Maintenance\SessionsCommand;
+use Alchemy\Phrasea\Command\Maintenance\LazaretFilesSetSizeCommand;
 
 require_once __DIR__ . '/../lib/autoload.php';
 
@@ -58,5 +59,7 @@ $cli->command(new CleanLogSearchCommand());
 $cli->command(new CleanLogViewCommand());
 
 $cli->command(new CleanWebhookLogsCommand());
+
+$cli->command(new LazaretFilesSetSizeCommand());
 
 $cli->run();

--- a/lib/Alchemy/Phrasea/Border/Manager.php
+++ b/lib/Alchemy/Phrasea/Border/Manager.php
@@ -405,6 +405,8 @@ class Manager
 
         $lazaretFile->setSession($session);
 
+        $lazaretFile->setSize($file->getFile()->getSize());
+
         $this->app['orm.em']->persist($lazaretFile);
 
         foreach ($file->getAttributes() as $fileAttribute) {

--- a/lib/Alchemy/Phrasea/Command/Maintenance/LazaretFilesSetSizeCommand.php
+++ b/lib/Alchemy/Phrasea/Command/Maintenance/LazaretFilesSetSizeCommand.php
@@ -18,7 +18,7 @@ class LazaretFilesSetSizeCommand extends Command
 
         $this
             ->setDescription('Set the null size in the LazaretFiles table')
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'dry run, count')
+            ->addOption('dry', null, InputOption::VALUE_NONE, 'dry run, count')
 
             ->setHelp('');
     }
@@ -34,13 +34,18 @@ class LazaretFilesSetSizeCommand extends Command
         /** @var EntityManager $em */
         $em = $this->container['orm.em'];
 
-        if (!$input->getOption('dry-run')) {
+        if (!$input->getOption('dry')) {
             /** @var LazaretFile $lazaretNullSize */
             foreach ($lazaretNullSizes as $lazaretNullSize) {
-                $lazaretFileName = $path .'/'.$lazaretNullSize->getFilename();
-                $media = $this->container->getMediaFromUri($lazaretFileName);
+                try {
+                    $lazaretFileName = $path .'/'.$lazaretNullSize->getFilename();
+                    $media = $this->container->getMediaFromUri($lazaretFileName);
+                    $size = $media->getFile()->getSize();
+                } catch (\Exception $e) {
+                    $size = 0;
+                }
 
-                $lazaretNullSize->setSize($media->getFile()->getSize());
+                $lazaretNullSize->setSize($size);
                 $em->persist($lazaretNullSize);
             }
 

--- a/lib/Alchemy/Phrasea/Command/Maintenance/LazaretFilesSetSizeCommand.php
+++ b/lib/Alchemy/Phrasea/Command/Maintenance/LazaretFilesSetSizeCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Alchemy\Phrasea\Command\Maintenance;
+
+use Alchemy\Phrasea\Command\Command;
+use Alchemy\Phrasea\Model\Entities\LazaretFile;
+use Alchemy\Phrasea\Model\Repositories\LazaretFileRepository;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LazaretFilesSetSizeCommand extends Command
+{
+    public function __construct()
+    {
+        parent::__construct('lazaret:set_sizes');
+
+        $this
+            ->setDescription('Set the null size in the LazaretFiles table')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'dry run, count')
+
+            ->setHelp('');
+    }
+
+    public function doExecute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var LazaretFileRepository $lazaretRepository */
+        $lazaretRepository = $this->container['repo.lazaret-files'];
+
+        $lazaretNullSizes = $lazaretRepository->findBy(['size' => null]);
+
+        $path = $this->container['tmp.lazaret.path'];
+        /** @var EntityManager $em */
+        $em = $this->container['orm.em'];
+
+        if (!$input->getOption('dry-run')) {
+            /** @var LazaretFile $lazaretNullSize */
+            foreach ($lazaretNullSizes as $lazaretNullSize) {
+                $lazaretFileName = $path .'/'.$lazaretNullSize->getFilename();
+                $media = $this->container->getMediaFromUri($lazaretFileName);
+
+                $lazaretNullSize->setSize($media->getFile()->getSize());
+                $em->persist($lazaretNullSize);
+            }
+
+            $em->flush();
+
+            $output->writeln(sprintf("%d LazaretFiles done!", count($lazaretNullSizes)));
+        } else {
+            $output->writeln(sprintf("%d LazaretFiles to update!", count($lazaretNullSizes)));
+        }
+    }
+}

--- a/lib/Alchemy/Phrasea/Controller/Api/V3/V3MonitorDataController.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V3/V3MonitorDataController.php
@@ -39,9 +39,203 @@ class V3MonitorDataController extends Controller
      */
     public function indexAction(Request $request)
     {
+        $stopwatch = new Stopwatch("controller");
+
+        list($getDetails, $blocksize, $divider, $unit, $sqlByColl, $sqlByName, $sqlByDb) = $this->getParamsFromRequest($request);
+
+        $ret = [
+            'unit' => $divider === 1 ? $unit : ucfirst($unit), // octet => octet ; mo => Mo
+            'databoxes' => []
+        ];
+
+        foreach ($this->app->getDataboxes() as $databox) {
+            // get volumes by db
+
+            $stmt = $databox->get_connection()->prepare($sqlByDb);
+            $stmt->execute();
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            $stmt->closeCursor();
+
+            $ret['databoxes'][$databox->get_sbas_id()] = [
+                'sbas_id'   => $databox->get_sbas_id(),
+                'viewname'  => $databox->get_viewname(),
+                'count'     => (int)$row['n'],
+                'size'      => round($row['size'], 2),
+                'disksize'  => round($row['disksize'], 2)
+            ];
+
+            if ($getDetails) {
+                list($collections, $subdefs) = $this->getVolumeDetails($databox, $sqlByColl, $sqlByName);
+
+                $ret['databoxes'][$databox->get_sbas_id()]['collections']   = $collections;
+                $ret['databoxes'][$databox->get_sbas_id()]['subdefs']       = $subdefs;
+            }
+        }
+
+        // get volumes of downloads
+
+        $sql = "SELECT `data` FROM `Tokens` WHERE `type`='download'";
+        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
+        $stmt->execute();
+        $size = 0;
+        $disksize = 0;
+        $n = 0;
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            try {
+                $data       = unserialize($row['data']);
+                $size       += $data['size'];
+                $disksize   += ceil($data['size'] / $blocksize) * $blocksize;
+                $n++;
+            }
+            catch (\Exception $e) {
+                // ignore
+            }
+        }
+        $stmt->closeCursor();
+
+        $sql = "SELECT DATEDIFF(NOW(), MIN(`created`)) AS `oldest`, SUM(IF(NOW()>`expiration`, 1, 0)) AS `expired` FROM `Tokens` WHERE `type`='download'";
+        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        $ret['downloads'] = [
+            'count'         => $n,
+            'days_oldest'   => (int)$row['oldest'],
+            'expired'       => (int)$row['expired'],
+            'size'          => round($size / $divider, 2),
+            'disksize'      => round($disksize / $divider, 2)
+        ];
+
+        $sql = "SELECT count(*) AS n , SUM(`size`) AS size FROM `LazaretFiles` WHERE size IS NOT NULL";
+        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
+        $stmt->execute();
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        $disksize = ceil($row['size'] / $blocksize) * $blocksize;;
+
+        $ret['lazaret'] = [
+            'count'     => $row['n'],
+            'size'      => round($row['size'] / $divider, 2),
+            'disksize'  => round($disksize / $divider, 2)
+        ];
+
+        return Result::create($request, $ret)->createResponse([$stopwatch]);
+    }
+
+    /**
+     * monitor info for app by databox
+     * @param Request $request
+     */
+    public function perDataboxAction(Request $request)
+    {
+        $stopwatch = new Stopwatch("controller");
+        $databoxId = $request->get('databox_id');
+
+        list($getDetails, $blocksize, $divider, $unit, $sqlByColl, $sqlByName, $sqlByDb) = $this->getParamsFromRequest($request);
+
+        $ret = [
+            'unit' => $divider === 1 ? $unit : ucfirst($unit), // octet => octet ; mo => Mo
+            'databox' => []
+        ];
+
+        $databox = $this->findDataboxById($databoxId);
+
+        // get volumes by db
+
+        $stmt = $databox->get_connection()->prepare($sqlByDb);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        $ret['databox'] = [
+            'sbas_id'   => $databox->get_sbas_id(),
+            'viewname'  => $databox->get_viewname(),
+            'count'     => (int)$row['n'],
+            'size'      => round($row['size'], 2),
+            'disksize'  => round($row['disksize'], 2)
+        ];
+
+        if ($getDetails) {
+            list($collections, $subdefs) = $this->getVolumeDetails($databox, $sqlByColl, $sqlByName);
+
+            $ret['databox']['collections']  = $collections;
+            $ret['databox']['subdefs']      = $subdefs;
+        }
+
+        // get volumes of downloads
+
+        $sql = "SELECT `data` FROM `Tokens` WHERE `type`='download'";
+        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
+        $stmt->execute();
+        $size = 0;
+        $disksize = 0;
+        $n = 0;
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            try {
+                $found = false;
+                $data = unserialize($row['data']);
+                foreach ($data['files'] as $file) {
+                    // get only for the needed databoxId
+                    if ($file['databox_id'] == $databoxId) {
+                        $found = true;
+                        foreach ($file['subdefs'] as $subdef) {
+                            $size += $subdef['size'];
+                            $disksize += ceil($subdef['size'] / $blocksize) * $blocksize;
+                        }
+                    }
+                }
+
+                if ($found) {
+                    $n++;
+                }
+            }
+            catch (\Exception $e) {
+                // ignore
+            }
+        }
+
+        $stmt->closeCursor();
+
+        $ret['downloads'] = [
+            'sbas_id'   => $databoxId,
+            'count'     => $n,
+            'size'      => round($size / $divider, 2),
+            'disksize'  => round($disksize / $divider, 2)
+        ];
+
+        // get lazaret volume for the databox
+
+        $sql = "SELECT count(*) AS n , SUM(`size`) AS size ".
+            " FROM `LazaretFiles` AS L ".
+            " LEFT JOIN `bas` AS b ON L.`base_id`=b.`base_id`".
+            " WHERE L.`size` IS NOT NULL AND b.`sbas_id`=". $databoxId;
+
+
+        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
+        $stmt->execute();
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        $disksize = ceil($row['size'] / $blocksize) * $blocksize;;
+
+        $ret['lazaret'] = [
+            'sbas_id'   => $databoxId,
+            'count'     => $row['n'],
+            'size'      => round($row['size'] / $divider, 2),
+            'disksize'  =>  round($disksize / $divider, 2)
+        ];
+
+        return Result::create($request, $ret)->createResponse([$stopwatch]);
+    }
+
+    private function getParamsFromRequest(Request $request)
+    {
         $getDetails = $request->get('details', '0') === '1';
 
-        $stopwatch = new Stopwatch("controller");
         $matches = [];
         if(preg_match("/^(\\d+)\\s*([a-z]*)$/i", $request->get('blocksize', '1'), $matches) !== 1) {
             throw new Exception("bad 'blocksize' parameter");
@@ -57,12 +251,10 @@ class V3MonitorDataController extends Controller
         }
         $sqlDivider = $divider === 1 ? '' : (' / ' . $divider);
 
-        $ret = [
-            'unit' => $divider === 1 ? $unit : ucfirst($unit), // octet => octet ; mo => Mo
-            'databoxes' => []
-        ];
+        $sqlByColl = "";
+        $sqlByName = "";
 
-        if($getDetails) {
+        if ($getDetails) {
 
             $sqlByColl = "SELECT COALESCE(r.`coll_id`, '?') AS `coll_id`,
                     COALESCE(c.`asciiname`, CONCAT('_',r.`coll_id`), '?') AS `asciiname`, s.`name`,
@@ -82,102 +274,44 @@ class V3MonitorDataController extends Controller
                     SUM(CEIL(s.`size` / " . $blocksize . ") * " . $blocksize . ") " . $sqlDivider . " AS `disksize`
                     FROM `subdef` AS s";
 
-        foreach($this->app->getDataboxes() as $databox) {
-
-            if($getDetails) {
-
-                // get volumes grouped by collection and subdef
-
-                $collections = [];
-                $stmt = $databox->get_connection()->prepare($sqlByColl);
-                $stmt->execute();
-                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                    if (!array_key_exists($row['coll_id'], $collections)) {
-                        $collections[$row['coll_id']] = [
-                            'coll_id' => $row['coll_id'],
-                            'name'    => $row['asciiname'],
-                            'subdefs' => []
-                        ];
-                    }
-                    $collections[$row['coll_id']]['subdefs'][$row['name']] = [
-                        'count'    => (int)$row['n'],
-                        'size'     => round($row['size'], 2),
-                        'disksize' => round($row['disksize'], 2)
-                    ];
-                }
-                $stmt->closeCursor();
-
-                // get volumes by subdef
-
-                $subdefs = [];
-                $stmt = $databox->get_connection()->prepare($sqlByName);
-                $stmt->execute();
-                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                    $subdefs[$row['name']]['count'] = (int)$row['n'];
-                    $subdefs[$row['name']]['size'] = round($row['size'], 2);
-                    $subdefs[$row['name']]['disksize'] = round($row['disksize'], 2);
-                }
-                $stmt->closeCursor();
-            }
-
-            // get volumes by db
-
-            $stmt = $databox->get_connection()->prepare($sqlByDb);
-            $stmt->execute();
-            $row = $stmt->fetch(PDO::FETCH_ASSOC);
-            $stmt->closeCursor();
-
-            $ret['databoxes'][$databox->get_sbas_id()] = [
-                'sbas_id' => $databox->get_sbas_id(),
-                'viewname' => $databox->get_viewname(),
-                'count' => (int)$row['n'],
-                'size' => round($row['size'], 2),
-                'disksize' => round($row['disksize'], 2)
-            ];
-
-            if($getDetails) {
-                $ret['databoxes'][$databox->get_sbas_id()]['collections'] = $collections;
-                $ret['databoxes'][$databox->get_sbas_id()]['subdefs'] = $subdefs;
-            }
-        }
-
-        // get volumes of downloads
-
-        $sql = "SELECT `data` FROM `Tokens` WHERE `type`='download'";
-        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
-        $stmt->execute();
-        $size = 0;
-        $disksize = 0;
-        $n = 0;
-        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            try {
-                $data = unserialize($row['data']);
-                $size += $data['size'];
-                $disksize += ceil($data['size'] / $blocksize) * $blocksize;
-                $n++;
-            }
-            catch (\Exception $e) {
-                // ignore
-            }
-        }
-        $stmt->closeCursor();
-
-        $sql = "SELECT DATEDIFF(NOW(), MIN(`created`)) AS `oldest`, SUM(IF(NOW()>`expiration`, 1, 0)) AS `expired` FROM `Tokens` WHERE `type`='download'";
-        $stmt = $this->getApplicationBox()->get_connection()->prepare($sql);
-        $stmt->execute();
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        $stmt->closeCursor();
-
-        $ret['downloads'] = [
-            'count' => $n,
-            'days_oldest' => (int)$row['oldest'],
-            'expired' => (int)$row['expired'],
-            'size' => round($size / $divider, 2),
-            'disksize' => round($disksize / $divider, 2)
-        ];
-
-
-        return Result::create($request, $ret)->createResponse([$stopwatch]);
+        return [$getDetails, $blocksize, $divider, $unit, $sqlByColl, $sqlByName, $sqlByDb];
     }
 
+    private function getVolumeDetails(\databox $databox, $sqlByColl, $sqlByName)
+    {
+        // get volumes grouped by collection and subdef
+
+        $collections = [];
+        $stmt = $databox->get_connection()->prepare($sqlByColl);
+        $stmt->execute();
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            if (!array_key_exists($row['coll_id'], $collections)) {
+                $collections[$row['coll_id']] = [
+                    'coll_id' => $row['coll_id'],
+                    'name'    => $row['asciiname'],
+                    'subdefs' => []
+                ];
+            }
+            $collections[$row['coll_id']]['subdefs'][$row['name']] = [
+                'count'    => (int)$row['n'],
+                'size'     => round($row['size'], 2),
+                'disksize' => round($row['disksize'], 2)
+            ];
+        }
+        $stmt->closeCursor();
+
+        // get volumes by subdef
+
+        $subdefs = [];
+        $stmt = $databox->get_connection()->prepare($sqlByName);
+        $stmt->execute();
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $subdefs[$row['name']]['count'] = (int)$row['n'];
+            $subdefs[$row['name']]['size'] = round($row['size'], 2);
+            $subdefs[$row['name']]['disksize'] = round($row['disksize'], 2);
+        }
+        $stmt->closeCursor();
+
+        return [$collections, $subdefs];
+    }
 }

--- a/lib/Alchemy/Phrasea/Controller/Api/V3/V3MonitorDataController.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V3/V3MonitorDataController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Alchemy\Phrasea\Controller\Api\V3;
+
+use Alchemy\Phrasea\Application\Helper\DispatcherAware;
+use Alchemy\Phrasea\Application\Helper\JsonBodyAware;
+use Alchemy\Phrasea\Controller\Api\InstanceIdAware;
+use Alchemy\Phrasea\Controller\Api\Result;
+use Alchemy\Phrasea\Controller\Controller;
+use Alchemy\Phrasea\Controller\Exception;
+use Alchemy\Phrasea\Utilities\Stopwatch;
+use PDO;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class V3MonitorDataController extends Controller
+{
+    use JsonBodyAware;
+    use DispatcherAware;
+    use InstanceIdAware;
+
+    /**
+     * monitor infos for app
+     *
+     * @param  Request $request
+     *
+     * @return Response
+     */
+    private function unitToMultiplier(string $unit)
+    {
+        static $map = ['o', 'ko', 'mo', 'go'];
+        if(($i = array_search(strtolower($unit), $map)) === false) {
+            return false;
+        }
+        return 1 << ($i * 10);
+    }
+
+    public function indexAction(Request $request)
+    {
+        $stopwatch = new Stopwatch("controller");
+        $ret = [
+            'databoxes' => []
+        ];
+        $matches = [];
+        if(preg_match("/^(\\d+)\\s*(ko|mo|go)?$/i", $request->get('blocksize', '1'), $matches) !== 1) {
+            throw new Exception("bad 'blocksize' parameter");
+        }
+        $matches[] = 'o';   // if no unit, force
+        $blocksize = (int)($matches[1]) * $this->unitToMultiplier($matches[2]);
+
+        $sql = "SELECT COALESCE(r.`coll_id`, '?') AS `coll_id`,
+                    COALESCE(c.`asciiname`, CONCAT('_',r.`coll_id`), '?') AS `asciiname`, s.`name`,
+                    SUM(1) AS n, SUM(s.`size`) AS `size`, SUM(CEIL(s.`size` / " . $blocksize . ") * " . $blocksize . ") AS `disksize`
+                    FROM `subdef` AS s LEFT JOIN `record` AS r ON r.`record_id`=s.`record_id` 
+                    LEFT JOIN `coll` AS c ON r.`coll_id`=c.`coll_id`
+                GROUP BY r.`coll_id`, s.`name`;";
+
+        foreach($this->app->getDataboxes() as $databox) {
+            $collections = [];
+            $subdefs = [];
+            $stmt = $databox->get_connection()->prepare($sql);
+            $stmt->execute();
+            while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                if(!array_key_exists($row['coll_id'], $collections)) {
+                    $collections[$row['coll_id']] = [
+                        'coll_id' => $row['coll_id'],
+                        'name' => $row['asciiname'],
+                        'subdefs' => []
+                    ];
+                }
+                $collections[$row['coll_id']]['subdefs'][$row['name']] = [
+                    'count' => $row['n'],
+                    'size' => $row['size'],
+                    'disksize' => $row['disksize']
+                ];
+                if(!array_key_exists($row['name'], $subdefs)) {
+                    $subdefs[$row['name']] = [
+                        'count' => 0,
+                        'size' => 0,
+                        'disksize' => 0
+                    ];
+                }
+                $subdefs[$row['name']]['count'] += $row['n'];
+                $subdefs[$row['name']]['size'] += $row['size'];
+                $subdefs[$row['name']]['disksize'] += $row['disksize'];
+            }
+            $ret['databoxes'][$databox->get_sbas_id()] = [
+                'sbas_id' => $databox->get_sbas_id(),
+                'viewname' => $databox->get_viewname(),
+                'collections' => $collections,
+                'subdefs' => $subdefs
+            ];
+        }
+        return Result::create($request, $ret)->createResponse([$stopwatch]);
+    }
+
+}

--- a/lib/Alchemy/Phrasea/Controller/Api/V3/V3MonitorDataController.php
+++ b/lib/Alchemy/Phrasea/Controller/Api/V3/V3MonitorDataController.php
@@ -21,7 +21,7 @@ class V3MonitorDataController extends Controller
 
     private function unitToMultiplier(string $unit)
     {
-        static $map = [''=>1, 'o'=>1, 'ko'=>1<<10, 'mo'=>1<<20, 'go'=>1<<30];
+        static $map = [''=>1, 'o'=>1, 'octet'=>1, 'octets'=>1, 'ko'=>1<<10, 'mo'=>1<<20, 'go'=>1<<30];
         try {
             return $map[strtolower($unit)];
         }
@@ -41,11 +41,14 @@ class V3MonitorDataController extends Controller
     {
         $stopwatch = new Stopwatch("controller");
         $matches = [];
-        if(preg_match("/^(\\d+)\\s*(ko|mo|go)?$/i", $request->get('blocksize', '1'), $matches) !== 1) {
+        if(preg_match("/^(\\d+)\\s*([a-z]*)$/i", $request->get('blocksize', '1'), $matches) !== 1) {
             throw new Exception("bad 'blocksize' parameter");
         }
         $matches[] = '';   // if no unit, force
-        $blocksize = (int)($matches[1]) * $this->unitToMultiplier($matches[2]);
+        if(($mutiplier = $this->unitToMultiplier($matches[2])) === false) {
+            throw new Exception("bad 'blocksize' unit");
+        }
+        $blocksize = (int)($matches[1]) * $mutiplier;
 
         if( ($divider = $this->unitToMultiplier($unit = $request->get('unit', '')) ) === false) {
             throw new Exception("bad 'unit' parameter");

--- a/lib/Alchemy/Phrasea/ControllerProvider/Api/V3.php
+++ b/lib/Alchemy/Phrasea/ControllerProvider/Api/V3.php
@@ -108,6 +108,14 @@ class V3 extends Api implements ControllerProviderInterface, ServiceProviderInte
         ;
 
         /**
+         * @uses V3MonitorDataController::perDataboxAction()
+         */
+        $controllers->get('databoxes/{databox_id}/monitor/data/', 'controller.api.v3.monitorData:perDataboxAction')
+            ->before('controller.api.v1:ensureAdmin')
+            ->assert('databox_id', '\d+')
+        ;
+
+        /**
          * @uses V3SearchController::helloAction()
          */
         $controllers->match('/hello/', 'controller.api.v3.searchraw:helloAction');

--- a/lib/Alchemy/Phrasea/ControllerProvider/Api/V3.php
+++ b/lib/Alchemy/Phrasea/ControllerProvider/Api/V3.php
@@ -5,6 +5,7 @@ namespace Alchemy\Phrasea\ControllerProvider\Api;
 use Alchemy\Phrasea\Application as PhraseaApplication;
 use Alchemy\Phrasea\Controller\Api\V1Controller;
 use Alchemy\Phrasea\Controller\Api\V3\V3Controller;
+use Alchemy\Phrasea\Controller\Api\V3\V3MonitorDataController;
 use Alchemy\Phrasea\Controller\Api\V3\V3RecordController;
 use Alchemy\Phrasea\Controller\Api\V3\V3ResultHelpers;
 use Alchemy\Phrasea\Controller\Api\V3\V3SearchController;
@@ -49,6 +50,9 @@ class V3 extends Api implements ControllerProviderInterface, ServiceProviderInte
             return (new V3SearchController($app))
                 ->setInstanceId($app['conf'])
                 ;
+        });
+        $app['controller.api.v3.monitorData'] = $app->share(function (PhraseaApplication $app) {
+            return (new V3MonitorDataController($app));
         });
         $app['controller.api.v3.searchraw'] = $app->share(function (PhraseaApplication $app) {
             return (new V3SearchRawController($app));
@@ -95,6 +99,13 @@ class V3 extends Api implements ControllerProviderInterface, ServiceProviderInte
             ->assert('databox_id', '\d+')
             ->assert('record_id', '\d+')
             ->value('must_be_story', true);
+
+        /**
+         * @uses V3MonitorDataController::indexAction()
+         */
+        $controllers->get('/monitor/data/', 'controller.api.v3.monitorData:indexAction')
+            ->before('controller.api.v1:ensureAdmin')
+        ;
 
         /**
          * @uses V3SearchController::helloAction()

--- a/lib/Alchemy/Phrasea/Model/Entities/LazaretFile.php
+++ b/lib/Alchemy/Phrasea/Model/Entities/LazaretFile.php
@@ -97,6 +97,11 @@ class LazaretFile
     private $session;
 
     /**
+     * @ORM\Column(type="bigint", nullable=true)
+     */
+    private $size;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -320,6 +325,29 @@ class LazaretFile
         $this->updated = $updated;
 
         return $this;
+    }
+
+    /**
+     * Set size
+     *
+     * @param  integer     $size
+     * @return LazaretFile
+     */
+    public function setSize($size)
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get size
+     *
+     * @return integer
+     */
+    public function getSize()
+    {
+        return $this->size;
     }
 
     /**


### PR DESCRIPTION
## Changelog

### Adds
  - PHRAS-4085: new route `/api/v3/monitor/data/?oauth_token=xxx&blocksize=16ko&unit=mo&details=1`
  `blocksize` is a number with possible units : '', 'o', 'octet', 'octets', 'Ko', 'Mo', 'Go' ; default: "" (same as 1 o) ==> disksize=size;
  `unit` sets the unit of size results
  `details=1` to also get subdefs by collection/name
  e.g.:
```
{
    "meta": {
        "api_version": "3.0.0",
        "request": "GET /api/v3/monitor/data/",
        "response_time": "2024-06-27T12:29:25+00:00",
        "http_code": 200,
        "error_type": null,
        "error_message": null,
        "error_details": null,
        "charset": "UTF-8"
    },
    "response": {
        "unit": "Mo",
        "databoxes": {
            "1": {
                "sbas_id": 1,
                "viewname": "new_databox_name",
                "collections": {
                    "1": {
                        "coll_id": "1",
                        "name": "test",
                        "subdefs": {
                            "document": {
                                "count": 27,
                                "size": 54.17,
                                "disksize": 54.39
                            },
                            "preview": {
                                "count": 29,
                                "size": 4.61,
                                "disksize": 4.8
                            },
                            "preview_mobile": {
                                "count": 26,
                                "size": 1.32,
                                "disksize": 1.5
                            },
                            "thumbnail": {
                                "count": 29,
                                "size": 5.28,
                                "disksize": 5.53
                            },
                            "thumbnail_mobile": {
                                "count": 24,
                                "size": 0.12,
                                "disksize": 0.38
                            }
                        }
                    },
                    "26": {
                        "coll_id": "26",
                        "name": "ww",
                        "subdefs": {
                            "document": {
                                "count": 4,
                                "size": 5.65,
                                "disksize": 5.69
                            },
                            "preview": {
                                "count": 4,
                                "size": 0.52,
                                "disksize": 0.56
                            },
                            "preview_mobile": {
                                "count": 4,
                                "size": 0.17,
                                "disksize": 0.19
                            },
                            "thumbnail": {
                                "count": 4,
                                "size": 0.7,
                                "disksize": 0.72
                            },
                            "thumbnail_mobile": {
                                "count": 4,
                                "size": 0.02,
                                "disksize": 0.06
                            }
                        }
                    }
                },
                "subdefs": {
                    "document": {
                        "count": 31,
                        "size": 59.81,
                        "disksize": 60.08
                    },
                    "preview": {
                        "count": 33,
                        "size": 5.14,
                        "disksize": 5.36
                    },
                    "preview_mobile": {
                        "count": 30,
                        "size": 1.49,
                        "disksize": 1.69
                    },
                    "thumbnail": {
                        "count": 33,
                        "size": 5.98,
                        "disksize": 6.25
                    },
                    "thumbnail_mobile": {
                        "count": 28,
                        "size": 0.13,
                        "disksize": 0.44
                    }
                },
                "count": 155,
                "size": 72.55,
                "disksize": 73.81
            }
        },
        "downloads": {
            "count": 33,
            "days_oldest": 21,
            "expired": 32,
            "size": 4.36,
            "disksize": 4.73
        }
    }
}
```
-  new route /api/v3/databoxes/68/monitor/data/?oauth_token=xxx&blocksize=16ko&unit=mo&details=1
- add column size in LazaretFiles table
- add command `bin/maintenance lazaret:set_sizes`  to fill the null size column of the  LazaretFiles
