### PR TITLE
PHRAS-4079 Bump phraseanet base image to 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alchemyfr/phraseanet-base:1.0.0 AS builder
+FROM alchemyfr/phraseanet-base:1.0.1-alpha4 AS builder
 
 COPY --from=composer:2.1.6 /usr/bin/composer /usr/bin/composer
 
@@ -39,8 +39,8 @@ USER app
 
 # Warm up composer cache for faster builds
 COPY docker/caching/composer.* ./
-RUN composer install --prefer-dist --no-dev --no-progress --classmap-authoritative --no-interaction --no-scripts \
-    && rm -rf vendor composer.*
+RUN composer install --prefer-dist --no-dev --no-progress --classmap-authoritative --no-interaction --no-scripts
+#    && rm -rf vendor composer.*
 # End warm up
 
 COPY --chown=app  . .
@@ -72,7 +72,7 @@ CMD []
 # Phraseanet install and setup application image
 #########################################################################
 
-FROM alchemyfr/phraseanet-base:1.0.0 AS phraseanet-setup
+FROM alchemyfr/phraseanet-base:1.0.1-alpha4 AS phraseanet-setup
 
 COPY --from=builder --chown=app /var/alchemy/Phraseanet /var/alchemy/Phraseanet
 ADD ./docker/phraseanet/root /
@@ -85,7 +85,7 @@ CMD []
 # Phraseanet web application image
 #########################################################################
 
-FROM alchemyfr/phraseanet-base:1.0.0 AS phraseanet-fpm
+FROM alchemyfr/phraseanet-base:1.0.1-alpha4 AS phraseanet-fpm
 
 COPY --from=builder --chown=app /var/alchemy/Phraseanet /var/alchemy/Phraseanet
 ADD ./docker/phraseanet/root /
@@ -97,7 +97,7 @@ CMD ["php-fpm", "-F"]
 # Phraseanet worker application image
 #########################################################################
 
-FROM alchemyfr/phraseanet-base:1.0.0 AS phraseanet-worker
+FROM alchemyfr/phraseanet-base:1.0.1-alpha4 AS phraseanet-worker
 
 COPY --from=builder --chown=app /var/alchemy/Phraseanet /var/alchemy/Phraseanet
 ADD ./docker/phraseanet/root /
@@ -139,7 +139,7 @@ HEALTHCHECK CMD wget --spider http://127.0.0.1/login || nginx -s reload || exit 
 # phraseanet adapted simplesaml service provider 
 #########################################################################
 
-FROM alchemyfr/phraseanet-base:1.0.0 AS phraseanet-saml-sp
+FROM alchemyfr/phraseanet-base:1.0.1-alpha4 AS phraseanet-saml-sp
 RUN apt-get update \
     && apt-get install -y \
         apt-transport-https \


### PR DESCRIPTION
### Adds
  - PHRAS-PHRAS-4099: Upgrade phraseanet base image to alpha4
  - clean and secure base image.
