### PR TITLE
Bump rabbitMQ version to 3.8.34

### DIFF
--- a/docker-compose.datastores.yml
+++ b/docker-compose.datastores.yml
@@ -21,7 +21,7 @@ services:
       - internal
 
   rabbitmq:
-    image: rabbitmq:3.6.16-management
+    image: rabbitmq:3.8.34-management
     profiles: ["rabbitmq"]
     restart: on-failure
     hostname: $RABBITMQ_HOSTNAME


### PR DESCRIPTION
Bump rabbitMQ version to 3.8.34. Issue with Centos 9 on previous version.

## Changelog
### Changed
  - Upgrade rabbitMQ version to 3.8.34 in docker-compose.datastores.yml