### PR TITLE
PHRAS-4109: Language : Secure cookie seems to be always needing HTTPS

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Root/RootController.php
+++ b/lib/Alchemy/Phrasea/Controller/Root/RootController.php
@@ -37,7 +37,21 @@ class RootController extends Controller
     public function setLocale($locale)
     {
         $response = $this->app->redirectPath('root');
-        $response->headers->setCookie(new Cookie('locale', $locale, 0, '/', null, true, false));
+
+        $cookiePath = ini_get('session.cookie_path');
+        $cookieDomain = ini_get('session.cookie_domain');
+        $cookieHttpOnly = ini_get('session.cookie_httponly');
+        $cookieSecure = ini_get('session.cookie_secure');
+
+        $response->headers->setCookie(new Cookie(
+            'locale',
+            $locale,
+            0,
+            $cookiePath,
+            empty($cookieDomain)? null : $cookieDomain,
+            $cookieSecure ? true: false,
+            $cookieHttpOnly ? true : false
+        ));
 
         $authenticatedUser = $this->getAuthenticatedUser();
 

--- a/lib/Alchemy/Phrasea/Core/Event/Subscriber/PhraseaLocaleSubscriber.php
+++ b/lib/Alchemy/Phrasea/Core/Event/Subscriber/PhraseaLocaleSubscriber.php
@@ -81,7 +81,20 @@ class PhraseaLocaleSubscriber implements EventSubscriberInterface
         $cookies = $event->getRequest()->cookies;
 
         if (isset($this->locale) && (false === $cookies->has('locale') || $cookies->get('locale') !== $this->locale)) {
-            $event->getResponse()->headers->setCookie(new Cookie('locale', $this->locale, 0,  '/',  null, true, false));
+            $cookiePath = ini_get('session.cookie_path');
+            $cookieDomain = ini_get('session.cookie_domain');
+            $cookieHttpOnly = ini_get('session.cookie_httponly');
+            $cookieSecure = ini_get('session.cookie_secure');
+
+            $event->getResponse()->headers->setCookie(new Cookie(
+                'locale',
+                $this->locale,
+                0,
+                $cookiePath,
+                empty($cookieDomain)? null : $cookieDomain,
+                $cookieSecure ? true: false,
+                $cookieHttpOnly ? true : false
+            ));
         }
     }
 }


### PR DESCRIPTION
## Changelog
  
### Fixes
  - PHRAS-4109: Language : Secure cookie seems to be always needing HTTPS.


