### PR TITLE
PHRAS-4157 Add Elasticsearch ulimits inside docker-compose.datastores.yml

### DIFF
--- a/docker-compose.datastores.yml
+++ b/docker-compose.datastores.yml
@@ -51,6 +51,10 @@ services:
 
   elasticsearch:
     image: $PHRASEANET_DOCKER_REGISTRY/phraseanet-elasticsearch:$PHRASEANET_DOCKER_TAG
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     profiles: ["elasticsearch"]
     build: ./docker/elasticsearch
     restart: on-failure


### PR DESCRIPTION
### Adds
  - PHRAS-4157: Add Elasticsearch ulimits configuration to docker-compose.datastores.yml for newer linux kernel

