### PR TITLE
PHRAS-4157-Elasticsearch-ulimits-configuration

### DIFF
--- a/docker-compose.datastores.yml
+++ b/docker-compose.datastores.yml
@@ -50,6 +50,10 @@ services:
 
   elasticsearch:
     image: $PHRASEANET_DOCKER_REGISTRY/phraseanet-elasticsearch:$PHRASEANET_DOCKER_TAG
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     profiles: ["elasticsearch"]
     build: ./docker/elasticsearch
     restart: on-failure


### PR DESCRIPTION
### Adds
  - PHRAS-4157: Add ulimits for Elasticsearch to prevent memory issues with Linux kernel >=6.1.135

