### PR TITLE
PHRAS-4146 bin/setup system:install - abort app installation if mysql db is not empty

### DIFF
--- a/docker/phraseanet/setup/init-test-install.sh
+++ b/docker/phraseanet/setup/init-test-install.sh
@@ -28,7 +28,7 @@ sleep 10
     --lazaret-path=$PHRASEANET_LAZARET_DIR \
     --caption-path=$PHRASEANET_CAPTION_DIR \
     --worker-tmp-files=$PHRASEANET_WORKER_TMP \
-    --data-path=/var/alchemy/Phraseanet/datas -y
+    --data-path=/var/alchemy/Phraseanet/datas -f
 done
 
 /var/alchemy/Phraseanet/bin/setup system:config set workers.queue.worker-queue.registry alchemy_worker.queue_registry

--- a/lib/Alchemy/Phrasea/Command/Setup/Install.php
+++ b/lib/Alchemy/Phrasea/Command/Setup/Install.php
@@ -61,6 +61,7 @@ class Install extends Command
             ->addOption('scheduler-locks-path', null, InputOption::VALUE_OPTIONAL, 'Path to scheduler-locks repository', __DIR__ . '/../../../../../tmp/locks')
             ->addOption('worker-tmp-files', null, InputOption::VALUE_OPTIONAL, 'Path to worker-tmp-files repository', __DIR__ . '/../../../../../tmp')
             ->addOption('yes', 'y', InputOption::VALUE_NONE, 'Answer yes to all questions')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'force to continue installation')
             ->setHelp("Phraseanet can only be installed on 64 bits PHP.");
             ;
 
@@ -118,7 +119,7 @@ class Install extends Command
 </comment>"
         );
 
-        if (!$input->getOption('yes') && !$input->getOption('appbox')) {
+        if (!$input->getOption('yes') && !$input->getOption('force') && !$input->getOption('appbox')) {
             $continue = $dialog->askConfirmation($output, 'Do you have these two DB handy ? (N/y)', false);
 
             if (!$continue) {
@@ -130,16 +131,30 @@ class Install extends Command
 
         $serverName = $this->getServerName($input, $output, $dialog);
 
+        /** @var Connection $abConn */
         $abConn = $this->getABConn($input, $output, $dialog, $serverName);
         if(!$abConn) {
             return 1;       // no ab is fatal
         }
 
+        if (!$input->getOption('force') && $abConn->getSchemaManager()->tablesExist(['users'])) {
+            $output->writeln("<error>Database table already exist in appbox! installation abort</error>");
+
+            return 1;
+        }
+
         list($dbConn, $templateName) = $this->getDBConn($input, $output, $abConn, $dialog);
+
+        if (!$input->getOption('force') && $dbConn->getSchemaManager()->tablesExist(['record'])) {
+            $output->writeln("<error>Database table already exist in databox! installation abort</error>");
+
+            return 1;
+        }
+
         list($email, $password) = $this->getCredentials($input, $output, $dialog);
         $dataPath = $this->getDataPath($input, $output, $dialog);
 
-        if (! $input->getOption('yes')) {
+        if (!$input->getOption('yes') && !$input->getOption('force')) {
             $output->writeln("<info>--- ElasticSearch connection settings ---</info>");
         }
 
@@ -154,7 +169,7 @@ class Install extends Command
 
         $output->writeln('');
 
-        if (!$input->getOption('yes')) {
+        if (!$input->getOption('yes') && !$input->getOption('force')) {
             $continue = $dialog->askConfirmation($output, "<question>Phraseanet is going to be installed, continue ? (N/y)</question>", false);
 
             if (!$continue) {
@@ -341,7 +356,7 @@ class Install extends Command
     {
         $dataPath = $input->getOption('data-path');
 
-        if (!$input->getOption('yes')) {
+        if (!$input->getOption('yes') && !$input->getOption('force')) {
             $continue = $dialog->askConfirmation($output, 'Would you like to change default data-path ? (N/y)', false);
 
             if ($continue) {
@@ -362,7 +377,7 @@ class Install extends Command
     {
         $serverName = $input->getOption('server-name');
 
-        if (!$serverName && !$input->getOption('yes')) {
+        if (!$serverName && !$input->getOption('yes') && !$input->getOption('force')) {
             do {
                 $serverName = $dialog->ask($output, 'Please provide the server name : ', null);
             } while (!$serverName);
@@ -380,7 +395,7 @@ class Install extends Command
         $host = $input->getOption('es-host');
         $port = (int) $input->getOption('es-port');
 
-        if (! $input->getOption('yes')) {
+        if (! $input->getOption('yes') && !$input->getOption('force')) {
             while (! $host) {
                 $host = $dialog->ask($output, 'ElasticSearch server host : ', null);
             };
@@ -397,7 +412,7 @@ class Install extends Command
     {
         $index = $input->getOption('es-index');
 
-        if (! $input->getOption('yes')) {
+        if (!$input->getOption('yes') && !$input->getOption('force')) {
             $index = $dialog->ask($output, 'ElasticSearch server index name (blank to autogenerate) : ', null);
         }
 

--- a/lib/Alchemy/Phrasea/Command/Setup/Install.php
+++ b/lib/Alchemy/Phrasea/Command/Setup/Install.php
@@ -94,7 +94,7 @@ class Install extends Command
         /** @var DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
 
-        $output->writeln("<comment>You are on your way to install Phraseanet, You will need access to 2 MySQL databases.</comment>");
+        $output->writeln("<comment> --- You are on your way to install Phraseanet, You will need access to 2 MySQL databases. --- </comment>");
 
         if (!$input->getOption('yes') && !$input->getOption('force') && !$input->getOption('appbox')) {
             $continue = $dialog->askConfirmation($output, 'Do you have these two DB handy ? (N/y)', false);
@@ -115,7 +115,7 @@ class Install extends Command
         }
 
         if (!$input->getOption('force') && $abConn->getSchemaManager()->tablesExist(['users'])) {
-            $output->writeln("<error>Database table already exist in appbox! installation abort</error>");
+            $output->writeln("<error>(*) Database table already exist in appbox! installation abort</error>");
 
             return 1;
         }
@@ -123,7 +123,7 @@ class Install extends Command
         list($dbConn, $templateName) = $this->getDBConn($input, $output, $abConn, $dialog);
 
         if (!$input->getOption('force') && $dbConn->getSchemaManager()->tablesExist(['record'])) {
-            $output->writeln("<error>Database table already exist in databox! installation abort</error>");
+            $output->writeln("<error>(*) Database table already exist in databox! installation abort</error>");
 
             return 1;
         }

--- a/lib/Alchemy/Phrasea/Command/Setup/Install.php
+++ b/lib/Alchemy/Phrasea/Command/Setup/Install.php
@@ -94,30 +94,7 @@ class Install extends Command
         /** @var DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
 
-        $output->writeln("<comment>
-                                                      ,-._.-._.-._.-._.-.
-                                                      `-.             ,-'
- .----------------------------------------------.       |             |
-|                                                |      |             |
-|  Hello !                                       |      |             |
-|                                                |      |             |
-|  You are on your way to install Phraseanet,    |     ,';\".________.-.
-|  You will need access to 2 MySQL databases.    |     ;';_'         )]
-|                                                |    ;             `-|
-|                                                `.    `T-            |
- `----------------------------------------------._ \    |             |
-                                                  `-;   |             |
-                                                        |..________..-|
-                                                       /\/ |________..|
-                                                  ,'`./  >,(           |
-                                                  \_.-|_/,-/   ii  |   |
-                                                   `.\"' `-/  .-\"\"\"||    |
-                                                    /`^\"-;   |    ||____|
-                                                   /     /   `.__/  | ||
-                                                        /           | ||
-                                                                    | ||
-</comment>"
-        );
+        $output->writeln("<comment>You are on your way to install Phraseanet, You will need access to 2 MySQL databases.</comment>");
 
         if (!$input->getOption('yes') && !$input->getOption('force') && !$input->getOption('appbox')) {
             $continue = $dialog->askConfirmation($output, 'Do you have these two DB handy ? (N/y)', false);


### PR DESCRIPTION
## Changelog

### Fixes
  - PHRAS-4146 : bin/setup system:install - abort app installation if mysql db is not empty

  - add force option -f  to force installation to continue even if table in DB already exist (override table)

