### PR TITLE
PHRAS-4148 release 4.1.18 

### DIFF
--- a/.env
+++ b/.env
@@ -154,7 +154,7 @@ PHRASEANET_DOCKER_REGISTRY=alchemyfr
 
 # Docker images tag.
 # @run
-PHRASEANET_DOCKER_TAG=4.1.17
+PHRASEANET_DOCKER_TAG=4.1.18
 
 # Stack Name
 # An optionnal Name for the stack
@@ -672,7 +672,7 @@ PHRASEANET_APP_PORT=8082
 PHRASEANET_ADMIN_ACCOUNT_ID=
 
 # @run
-PHRASEANET_ADMIN_ACCOUNT_EMAIL=admin@alchemy.fr
+PHRASEANET_ADMIN_ACCOUNT_EMAIL=admin@phraseanet.local
 
 # require to be change for securitie reasons
 # @run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # CHANGELOG
 
+## 4.1.18
+
+#### Phraseanet Upgrade
+
+- **Phraseanet Migration Patch**:
+  - A migration script for the configuration file is available. Run the following command in the setup container with Docker if the environment variable `PHRASEANET_UPGRADE=1` is set:
+    ```
+    bin/setup system:upgrade
+    ```
+
+
+### Stack (Docker Compose and Helm)
+
+- no change
+
+### Version Summary
+
+- Installation process (bin/setup system:install) now aborts if the application and/or databox contain existing data. the option -f  also answer all questions for yes AND  force installation to continue even if DB table  already exist
+
+## What's Changed
+* PHRAS-4146 bin/setup system:install - abort app installation if mysql db is not empty by @aynsix in https://github.com/alchemy-fr/Phraseanet/pull/4599
+
+
+**Full Changelog**: https://github.com/alchemy-fr/Phraseanet/compare/4.1.17...4.1.18
+
+__
 ## 4.1.17
 
 #### Phraseanet Upgrade
@@ -37,7 +63,7 @@
 
 **Full Changelog**: https://github.com/alchemy-fr/Phraseanet/compare/4.1.16...4.1.17
 
-
+__
 ## 4.1.16
 
 ### Update Instructions
@@ -111,6 +137,7 @@ The provided MariaDB container in the Docker Compose stack is not ready for prod
 
 **Full Changelog**: https://github.com/alchemy-fr/Phraseanet/compare/4.1.15...4.1.16
 
+__
 ## 4.1.15
 
 ### Update Instructions

--- a/lib/Alchemy/Phrasea/Core/Version.php
+++ b/lib/Alchemy/Phrasea/Core/Version.php
@@ -17,7 +17,7 @@ class Version
      * @var string
      */
 
-    private $number = '4.1.17';
+    private $number = '4.1.18';
 
     /**
      * @var string


### PR DESCRIPTION
## 4.1.18

#### Phraseanet Upgrade

- **Phraseanet Migration Patch**:
  - A migration script for the configuration file is available. Run the following command in the setup container with Docker if the environment variable `PHRASEANET_UPGRADE=1` is set:
    ```
    bin/setup system:upgrade
    ```


### Stack (Docker Compose and Helm)

- no change

### Version Summary

- Installation process (bin/setup system:install) now aborts if the application and/or databox contain existing data. the option -f  also answer all questions for yes AND  force installation to continue even if DB table  already exist

## What's Changed
* PHRAS-4146 bin/setup system:install - abort app installation if mysql db is not empty by @aynsix in https://github.com/alchemy-fr/Phraseanet/pull/4599


**Full Changelog**: https://github.com/alchemy-fr/Phraseanet/compare/4.1.17...4.1.18
