### PR TITLE
PHRAS-4170 : fix error on sharing link of unknown type files

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Prod/ShareController.php
+++ b/lib/Alchemy/Phrasea/Controller/Prod/ShareController.php
@@ -45,7 +45,7 @@ class ShareController extends Controller
                 }
                 $label = $this->app->trans('prod::tools: document');
             }
-            elseif ($databoxSubdefs->hasSubdef($subdefName)) {
+            elseif ($databoxSubdefs !== null && $databoxSubdefs->hasSubdef($subdefName)) {
                 if (!$acl->has_access_to_subdef($record, $subdefName)) {
                     continue;
                 }


### PR DESCRIPTION
### Fixes
  - PHRAS-4170: fix unknown type sharing link error
  - sharing link of a zip file for example